### PR TITLE
add the GitHub CLI utility to the Crucible controller

### DIFF
--- a/workshop/controller-workshop.json
+++ b/workshop/controller-workshop.json
@@ -34,7 +34,10 @@
         "nodejs",
         "motd",
         "bc",
-        "sshpass"
+        "sshpass",
+        "dnf",
+        "gh-cli-repo",
+        "gh-cli"
       ]
     }
   ],
@@ -322,7 +325,7 @@
         ]
       }
     },
-        {
+    {
       "name": "perl-modules",
       "type": "cpan",
       "cpan_info": {
@@ -335,6 +338,33 @@
           "DBI DBD::SQLite",
           "IO::Uncompress::UnXz",
           "IO::Compress::Xz"
+        ]
+      }
+    },
+    {
+      "name": "dnf",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "\"dnf-command(config-manager)\""
+        ]
+      }
+    },
+    {
+      "name": "gh-cli-repo",
+      "type": "manual",
+      "manual_info": {
+        "commands": [
+          "dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo"
+        ]
+      }
+    },
+    {
+      "name": "gh-cli",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "gh"
         ]
       }
     }


### PR DESCRIPTION
- this allows a user to use the `crucible console` to run GitHub CLI
  commands

- an example of why a user would want to do this is to retrieve code
  from a pending PR for testing purposes