### PR TITLE
Filter on "origin" when getting git project

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -78,7 +78,7 @@ for subproject in "${!subprojects[@]}"; do
     # If the repo location was omitted, get this from existing crucible repo
     if [ -z "$sp_git_user_host_org" ]; then
         pushd $crucible_repo_dir >/dev/null
-        cru_git_user_host_org_proj=`git remote -v | grep fetch | awk '{print $2}'`
+        cru_git_user_host_org_proj=`git remote -v | grep origin | grep fetch | head -1 | awk '{print $2}'`
         cru_git_proj=`echo $cru_git_user_host_org_proj | awk -F/ '{print $NF}'`
 	    sp_git_user_host_org=`echo $cru_git_user_host_org_proj | sed -e s/$cru_git_proj$// -e s,/$,,`
 	    popd >/dev/null


### PR DESCRIPTION
-When cloning subprojects and the subproject is listed in
 either config/default_subprojects or ~/.config/subprojects
 but does not include the host/org, we fetch this info from
 the current crucible's 'git remote -v'.  We need to filter
 on 'origin' because there may be other entries for 'upstream'
 and would return mulitple lines, which would fail as a
 correctly formatted git repo location.  As a failsafe, we
 also add "head -1" to ensure we never have more than 1
 line.