### PR TITLE
add the crucible-examples repo at subprojects/docs/examples

### DIFF
--- a/bin/subprojects-install
+++ b/bin/subprojects-install
@@ -71,7 +71,7 @@ done
 
 no_clone=""
 pushd "$crucible_repo_dir" >/dev/null || exit_error "Could not change directory to $crucible_repo_dir"
-/bin/mkdir -p subprojects/benchmarks subprojects/tools subprojects/core
+/bin/mkdir -p subprojects/benchmarks subprojects/tools subprojects/core subprojects/docs
 for link in $(find subprojects -type l); do
     type_dir=$(echo "${link}" | awk -F'/' '{ print $2 }')
     name_link=$(echo "${link}" | awk -F'/' '{ print $3 }')
@@ -91,6 +91,11 @@ for link in $(find subprojects -type l); do
                 ;;
             "core")
                 if [ "${type_dir}" == "core" ]; then
+                    active=1
+                fi
+                ;;
+            "doc")
+                if [ "${type_dir}" == "docs" ]; then
                     active=1
                 fi
                 ;;
@@ -130,6 +135,9 @@ for subproject in "${!subprojects[@]}"; do
             ;;
         "core")
             sp_dir_prefix="core/"
+            ;;
+        "doc")
+            sp_dir_prefix="docs/"
             ;;
     esac
     clone_user_host_org_dir="repos/$sp_git_user$sp_git_host_org"

--- a/config/default_subprojects
+++ b/config/default_subprojects
@@ -23,3 +23,4 @@ kernel               tool           /tool-kernel                                
 ovs                  tool           /tool-ovs                                       master
 tcpdump              tool           /tool-tcpdump                                   main
 flexran              benchmark      /bench-flexran                                  main
+examples             doc            /crucible-examples                              main


### PR DESCRIPTION
- this adds the basic infrastructure to support subprojects/docs as a
  valid subproject target