### PR TITLE
Add the ability to run a benchmark via rickshaw

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -16,7 +16,7 @@ _crucible_completions() {
     num_words=${#COMP_WORDS[@]} # Total number of words on the command
     let num_index=$num_words-1
     if [ $num_words -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo update workshop gen-iterations wrapper" -- "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "help log repo update workshop gen-iterations run wrapper" -- "${COMP_WORDS[1]}"))
     elif [ ${COMP_WORDS[1]} == "workshop" ]; then
         if [ "$(expr $num_words % 2)" -eq 1 ]; then
             COMPREPLY=($(compgen -W "$($CRUCIBLE_HOME/subprojects/core/workshop/workshop.pl --completions all)" -- "${COMP_WORDS[$num_index]}"))
@@ -27,7 +27,7 @@ _crucible_completions() {
     elif [ $num_words -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)
-                COMPREPLY=($(compgen -W "log repo update gen-iterations" -- "${COMP_WORDS[2]}"))
+                COMPREPLY=($(compgen -W "log repo update gen-iterations run" -- "${COMP_WORDS[2]}"))
                 ;;
             log)
                 COMPREPLY=($(compgen -W "clear info init insert view" -- "${COMP_WORDS[2]}"))
@@ -38,7 +38,7 @@ _crucible_completions() {
             update)
                 COMPREPLY=($(compgen -W "all crucible $(cd $CRUCIBLE_HOME/subprojects/; find . -type l | sed 'sX./XX')" -- "${COMP_WORDS[2]}"))
                 ;;
-            gen-iterations)
+            gen-iterations|run)
                 COMPREPLY=($(compgen -W "$(cd $CRUCIBLE_HOME/subprojects/benchmarks/; find . -mindepth 1 -maxdepth 1 -type l | sed 'sX./XX')" -- "${COMP_WORDS[2]}"))
                 ;;
         esac
@@ -48,6 +48,13 @@ _crucible_completions() {
                 COMPREPLY=($(compgen -W "all crucible $(cd $CRUCIBLE_HOME/subprojects/; find . -type l | sed 'sX./XX')" -- "${COMP_WORDS[3]}"))
                 ;;
         esac
+    elif [ "$(expr $num_words % 2)" -eq 0 -a ${COMP_WORDS[1]} == "run" ]; then
+        params=""
+        rickshaw_params_file="$CRUCIBLE_HOME/subprojects/core/rickshaw/params"
+        if [ -e $rickshaw_params_file ]; then
+            params="$params $(cat $rickshaw_params_file)"
+        fi
+        COMPREPLY=($(compgen -W "$params" -- "${COMP_WORDS[$num_index]}"))
     elif [ "$(expr $num_words % 2)" -eq 0 -a ${COMP_WORDS[1]} == "gen-iterations" ]; then
         params=""
         bench_params_file="$CRUCIBLE_HOME/subprojects/benchmarks/${COMP_WORDS[2]}/params"

--- a/bin/crucible
+++ b/bin/crucible
@@ -229,6 +229,50 @@ elif [ "$1" == "gen-iterations" ]; then
     "$CRUCIBLE_HOME"/subprojects/core/multiplex/multiplex \
         "$CRUCIBLE_HOME/subprojects/benchmarks/$benchmark/multiplex.json" "$@"
     RET_VAL=$?
+elif [ "$1" == "run" ]; then
+    shift
+    benchmark=$1
+    shift
+    benchmark_subproj_dir="$CRUCIBLE_HOME"/subprojects/benchmarks/$benchmark
+    rs_dir="$CRUCIBLE_HOME"/subprojects/core/rickshaw
+    if [ ! -e bench-params.json ]; then
+        echo "Make sure you have defined the benchmark parameters and put in a file \"bench-params.json\""
+        echo "You can generate these parameters with \"crucible gen-iterations <benchmark> <options>"
+        echo "Here are some examples:"
+        echo "crucible gen-iterations fio --defaults basic"
+        echo "crucible gen-iterations fio --defaults basic --rw randread,randwrite --bs 4k,64k"
+        echo ""
+        echo "Once you have run this, you should have a file, \"bench-params.json\" in your current directory"
+        exit 1
+    fi
+
+    if [ ! -e tool-params.json ]; then
+        echo "You do not have a \"tool-params.json\" in the current directory.  Crucible will use"
+        echo "the default tools found in $rs_dir/config/tool-params.json.  If you wish to use"
+        echo "different tools, create a tool-params.json which adheres to this schema: $rs_dir/schema/tools/json"
+        tool_params_file=$rs_dir/config/tool-params.json
+    else
+        tool_params_file=`/bin/pwd`/tool-params.json
+    fi
+
+    if [ ! -e "$benchmark_subproj_dir" ]; then
+        echo "Running benchmark $benchmark requires that subproject"
+        echo "located in "$CRUCIBLE_HOME"/subprojects/bench/$benchmark"
+        ehco "This directory could not be found.  Here are the benchmark"
+        echo "subproject directories:"
+        /bin/ls "$CRUCIBLE_HOME"/subprojects/bench/$benchmark
+        exit 1
+    fi
+
+    $rs_dir/rickshaw-run\
+    --tool-params "$tool_params_file"\
+    --bench-params bench-params.json\
+    --bench-dir "$benchmark_subproj_dir"\
+    --roadblock-dir="$CRUCIBLE_HOME/subprojects/core/roadblock"\
+    --workshop-dir="$CRUCIBLE_HOME/subprojects/core/workshop"\
+    --tools-dir="$CRUCIBLE_HOME/subprojects/tools"\
+    "$@"
+    RET_VAL=$?
 elif [ "$1" == "wrapper" ]; then
     shift
     "$@"


### PR DESCRIPTION
-once should be able to run fio like the following:
 crucible gen-iterations fio --defaults basic
 crucible run fio
-several env vars are required for rickshaw to use
 a container image: RS_REGISTRY_[HOST|PROJ|REPO|AUTH_FILE]