### PR TITLE
update fio test json to reflect bench-fio multiplex.json essentials

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  crucible-ci:
+  crucible-ci-iteration-repeat-runs-fio:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,6 +28,33 @@ jobs:
     - name: Run crucible-ci->integration-tests
       uses: ./crucible-ci/.github/actions/integration-tests
       with:
-        artifact_tag: "crucible"
+        artifact_tag: "fio"
         ci_target: "crucible"
         ci_target_dir: ${{ github.workspace }}/crucible
+        repeat_runs: "yes"
+        scenarios: "fio"
+
+  crucible-ci-iteration-repeat-runs-uperf:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout crucible
+      uses: actions/checkout@v2
+      with:
+        path: crucible
+
+    - name: Checkout crucible-ci
+      uses: actions/checkout@v2
+      with:
+        repository: perftool-incubator/crucible-ci
+        ref: main
+        path: crucible-ci
+
+    - name: Run crucible-ci->integration-tests
+      uses: ./crucible-ci/.github/actions/integration-tests
+      with:
+        artifact_tag: "uperf"
+        ci_target: "crucible"
+        ci_target_dir: ${{ github.workspace }}/crucible
+        repeat_runs: "yes"
+        scenarios: "uperf"

--- a/tests/end-to-end/fio-1.json
+++ b/tests/end-to-end/fio-1.json
@@ -3,16 +3,7 @@
 	{
 	    "name": "required",
 	    "params": [
-		{ "arg": "write_hist_log", "vals": [ "fio" ] },
-		{ "arg": "write_bw_log", "vals": [ "fio" ] },
-		{ "arg": "write_iops_log", "vals": [ "fio" ] },
-		{ "arg": "write_lat_log", "vals": [ "fio" ] },
-		{ "arg": "output-format", "vals": [ "json" ] },
-		{ "arg": "output", "vals": [ "fio-result.json" ] },
-		{ "arg": "log_unix_epoch", "vals": [ "1" ] },
 		{ "arg": "clocksource", "vals": [ "gettimeofday" ] },
-		{ "arg": "log_hist_msec", "vals": [ "10000" ] },
-		{ "arg": "log_avg_msec", "vals": [ "1000" ] },
 		{ "arg": "ramp_time", "vals": [ "5s" ] },
 
 		{ "arg": "bs", "vals": [ "4K" ] },

--- a/tests/end-to-end/fio-2.json
+++ b/tests/end-to-end/fio-2.json
@@ -3,16 +3,7 @@
 	{
 	    "name": "required",
 	    "params": [
-		{ "arg": "write_hist_log", "vals": [ "fio" ] },
-		{ "arg": "write_bw_log", "vals": [ "fio" ] },
-		{ "arg": "write_iops_log", "vals": [ "fio" ] },
-		{ "arg": "write_lat_log", "vals": [ "fio" ] },
-		{ "arg": "output-format", "vals": [ "json" ] },
-		{ "arg": "output", "vals": [ "fio-result.json" ] },
-		{ "arg": "log_unix_epoch", "vals": [ "1" ] },
 		{ "arg": "clocksource", "vals": [ "gettimeofday" ] },
-		{ "arg": "log_hist_msec", "vals": [ "10000" ] },
-		{ "arg": "log_avg_msec", "vals": [ "1000" ] },
 		{ "arg": "ramp_time", "vals": [ "5s" ] },
 
 		{ "arg": "bs", "vals": [ "8K", "16K" ] },


### PR DESCRIPTION
- many parameters included are no longer required since they
  automatically come from bench-fio's multiplex.json essentials
  section