### PR TITLE
Switch to shell executor

### DIFF
--- a/tests/.gitlab-ci.yml
+++ b/tests/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 include: '/tests/.gitlab-jobs.yml'
 
-image: quay.io/krister/centos-stream
-
 stages:
   - installation
   - update

--- a/tests/.gitlab-jobs.yml
+++ b/tests/.gitlab-jobs.yml
@@ -1,9 +1,23 @@
 # anchor to run tests for every job
 .job_template: &job_script
-  script:
-    - echo 'Running tests for ${CI_JOB_NAME}'
-    - ./tests/${CI_JOB_NAME}
-    - echo 'Complete'
+  script: |
+    if [ -f ./tests/${CI_JOB_NAME} ]; then
+        ./tests/${CI_JOB_NAME}
+    fi
+
+# global test-before script
+before_script:
+  - |
+    if [ -f ./tests/before ]; then
+          ./tests/before
+    fi
+
+# global test-after script
+after_script:
+  - |
+    if [ -f ./tests/after ]; then
+          ./tests/after
+    fi
 
 test-installer:
   stage: installation

--- a/tests/after
+++ b/tests/after
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set +e
+set -x
+
+# remove auth file
+rm -f /tmp/auth-file.json
+
+# remove config file
+cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
+rm -f $cfgfile
+
+# remove install path
+install_path=$(grep INSTALL_PATH= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
+rm -rf $install_path
+
+# remove identity file
+rm -f /root/.crucible/identity


### PR DESCRIPTION
A specific runner has been registered with the shell executor
to run ci jobs against crucible PRs.
This change removes the container image from the gitlab config
that was used by docker executor in shared runners.