### PR TITLE
Switch to shell executor specific runner

### DIFF
--- a/tests/.gitlab-ci.yml
+++ b/tests/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 include: '/tests/.gitlab-jobs.yml'
 
-image: quay.io/krister/centos-stream
-
 stages:
   - installation
   - update


### PR DESCRIPTION
crucible ci jobs should run on specific runner w/ the shell
executor. This implies that the 'centos-stream' container image
no longer makes sense for this environment.