### PR TITLE
bin/_main: cleanup summary report generation

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -260,9 +260,7 @@ elif [ "${1}" == "run" ]; then
             RET_VAL=$?
             if [ $RET_VAL -eq 0 ]; then
                 echo "Benchmark result now in elastic, localhost:9200"
-                $podman_run "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE ${result_dumper} ${result_json} | jq -r '."run-id"' | tr -d '\n' 
-                # Yes, there's a carriage return in this output, and no, I have no idea why...
-                this_id=`$podman_run "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE ${result_dumper} ${result_json} | jq -r '."run-id"' | tr -d '\r'`
+                this_id=`$podman_run "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE ${result_dumper} ${result_json} | jq -r '."run-id"'`
                 if [ ! -z "$this_id" ]; then
                     cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-result-summary.sh"
                     cdm_query_cmd+=" --run=$this_id"


### PR DESCRIPTION
- Do not run the same command twice (oops) and let one's output leak
  to the console.

- The carriage return in the output has been fixed elsewhere with
  podman changes (no tty).