### PR TITLE
Update fio repo name and add mpstat tool

### DIFF
--- a/config/default_subprojects
+++ b/config/default_subprojects
@@ -2,4 +2,5 @@
 multiplex            core           /multiplex                                      master                
 roadblock            core           /roadblock                                      master
 workshop             core           /workshop                                       master
-fio                  benchmark      /fio                                            master                
+fio                  benchmark      /bench-fio                                      master
+mpstat               tool           /tool-mpstat                                    master


### PR DESCRIPTION
-Benchmark helper subprojects are now using "bench-" to help
 avoid them being confused with a repo for the original benchmark.
-Same goes for tools, but "tool-".
-Mpstat tool helper subproject added, but it currently empty as of
this commit.