### PR TITLE
_crucible_completions: source correct mulitplex params

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -33,7 +33,7 @@ _crucible_completions() {
         if [ -e "$bench_params_file" ]; then
             params="$params $(cat $bench_params_file)"
         fi
-        if [ -e "$geni_params_file" ]; then
+        if [ -e "$multiplex_params_file" ]; then
             params="$params $(cat $multiplex_params_file)"
         fi
         COMPREPLY=($(compgen -W "$params" -- "${COMP_WORDS[$num_index]}"))


### PR DESCRIPTION
-For tab completion when using 'gen-iterations', possible
 commands come from a specific benchmark and special
 commands from multiplex (the subproject for gen-iterations).
 That params files was not correectly referenced in
 _crucible_completions.