### PR TITLE
give crucible controller containers full access to the host's / files…

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -85,7 +85,7 @@ function start_redis() {
 
 function start_es() {
     local es_available count status_check RET_VAL es_timeout pod_name
-    local es_start_cmd es_status_cmd
+    local es_start_cmd es_status_cmd common_container_args
     es_start_cmd="${CRUCIBLE_HOME}/config/start-es.sh $var_crucible/es"
     es_status_cmd="curl --silent --show-error --stderr - -X GET localhost:9200/_cat/indices"
     echo -n "Checking for elasticsearch"
@@ -96,7 +96,14 @@ function start_es() {
         echo "...not present, starting a container for it:"
         firewall-cmd --zone=public --add-port=9200/tcp --add-port=9300/tcp >/dev/null 2>&1
         mkdir -p "$var_crucible/es"
-        $podman_run --name crucible-es "${container_common_args[@]}" "${container_es_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $es_start_cmd
+        common_container_args=()
+        for arg in "${container_common_args[@]}"; do
+            # remove the hostfs mount from the ES container due to cgroup issues with ES/java
+            if ! echo "${arg}" | grep -q "hostfs"; then
+                common_container_args+=("${arg}")
+            fi
+        done
+        $podman_run --name crucible-es "${common_container_args[@]}" "${container_es_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $es_start_cmd
         RET_VAL=$?
         if [ $RET_VAL -gt 0 ]; then
             exit_error "Could not start elasticseach"

--- a/bin/base
+++ b/bin/base
@@ -11,15 +11,21 @@ if [ ! -d ${USER_STORE} ]; then
 fi
 LOG_DB=${USER_STORE}/log.db
 
+if [ -z "${HOSTFS_DIR}" ]; then
+    export CRUCIBLE_HOSTFS_PWD=$(pwd)
+fi
+
 container_common_args=()
 container_common_args+=("--rm")
 container_common_args+=("-e CRUCIBLE_HOME=$CRUCIBLE_HOME")
 container_common_args+=("-e TOOLBOX_HOME=${TOOLBOX_HOME}")
+container_common_args+=("-e CRUCIBLE_HOSTFS_PWD=${CRUCIBLE_HOSTFS_PWD}")
 container_common_args+=("--mount=type=bind,source=/root,destination=/root")
 container_common_args+=("--mount=type=bind,source=${CRUCIBLE_HOME}/config/.bashrc,destination=/root/.bashrc")
 container_common_args+=("--mount=type=bind,source=/home,destination=/home")
 container_common_args+=("--mount=type=bind,source=/var/lib/crucible,destination=/var/lib/crucible")
 container_common_args+=("--mount=type=bind,source=${CRUCIBLE_HOME},destination=${CRUCIBLE_HOME}")
+container_common_args+=("--mount=type=bind,source=/,destination=/hostfs")
 container_common_args+=("--privileged")
 container_common_args+=("--ipc=host")
 container_common_args+=("--pid=host")


### PR DESCRIPTION
…ystem

- the host's filesystem is mounted at /hostfs

- also store the PWD in CRUCIBLE_HOSTFS_PWD when a controller
  container is launched

- Using /hostfs + $CRUCIBLE_HOSTFS_PWD will allow relative file paths
  in benchmark parameters to be resolved (such as in a controller
  pre-script).