### PR TITLE
Remove any reference to 'gen-iterations'

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -16,7 +16,7 @@ _crucible_completions() {
     num_words=${#COMP_WORDS[@]} # Total number of words on the command
     let num_index=$num_words-1
     if [ $num_words -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo update workshop gen-iterations run wrapper console" -- "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "help log repo update workshop run wrapper console" -- "${COMP_WORDS[1]}"))
     elif [ ${COMP_WORDS[1]} == "workshop" ]; then
         if [ "$(expr $num_words % 2)" -eq 1 ]; then
             COMPREPLY=($(compgen -W "$($CRUCIBLE_HOME/subprojects/core/workshop/workshop.pl --completions all)" -- "${COMP_WORDS[$num_index]}"))
@@ -27,7 +27,7 @@ _crucible_completions() {
     elif [ $num_words -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)
-                COMPREPLY=($(compgen -W "log repo update gen-iterations run" -- "${COMP_WORDS[2]}"))
+                COMPREPLY=($(compgen -W "log repo update run" -- "${COMP_WORDS[2]}"))
                 ;;
             log)
                 COMPREPLY=($(compgen -W "clear info init insert view" -- "${COMP_WORDS[2]}"))
@@ -38,7 +38,7 @@ _crucible_completions() {
             update)
                 COMPREPLY=($(compgen -W "all crucible $(cd $CRUCIBLE_HOME/subprojects/; find . -type l | sed 'sX./XX')" -- "${COMP_WORDS[2]}"))
                 ;;
-            gen-iterations|run)
+            run)
                 COMPREPLY=($(compgen -W "$(cd $CRUCIBLE_HOME/subprojects/benchmarks/; find . -mindepth 1 -maxdepth 1 -type l | sed 'sX./XX')" -- "${COMP_WORDS[2]}"))
                 ;;
         esac
@@ -53,17 +53,6 @@ _crucible_completions() {
         rickshaw_params_file="$CRUCIBLE_HOME/subprojects/core/rickshaw/params"
         if [ -e $rickshaw_params_file ]; then
             params="$params $(cat $rickshaw_params_file)"
-        fi
-        COMPREPLY=($(compgen -W "$params" -- "${COMP_WORDS[$num_index]}"))
-    elif [ "$(expr $num_words % 2)" -eq 0 -a ${COMP_WORDS[1]} == "gen-iterations" ]; then
-        params=""
-        bench_params_file="$CRUCIBLE_HOME/subprojects/benchmarks/${COMP_WORDS[2]}/params"
-        multiplex_params_file="$CRUCIBLE_HOME/subprojects/core/multiplex/params"
-        if [ -e "$bench_params_file" ]; then
-            params="$params $(cat $bench_params_file)"
-        fi
-        if [ -e "$multiplex_params_file" ]; then
-            params="$params $(cat $multiplex_params_file)"
         fi
         COMPREPLY=($(compgen -W "$params" -- "${COMP_WORDS[$num_index]}"))
     fi

--- a/bin/_help
+++ b/bin/_help
@@ -13,7 +13,6 @@ function help() {
     echo "repo            |  Crucible repository management"
     echo "update          |  Update the repositories that comprise crucible"
     echo "workshop        |  Build container images"
-    echo "gen-iterations  |  Show the iterations generated for a benchmark"
     echo "wrapper         |  Run user supplied programs inside a crucible wrapper for logging purposes"
     echo ""
     echo "For more detailed help for each command, try:"
@@ -38,17 +37,6 @@ function help() {
         ${CRUCIBLE_HOME}/bin/update help
     elif [ "${1}" == "workshop" ]; then
         ${CRUCIBLE_HOME}/subprojects/core/workshop/workshop.pl --help
-    elif [ "${1}" == "gen-iterations" ]; then
-        shift
-        if [ -z "${1}" ]; then
-            test -e ${CRUCIBLE_HOME}/subprojects/core/multiplex/print_help && \
-                ${CRUCIBLE_HOME}/subprojects/core/multiplex/print_help || \
-                echo "No help found"
-        else
-            test -e ${CRUCIBLE_HOME}/subprojects/benchmarks/${1}/print_help && \
-                ${CRUCIBLE_HOME}/subprojects/benchmarks/${1}/print_help || \
-                echo "No help found"
-        fi
     else
         help
     fi

--- a/bin/_main
+++ b/bin/_main
@@ -63,13 +63,6 @@ elif [ "${1}" == "workshop" ]; then
     shift
     ${CRUCIBLE_HOME}/subprojects/core/workshop/workshop.pl "$@"
     RET_VAL=$?
-elif [ "${1}" == "gen-iterations" ]; then
-    shift
-    benchmark=${1}
-    shift
-    "${CRUCIBLE_HOME}"/subprojects/core/multiplex/multiplex \
-        "${CRUCIBLE_HOME}/subprojects/benchmarks/$benchmark/multiplex.json" "$@"
-    RET_VAL=$?
 elif [ "${1}" == "run" ]; then
     shift
     benchmark=${1}
@@ -148,13 +141,6 @@ elif [ "${1}" == "run" ]; then
     elif [ ! -e ${bench_params} ]; then
         echo "Make sure you have defined the benchmark parameters and put them in a file \"./bench-params.json\""
         echo "or that you explicitly specify the benchmark parameters file with \"--bench-params=<file>\"."
-        echo ""
-        echo "You can generate these parameters with \"crucible gen-iterations <benchmark> <options>"
-        echo "Here are some examples:"
-        echo "crucible gen-iterations fio --defaults basic"
-        echo "crucible gen-iterations fio --defaults basic --rw randread,randwrite --bs 4k,64k"
-        echo ""
-        echo "Once you have run this, you should have a file, \"bench-params.json\" in your current directory"
         exit 1
     else
         bench_params_run_dir=${base_run_dir}/config/bench-params.json

--- a/bin/crucible
+++ b/bin/crucible
@@ -14,15 +14,12 @@
 #                   clear-result    of a benchmark with one
 #                                   or more iterations
 #
-# Multiplex         gen-iterations  Convert a user's list     Minimally viable,
-#                                   of benchamrk params       Integrated
-#                                   (--opt val1,val2)
-#                                   into multiple benchmark
-#                                   iterations
-#
-# <remote-exec>     auth-hosts      Automated ssh key         Not implemented
-#                   ssh-hosts       installation, multi-
-#                                   remote-host execution
+# Multiplex         <TBD>           Convert a user's list     Currently only
+#                                   of benchamrk params       supported via
+#                                   (--opt val1,val2)         --mv-params with
+#                                   into multiple benchmark   run command (and
+#                                   iterations                requires mv-params
+#                                                             JSON format
 #
 # Roadblock         <TBD>           Provide synchrnization    Minimally viable,
 #                                   across endpoints (hosts   Not integrated


### PR DESCRIPTION
-The ability to generate a bunch of iterations from a user
 specifying --param1 val1,...valN does not exist in a command-line
 capability right now.  Using --mv-params with 'crucible run' does
 work, but the user must populate a mv-params.json in the correct
 format.