### PR TITLE
bin/bash: update container arguments

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -10,7 +10,6 @@ fi
 LOG_DB=${USER_STORE}/log.db
 
 container_common_args=()
-container_common_args+=("-t")
 container_common_args+=("--rm")
 container_common_args+=("-e CRUCIBLE_HOME=$CRUCIBLE_HOME")
 container_common_args+=("--mount=type=bind,source=/var/lib/containers,destination=/var/lib/containers")
@@ -27,7 +26,6 @@ container_common_args+=("--security-opt=label=disable")
 container_common_args+=("--workdir=`/bin/pwd`")
 
 container_log_args=()
-container_log_args+=("-i")
 container_log_args+=("--name crucible-log")
 container_log_args+=("--mount=type=bind,source=${USER_STORE},destination=${USER_STORE}")
 container_log_args+=("--mount=type=bind,source=/tmp,destination=/tmp")


### PR DESCRIPTION
- Remove the TTY argument from the common container argument list.  It
  is not needed and it adds ^M to the end of every line.

- Remove the interactive argument from the log container argument
  list.  This messes up things like piping the output to less
  (presumably because STDIN is attached?).