### PR TITLE
Provide command from crucible to get result or metrics

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -16,7 +16,7 @@ _crucible_completions() {
     num_words=${#COMP_WORDS[@]} # Total number of words on the command
     let num_index=$num_words-1
     if [ $num_words -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo update run wrapper console start" -- "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "help log repo update run wrapper console start get" -- "${COMP_WORDS[1]}"))
     elif [ $num_words -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)
@@ -24,6 +24,9 @@ _crucible_completions() {
                 ;;
             log)
                 COMPREPLY=($(compgen -W "clear info init view" -- "${COMP_WORDS[2]}"))
+                ;;
+            get)
+                COMPREPLY=($(compgen -W "result metric" -- "${COMP_WORDS[2]}"))
                 ;;
             repo)
                 COMPREPLY=($(compgen -W "status" -- "${COMP_WORDS[2]}"))

--- a/bin/_help
+++ b/bin/_help
@@ -15,6 +15,7 @@ function help() {
     echo "update          |  Update all or part of the crucible software"
     echo "console         |  Run user supplied programs inside a crucible wrapper for logging purposes"
     echo "wrapper         |  Run a crucible subproject command directly, within a crucible container"
+    echo "get             |  Get either a result summary (get result) or any metric (get metric)"
     echo ""
     echo "For more detailed help for each command, try:"
     echo "  crucible help <command>"

--- a/bin/_main
+++ b/bin/_main
@@ -139,6 +139,23 @@ elif [ "${1}" == "start" ]; then
         shift
         start_es
     fi
+elif [ "${1}" == "get" ]; then
+    shift
+    if [ "${1}" == "result" ]; then
+        shift
+        start_redis
+        start_httpd
+        start_es
+        get_result_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-result-summary.sh"
+        $podman_run --name crucible-get-result "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $get_result_cmd "$@"
+    elif [ "${1}" == "metric" ]; then
+        shift
+        start_redis
+        start_httpd
+        start_es
+        get_metric_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-metric-data.sh"
+        $podman_run --name crucible-get-metric "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $get_metric_cmd "$@"
+    fi
 elif [ "${1}" == "run" ]; then
     shift
     benchmark=${1}


### PR DESCRIPTION
-no need to run 'crucible wapper' to get to this info
-we probably need more help output from CDM's get-result-summary.sh and get-metric-data.sh,
 the two scripts that get called.