### PR TITLE
modify update process to stop existing controller infrastructure pods

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 
 EC_FAIL_USER=2
 
@@ -35,6 +35,7 @@ container_log_args+=("--mount=type=bind,source=/tmp,destination=/tmp")
 
 var_crucible="/var/lib/crucible"
 podman_pull="podman pull"
+podman_stop="podman stop"
 podman_run="podman run --pull=missing"
 
 datetime=`date +%Y-%m-%d_%H:%M:%S`

--- a/bin/update
+++ b/bin/update
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 
 # repo updating infrastructure
 
@@ -93,9 +93,15 @@ esac
 case "${repo}" in
     "____all"|"____crucible"|"controller-image")
         echo
+        echo "Controller update:"
+        echo
+        echo "Shutting down existing controller pods:"
+        ${podman_stop} crucible-es
+        ${podman_stop} crucible-httpd
+        ${podman_stop} crucible-redis
+        echo
         echo "Checking for new controller image:"
         echo
-
         ${podman_pull} ${CRUCIBLE_CONTAINER_IMAGE}
         ;;
     *)


### PR DESCRIPTION
- this ensures that the infrastructure pods will be restarted with a
  new controller image if it is pulled as part of the update process