### PR TITLE
fixup result summary handling logic

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -159,7 +159,7 @@ elif [ "${1}" == "es" ]; then
                         post_process_run "${var_run_crucible}/${base_run_dir}"
                         index_run "${var_run_crucible}/${base_run_dir}"
                         this_id=$(extract_run_id "${var_run_crucible}/${base_run_dir}")
-                        get_result --run $this_id
+                        get_result_to_file "${base_run_dir}" --run ${this_id}
                         RC=$?
                         if [ ${RC} != 0 ]; then
                             echo "ERROR: Failed to post-process ${base_run_dir} [rc=${RC}]"
@@ -397,7 +397,7 @@ elif [ "${1}" == "run" ]; then
     if [ ${RC} == 0 ]; then
         post_process_run ${base_run_dir} &&\
         index_run ${base_run_dir} &&\
-        get_result --run $(extract_run_id "${base_run_dir}")
+        get_result_to_file "${base_run_dir}" --run $(extract_run_id "${base_run_dir}")
         EXIT_VAL=$?
     else
         echo "Skipping run post-processing due to error(s) [rc=${RC}]"

--- a/bin/base
+++ b/bin/base
@@ -607,22 +607,48 @@ function index_run() {
     return ${RC}
 }
 
-function get_result() {
+function get_result_backend() {
+    local RC
 
     cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-result-summary.sh $@"
-    echo "Generating benchmark summary report"
-    result_summary="${RUN_DIR}/run/result-summary.txt"
-    $podman_run --name crucible-get-result-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $cdm_query_cmd > ${result_summary}
+    $podman_run --name crucible-get-result-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $cdm_query_cmd
     RC=$?
-    cat ${result_summary}
+    return ${RC}
+}
+
+function get_result_to_file() {
+    local RC
+
+    local output_file="$1/run/result-summary.txt"; shift
+
+    echo "Generating benchmark summary report:"
+    get_result_backend "$@" > ${output_file}
+    RC=$?
+    cat ${output_file}
     if [ ${RC} == 0 ]; then
         echo
         echo "Benchmark summary is complete and can be found in:"
-        echo "${RUN_DIR}/run/result-summary.txt"
+        echo "${output_file}"
     else
         echo "ERROR: Could not generate benchmark summary"
         RC=1
     fi
+
+    return ${RC}
+}
+
+function get_result() {
+    local RC
+
+    echo "Generating benchmark summary report:"
+    get_result_backend "$@"
+    RC=$?
+
+    if [ ${RC} != 0 ]; then
+        echo "ERROR: Could not generate benchmark summary"
+        RC=1
+    fi
+
     return ${RC}
 }
 


### PR DESCRIPTION
- create a shared get_result_backend function that just does the result summary retrieval

- create separate get_result and get_result_to_file functions that wrap around get_result_backend but handle the output differently depending on the use case