### PR TITLE
logger: convert to using SQLite as the backing store for the log

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -23,7 +23,7 @@ _crucible_completions() {
                 COMPREPLY=($(compgen -W "log repo update gen-iterations" -- "${COMP_WORDS[2]}"))
                 ;;
 	    log)
-		COMPREPLY=($(compgen -W "clear info view" -- "${COMP_WORDS[2]}"))
+		COMPREPLY=($(compgen -W "clear info init insert view" -- "${COMP_WORDS[2]}"))
 		;;
 	    repo)
 		COMPREPLY=($(compgen -W "status" -- "${COMP_WORDS[2]}"))

--- a/bin/_logger
+++ b/bin/_logger
@@ -8,15 +8,21 @@ use warnings;
 
 use Time::HiRes qw(time);
 use IO::Select;
+use DBI;
 
 # disable STDOUT output buffering
 $|++;
 
-my $log_filename = $ARGV[0];
-my $stdout_pipe = $ARGV[1];
-my $stderr_pipe = $ARGV[2];
+my $source = $ARGV[0];
+my $command = $ARGV[1];
+my $log_filename = $ARGV[2];
+my $stdout_pipe = $ARGV[3];
+my $stderr_pipe = $ARGV[4];
 
-my $log_fh;
+my $start_timestamp = time();
+my $session_id;
+
+my $log_dbh;
 my $stdout_fh;
 my $stderr_fh;
 
@@ -24,9 +30,83 @@ my $stderr_fh;
 # the logger should gracefully exit on it's own
 $SIG{'INT'} = sub { my $foo = 1; };
 
-if (!open($log_fh, ">>", $log_filename)) {
-    printf("ERROR: Logger could not open '%s' for writing!\n", $log_filename);
+$log_dbh = DBI->connect("dbi:SQLite:dbname=" . $log_filename, "", "", { PrintError => 0 });
+if (! $log_dbh) {
+    printf("ERROR: Logger could not open SQLite DB '%s'!\n", $log_filename);
     exit(1);
+} else {
+    my $log_open_error = 0;
+
+    my $rv = $log_dbh->do("SELECT timestamp FROM db_state;") or $log_open_error = 1;
+
+    if ($log_open_error) {
+	printf("ERROR: The SQLite log DB '%s' does not appear to be initialized!\n", $log_filename);
+	exit(1);
+    } else {
+	if ($rv < 0) {
+	    print $DBI::errstr;
+	    exit(1);
+	}
+
+	$rv = $log_dbh->do("UPDATE db_state SET timestamp=$start_timestamp;");
+	if ($rv < 0) {
+	    print $DBI::errstr;
+	    exit(1);
+	}
+    }
+
+    my $sth = $log_dbh->prepare("SELECT id FROM sources WHERE source=" . $log_dbh->quote($source) . ";");
+    $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    my $source_id;
+    my $rows = 0;
+    while (my $row = $sth->fetchrow_hashref()) {
+	$source_id = $row->{'id'};
+	$rows += 1;
+    }
+
+    if ($rows == 0) {
+	$rv = $log_dbh->do("INSERT INTO sources (source) VALUES (" . $log_dbh->quote($source) . ");");
+	if ($rv < 0) {
+	    print $DBI::errstr;
+	    exit(1);
+	}
+	$source_id = $log_dbh->last_insert_id("", "", "sources", "");
+    }
+
+    $sth = $log_dbh->prepare("SELECT id FROM commands WHERE command=" . $log_dbh->quote($command) . ";");
+    $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    my $command_id;
+    $rows = 0;
+    while (my $row = $sth->fetchrow_hashref()) {
+	$command_id = $row->{'id'};
+	$rows += 1;
+    }
+
+    if ($rows == 0) {
+	$rv = $log_dbh->do("INSERT INTO commands (command) VALUES (" . $log_dbh->quote($command) . ");");
+	if ($rv < 0) {
+	    print $DBI::errstr;
+	    exit(1);
+	}
+	$command_id = $log_dbh->last_insert_id("", "", "commands", "");
+    }
+
+    $rv = $log_dbh->do("INSERT INTO sessions (timestamp, source, command) VALUES ($start_timestamp, $source_id, $command_id);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+    $session_id = $log_dbh->last_insert_id("", "", "sessions", "");
 }
 
 if (!open($stdout_fh, "<", $stdout_pipe)) {
@@ -39,18 +119,13 @@ if (!open($stderr_fh, "<", $stderr_pipe)) {
     exit(1);
 }
 
-# disable logfile output buffering
-my $ofh = select($log_fh);
-$|++;
-select($ofh);
-
 my $s = IO::Select->new();
 $s->add($stdout_fh);
 $s->add($stderr_fh);
 
 while($s->count()) {
     my @ready = $s->can_read(1);
-    
+
     foreach my $fh (@ready) {
 	$_ = readline($fh);
 	if (!defined($_)) {
@@ -64,36 +139,44 @@ while($s->count()) {
 	my $subsec = ($ts - int($ts))*1000;
 	my $timestamp = sprintf("%04d-%02d-%02d %02d:%02d:%02d.%03d", $var[5]+1900, $var[4]+1, $var[3], $var[2], $var[1], $var[0], $subsec);
 
-	my $stream = "UNKOWN";
+	my $stream = "0";
 	my $logit = 0;
 	if ($fh == $stdout_fh) {
+	    $stream = "STDOUT";
+
 	    if ($_ =~ /CRUCIBLE_CLOSE_LOG_PIPE/) {
 		$s->remove($stdout_fh);
 		close($stdout_fh);
+		#print("Closed STDOUT pipe\n");
+		#$logit = 1;
 	    } else {
 		$logit = 1;
-		$stream = "STDOUT";
-		if ($_ !~ /^CRUCIBLE_INTERNAL/) {
-		    printf("[%s] %s\n", $timestamp, $_);
-		} else {
-		    $_ =~ s/^CRUCIBLE_INTERNAL//;
-		}
+		printf("[%s][%s][STDOUT] %s\n", $timestamp, $source, $_);
 	    }
 	} elsif ($fh == $stderr_fh) {
+	    $stream = "STDERR";
+
 	    if ($_ =~ /CRUCIBLE_CLOSE_LOG_PIPE/) {
 		$s->remove($stderr_fh);
 		close($stderr_fh);
+		#print("Closed STDERR pipe\n");
+		#$logit = 1;
 	    } else {
 		$logit = 1;
-		$stream = "STDERR";
-		printf(STDERR "[%s][STDERR] %s\n", $timestamp, $_);
+		printf(STDERR "[%s][%s][STDERR] %s\n", $timestamp, $source, $_);
 	    }
 	}
 
 	if ($logit) {
-	    printf({$log_fh} "%f %s %s\n", $ts, $stream, $_);
+	    my $rv = $log_dbh->do("INSERT INTO lines (session, timestamp, stream, line) SELECT $session_id, $ts, id, " . $log_dbh->quote($_) . " FROM streams WHERE stream=" . $log_dbh->quote($stream) . ";");
+	    if ($rv < 0) {
+		print $DBI::errstr;
+		exit(1);
+	    }
 	}
     }
 }
 
-close($log_fh);
+$log_dbh->disconnect();
+
+unlink $stdout_pipe, $stderr_pipe;

--- a/bin/crucible
+++ b/bin/crucible
@@ -78,6 +78,8 @@ if [ ! -d ${USER_STORE} ]; then
     mkdir -v ${USER_STORE}
 fi
 
+LOG_DB=${USER_STORE}/log.db
+
 function help() {
     echo "Usage:"
     echo "  crucible <command> [command-specific-options]"
@@ -105,16 +107,34 @@ function setup_pipe() {
 # special case some log operations so they don't happen under log
 # redirection
 if [ "$1" == "log" ]; then
-    if [ ! -e ${USER_STORE}/log ]; then
-	touch ${USER_STORE}/log
+    if [ ! -e ${LOG_DB} -o "$2" == "init" ]; then
+	$CRUCIBLE_HOME/bin/log init ${LOG_DB}
     fi
 
     if [ "$2" == "view" -o -z "$2" ]; then
-	$CRUCIBLE_HOME/bin/log view ${USER_STORE}/log | less -S -F
+	$CRUCIBLE_HOME/bin/log view ${LOG_DB} | less -S -F
 	exit
     elif [ "$2" == "clear" ]; then
-	$CRUCIBLE_HOME/bin/log clear ${USER_STORE}/log
+	$CRUCIBLE_HOME/bin/log clear ${LOG_DB}
 	exit
+    elif [ "$2" == "init" ]; then
+	exit
+    elif [ "$2" == "insert" ]; then
+	shift
+	shift
+	${CRUCIBLE_HOME}/bin/log insert ${LOG_DB} "$@"
+	exit
+    elif [ "$2" == "debug" ]; then
+	    sqlite3 /home/krister/.crucible/log.db ".headers on" \
+		    ".echo on" \
+		    "select * from db_state;" ".print" \
+		    "select * from streams;" ".print" \
+		    "select * from sources;" ".print" \
+		    "select * from commands;" ".print" \
+		    "select * from sessions;" ".print" \
+		    "select * from lines;" \
+		| less -S -F
+	    exit
     fi
 elif [ "$1" == "help" ]; then
     # print all help output outside of the logger context to avoid
@@ -158,21 +178,18 @@ STDERR_PIPE=$(mktemp)
 setup_pipe ${STDOUT_PIPE}
 setup_pipe ${STDERR_PIPE}
 
+COMMAND="$(basename $0) $@"
+
 # launch the logger into the background
-$CRUCIBLE_HOME/bin/_logger ${USER_STORE}/log ${STDOUT_PIPE} ${STDERR_PIPE} &
+${CRUCIBLE_HOME}/bin/_logger console "${COMMAND}" ${USER_STORE}/log.db ${STDOUT_PIPE} ${STDERR_PIPE} &
 LOGGER_PID=$!
 
 # redirect the output to the pipes
 exec > ${STDOUT_PIPE} 2> ${STDERR_PIPE}
 
-# log a command separator that is only written to the log and not to the screen
-echo "CRUCIBLE_INTERNAL======================================================================"
-# log the command being invoked
-echo -e "command: $(basename $0) $@\n"
-
 if [ "$1" == "log" ]; then
     shift
-    $CRUCIBLE_HOME/bin/log $1 ${USER_STORE}/log
+    ${CRUCIBLE_HOME}/bin/log $1 ${LOG_DB}
 elif [ "$1" == "repo" ]; then
     shift
     if [ -z "$1" ]; then
@@ -203,10 +220,7 @@ echo "STDOUT->CRUCIBLE_CLOSE_LOG_PIPE" > ${STDOUT_PIPE}
 echo "STDERR->CRUCIBLE_CLOSE_LOG_PIPE" > ${STDERR_PIPE}
 
 # flush stdout to make sure all output gets processed by the logger
-stdbuf --output=0 echo
+printf "%4194304s\n" "sending a large (4KB) padded string to STDOUT to flush the buffer"
 
 # wait for the logger to exit
 wait ${LOGGER_PID}
-
-# clean up the pipes
-rm -v ${STDOUT_PIPE} ${STDERR_PIPE}

--- a/bin/log
+++ b/bin/log
@@ -6,11 +6,15 @@
 use strict;
 use warnings;
 
+use Time::HiRes qw(time);
+use DBI;
+use Data::Dumper;
+
 # disable output buffering
 $|++;
 
 my $mode = $ARGV[0];
-my $filename = $ARGV[1];
+my $log_filename = $ARGV[1];
 
 sub help {
     print("Usage:\n");
@@ -21,6 +25,8 @@ sub help {
     print("help            |  Show this help message\n");
     print("clear           |  Clear the crucible log\n");
     print("info            |  Display information about the log\n");
+    print("init            |  Initialize the log\n");
+    print("insert          |  Insert a message into the log\n");
     print("view            |  View the crucible log (default)\n");
     print("\n");
 }
@@ -37,45 +43,145 @@ sub format_ts {
 
 if ((!($mode eq "view") &&
      !($mode eq "clear") &&
-     !($mode eq "info")) ||
+     !($mode eq "info") &&
+     !($mode eq "init") &&
+     !($mode eq "insert")) ||
     ($mode eq "help")) {
     help();
     exit();
 }
 
-if ($filename eq "") {
-    if (! -e $filename) {
-	printf("ERROR: Log could not find the specified logfile '%s'!\n", $filename);
+my $do_init = 0;
+if (! -e $log_filename) {
+    $do_init = 1;
+} else {
+    if (($mode eq "init") && (! -z $log_filename)) {
+	print("Removing existing long and re-initializing\n");
+	unlink $log_filename;
+    }
+}
+
+my $log_dbh = DBI->connect("dbi:SQLite:dbname=" . $log_filename, "", "", { PrintError => 0 });
+if (! $log_dbh) {
+    printf("ERROR: Logger could not open SQLite DB '%s'!\n", $log_filename);
+    exit(1);
+}
+
+if (($mode eq "init") || $do_init) {
+    my $start_timestamp = time();
+
+    my $rv = $log_dbh->do("CREATE TABLE streams (id INTEGER PRIMARY KEY NOT NULL, stream TEXT UNIQUE NOT NULL);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("CREATE TABLE sources (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, source TEXT UNIQUE NOT NULL);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("CREATE TABLE commands (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, command TEXT UNIQUE NOT NULL);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("CREATE TABLE sessions (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, timestamp REAL NOT NULL, source INTEGER NOT NULL REFERENCES sources (id), command INTEGER NOT NULL REFERENCES commands (id));");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("CREATE TABLE lines (id INTEGER PRIMARY KEY AUTOINCREMENT, session INTEGER NOT NULL REFERENCES sessions (id), timestamp REAL NOT NULL, stream INTEGER NOT NULL REFERENCES streams (id), line TEXT);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("CREATE TABLE db_state (timestamp REAL PRIMARY KEY NOT NULL);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("INSERT INTO db_state (timestamp) VALUES ($start_timestamp);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("INSERT INTO streams (id, stream) VALUES (1, 'STDOUT');");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("INSERT INTO streams (id, stream) VALUES (2, 'STDERR');");
+    if ($rv < 0) {
+	print $DBI::errstr;
 	exit(1);
     }
 }
 
 if ($mode eq "view") {
-    if (open(LOG, "<", $filename)) {
-	while(<LOG>) {
-	    chomp($_);
-	    my @array = split(/\s/, $_, 3);
-
-	    my $timestamp = format_ts($array[0]);
-
-	    if ($array[1] eq "STDOUT") {
-		printf("[%s] %s\n", $timestamp, $array[2]);
-	    } elsif ($array[1] eq "STDERR") {
-		printf("[%s][STDERR] %s\n", $timestamp, $array[2]);
-	    }
-	}
-
-	close(LOG);
-    } else {
-	printf("ERROR: Could not open logfile '%s' for reading!\n", $filename);
+    my $sth = $log_dbh->prepare("SELECT ".
+				"sessions.timestamp AS session_timestamp, " .
+				"commands.command AS session_command, " .
+				"sources.source AS session_source, " .
+				"lines.timestamp AS line_timestamp, " .
+				"lines.line AS line, " .
+				"streams.stream AS line_stream " .
+				"FROM sessions " .
+				"JOIN lines ON sessions.id=lines.session " .
+				"JOIN streams ON streams.id=lines.stream " .
+				"JOIN sources ON sources.id=sessions.source " .
+				"JOIN commands ON commands.id=sessions.command " .
+				"ORDER BY sessions.timestamp;");
+    my $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
 	exit(1);
     }
+
+    my $last_session_timestamp = -1;
+    while (my $row = $sth->fetchrow_hashref()) {
+	$row->{'session_timestamp_fmt'} = format_ts($row->{'session_timestamp'});
+	$row->{'line_timestamp_fmt'} = format_ts($row->{'line_timestamp'});
+
+	if ($last_session_timestamp != $row->{'session_timestamp'}) {
+	    printf("==============================================================================================\n");
+	    printf("[%s][%s][%s] command: %s\n", $row->{'session_timestamp_fmt'}, $row->{'session_source'}, $row->{'line_stream'}, $row->{'session_command'});
+	    printf("[%s][%s][%s]\n", $row->{'session_timestamp_fmt'}, $row->{'session_source'}, $row->{'line_stream'});
+
+	    $last_session_timestamp = $row->{'session_timestamp'};
+	}
+
+	printf("[%s][%s][%s] %s\n", $row->{'line_timestamp_fmt'}, $row->{'session_source'}, $row->{'line_stream'}, $row->{'line'});
+    }
 } elsif ($mode eq "clear") {
-    if (open(LOG, ">", $filename)) {
-	print(LOG "");
-	close(LOG);
-    } else {
-	printf("ERROR: Could not open logfile '%s' for clearing!\n", $filename);
+    my $rv = $log_dbh->do("DELETE FROM lines");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("DELETE FROM sessions");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("DELETE FROM sources");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $rv = $log_dbh->do("DELETE FROM commands");
+    if ($rv < 0) {
+	print $DBI::errstr;
 	exit(1);
     }
 } elsif ($mode eq "info") {
@@ -83,21 +189,133 @@ if ($mode eq "view") {
 
     my $fmt_line = "%-25s %s\n";
 
-    printf($fmt_line, "Current Log:", $filename);
+    printf($fmt_line, "Current Log:", $log_filename);
 
-    my @log_size = split(/\s+/, `du -hsc --apparent-size $filename`);
+    my @log_size = split(/\s+/, `du -hsc --apparent-size $log_filename`);
     printf($fmt_line, "Log Size:", $log_size[0]);
 
-    if (open(LOG, "<", $filename)) {
-	my $head = <LOG>;
-	my @array = split(/\s/, $head);
-	printf($fmt_line, "First entry:", format_ts($array[0]));
-
-	close(LOG);
-    } else {
-	printf("ERROR: Could not open '%s' for reading!\n", $filename);
-	exit(1)
+    my $sth = $log_dbh->prepare("SELECT timestamp FROM sessions ORDER BY timestamp ASC LIMIT 1;");
+    my $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
     }
 
+    my $row = $sth->fetchrow_hashref();
+    printf($fmt_line, "First session:", format_ts($row->{'timestamp'}));
+
+
+    $sth = $log_dbh->prepare("SELECT timestamp FROM sessions ORDER BY timestamp DESC LIMIT 1;");
+    $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $row = $sth->fetchrow_hashref();
+    printf($fmt_line, "Last session:", format_ts($row->{'timestamp'}));
+
+
+    $sth = $log_dbh->prepare("SELECT count(timestamp) AS sessions FROM sessions;");
+    $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    $row = $sth->fetchrow_hashref();
+    printf($fmt_line, "Total sessions:", $row->{'sessions'});
+
+
     print("\n");
+} elsif ($mode eq "insert") {
+    my $source = $ARGV[2];
+    my $stream = $ARGV[3];
+    my $msg = $ARGV[4];
+    my $start_timestamp = time();
+
+    if ($source eq "") {
+	printf(STDERR "ERROR: You must provide a message source!\n");
+	exit(1);
+    }
+
+    if (!($stream eq "STDOUT") && !($stream eq "STDERR")) {
+	printf(STDERR "ERROR: You must provid a valid stream (either STDOUT or STDERR)!\n");
+	exit(1);
+    }
+
+    if ($msg eq "") {
+	printf(STDERR "ERROR: You must provide a message!\n");
+	exit(1);
+    }
+
+    my $rv = $log_dbh->do("UPDATE db_state SET timestamp=$start_timestamp;");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    my $sth = $log_dbh->prepare("SELECT id FROM sources WHERE source=" . $log_dbh->quote($source) . ";");
+    $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    my $source_id;
+    my $rows = 0;
+    while (my $row = $sth->fetchrow_hashref()) {
+	$source_id = $row->{'id'};
+	$rows += 1;
+    }
+
+    if ($rows == 0) {
+	$rv = $log_dbh->do("INSERT INTO sources (source) VALUES (" . $log_dbh->quote($source) . ");");
+	if ($rv < 0) {
+	    print $DBI::errstr;
+	    exit(1);
+	}
+	$source_id = $log_dbh->last_insert_id("", "", "sources", "");
+    }
+
+    my $command = "crucible log insert";
+
+    $sth = $log_dbh->prepare("SELECT id FROM commands WHERE command=" . $log_dbh->quote($command) . ";");
+    $rv = $sth->execute() or die $DBI::errstr;
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
+    my $command_id;
+    $rows = 0;
+    while (my $row = $sth->fetchrow_hashref()) {
+	$command_id = $row->{'id'};
+	$rows += 1;
+    }
+
+    if ($rows == 0) {
+	$rv = $log_dbh->do("INSERT INTO commands (command) VALUES (" . $log_dbh->quote($command) . ");");
+	if ($rv < 0) {
+	    print $DBI::errstr;
+	    exit(1);
+	}
+	$command_id = $log_dbh->last_insert_id("", "", "commands", "");
+    }
+
+    $rv = $log_dbh->do("INSERT INTO sessions (timestamp, source, command) VALUES ($start_timestamp, $source_id, $command_id);");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+    my $session_id = $log_dbh->last_insert_id("", "", "sessions", "");
+
+    $rv = $log_dbh->do("INSERT INTO lines (session, timestamp, stream, line) SELECT $session_id, $start_timestamp, id, " . $log_dbh->quote($msg) . " FROM streams WHERE stream=" . $log_dbh->quote($stream) . ";");
+    if ($rv < 0) {
+	print $DBI::errstr;
+	exit(1);
+    }
+
 }
+
+$log_dbh->disconnect();


### PR DESCRIPTION
- This has many benefits including, but not limited too:

  1. Support for concurrent logging since SQLite supports multi
     process access:

     https://www.sqlite.org/faq.html#q5

  2. Easily queried data for find specific information