### PR TITLE
exec workshop in build-controller.sh

### DIFF
--- a/workshop/build-controller.sh
+++ b/workshop/build-controller.sh
@@ -15,9 +15,7 @@ fi
 if pushd ${CRUCIBLE_HOME} > /dev/null; then
     export TOOLBOX_HOME=${CRUCIBLE_HOME}/subprojects/core/toolbox
     
-    ./subprojects/core/workshop/workshop.pl --userenv ./workshop/fedora36.json --requirements ./workshop/controller-workshop.json --label crucible-controller
-
-    popd > /dev/null
+    exec ./subprojects/core/workshop/workshop.pl --userenv ./workshop/fedora36.json --requirements ./workshop/controller-workshop.json --label crucible-controller
 else
     echo "ERROR: Failed to pushd to \$CRUCIBLE_HOME [${CRUCIBLE_HOME}]"
     exit 1


### PR DESCRIPTION
- pass control over to workshop entirely

- ensure return codes are properly given to the call