### PR TITLE
change podman's log level to suppress warnings

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -49,7 +49,7 @@ var_archive_crucible="${var_crucible}/archive"
 function podman_wrapper() {
     local RC
 
-    podman "$@" 2>&1 | grep --line-buffered -v "level=warning"
+    podman --log-level error "$@" 2>&1 | grep --line-buffered -v "level=warning\|WARNING: The same type, major and minor should not be used for multiple devices."
     RC=${PIPESTATUS[0]}
 
     return ${RC}


### PR DESCRIPTION
- This doesn't appear to suppress all warnings so the grep filter is
  still necessary, I assume this is because a library that podman is
  loading is emitting warnings that don't honor the log level.