### PR TITLE
bugfix: remove --workdir from the container_common_args

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -37,7 +37,6 @@ container_common_args+=("--ipc=host")
 container_common_args+=("--pid=host")
 container_common_args+=("--net=host")
 container_common_args+=("--security-opt=label=disable")
-container_common_args+=("--workdir=`/bin/pwd`")
 
 container_log_args=()
 container_log_args+=("--mount=type=bind,source=${USER_STORE},destination=${USER_STORE}")


### PR DESCRIPTION
- we don't actually need or rely on this

- if the working directory (/bin/pwd) does not actually exist inside the container this would cause a fatal error and hang