### PR TITLE
add testing-repo to the list of default subprojects

### DIFF
--- a/config/default_subprojects
+++ b/config/default_subprojects
@@ -26,3 +26,4 @@ forkstat             tool           /tool-forkstat                              
 flexran              benchmark      /bench-flexran                                  main
 iperf                benchmark      /bench-iperf                                    main
 examples             doc            /crucible-examples                              main
+testing              doc            /testing-repo                                   master


### PR DESCRIPTION
- this new repo is to be used as an experiment in migrating the primary branch from the 'master' name to the 'main' name