### PR TITLE
Ignore passthru args on from-file mode

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -236,7 +236,11 @@ elif [ "${1}" == "run" ]; then
                 use_mv_params=1
                 ;;
             *)
-                passthru_args+=("${arg}")
+                if [ -z ${run_file+x} ]; then
+                    passthru_args+=("${arg}")
+                else
+                    echo "'${arg}' was ignored. Specify passthru args with --from-file <run-file>."
+                fi
                 ;;
         esac
     done


### PR DESCRIPTION
Do not aggregate passthru args if coming from command line. Instead, only consider passthru args coming from the run file, the so called "single-json". This code path will remain active until we deprecate the old passthru args from command line. Meanwhile we need maintain both code paths: 1) old passthru args from command line and 2) passthru-args from single-json run file.