### PR TITLE
Prevent passthru in cmdline when --run-file is used

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -246,9 +246,12 @@ elif [ "${1}" == "run" ]; then
         esac
     done
 
-    # merge passthru args from json file
+    if [ -n "${passthru_str}" && -n "${passthru_args}" ]; then
+        exit_error "Error: --from-file option cannot be used with --tags or passthru args."
+    fi
+
     if [ -n "${passthru_str}" ]; then
-        passthru_args="${passthru_args[*]} ${passthru_str}"
+        passthru_args="${passthru_str}"
     fi
 
     if [ -n "${tags_str}" ]; then


### PR DESCRIPTION
Do not allow user to specify passthru args in command line if --run-file <all-in-one.json> is used. Passthru args must be set in the json file instead.