### PR TITLE
detect created but not running containers and clean them up

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -45,12 +45,7 @@ function start_httpd() {
     local RC httpd_cmd
     httpd_cmd="/usr/sbin/httpd -DFOREGROUND"
     echo -n "Checking for httpd"
-    ${podman_exists} crucible-httpd
-    RC=$?
-    if [ ${RC} == 0 ]; then
-        echo "...appears to be running"
-    else
-        echo "...not present, starting a container for it:"
+    if ! podman_running crucible-httpd; then
         firewall-cmd --zone=public --add-port=8080/tcp >/dev/null 2>&1
         $podman_run --name crucible-httpd "${container_common_args[@]}" "${container_httpd_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $httpd_cmd
         RC=$?
@@ -65,12 +60,7 @@ function start_redis() {
     local RC redis_cmd
     redis_cmd="redis-server /etc/redis.conf"
     echo -n "Checking for redis"
-    ${podman_exists} crucible-redis
-    RC=$?
-    if [ ${RC} == 0 ]; then
-        echo "...appears to be running"
-    else
-        echo "...not present, starting a container for it:"
+    if ! podman_running crucible-redis; then
         firewall-cmd --zone=public --add-port=6379/tcp >/dev/null 2>&1
         $podman_run --name crucible-redis "${container_common_args[@]}" "${container_redis_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $redis_cmd
         RC=$?
@@ -88,12 +78,7 @@ function start_es() {
     es_start_cmd="${CRUCIBLE_HOME}/config/start-es.sh $var_crucible/es"
     es_status_cmd="curl --silent --show-error --stderr - -X GET localhost:9200/_cat/indices"
     echo -n "Checking for elasticsearch"
-    ${podman_exists} crucible-es;
-    RC=$?
-    if [ ${RC} == 0 ]; then
-        echo "...appears to be running"
-    else
-        echo "...not present, starting a container for it:"
+    if ! podman_running crucible-es; then
         firewall-cmd --zone=public --add-port=9200/tcp --add-port=9300/tcp >/dev/null 2>&1
         mkdir -p "$var_crucible/es"
         common_container_args=()

--- a/bin/base
+++ b/bin/base
@@ -45,8 +45,33 @@ container_log_args+=("--mount=type=bind,source=/tmp,destination=/tmp")
 var_crucible="/var/lib/crucible"
 podman_pull="podman pull"
 podman_stop="podman stop"
+podman_rm="podman rm"
 podman_run="podman run --pull=missing"
 podman_exists="podman container exists"
+
+function podman_running() {
+    pod=${1}
+    if [ -z "${pod}" ]; then
+        exit_error "podman_running: no pod name supplied" 3
+    fi
+
+    if ${podman_exists} ${pod}; then
+        check_output=$(podman ps --noheading --filter status=running --filter name=${pod})
+
+        if [ -n "${check_output}" ]; then
+            echo "...appears to be running"
+            return 0
+        else
+            echo "...appears to be present but not running...fixing:"
+            ${podman_stop} ${pod}
+            ${podman_rm} ${pod}
+            return 1
+        fi
+    else
+        echo "...not present, starting a container for it:"
+        return 1
+    fi
+}
 
 datetime=`date +%Y-%m-%d_%H:%M:%S`
 


### PR DESCRIPTION
- Sometimes podman gets in a state where containers that should be
  removed when they stop are left around, this is usually tied to some
  undesirable event (such as a system crash), and when this happens
  our logic to start the containers if they are not present fails.

- If a container is detected in this state attempt to forcibly remove
  it so that it can be relaunched through the normal container start
  procedures.