### PR TITLE
add --tty to the rickshaw-run pod command

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -361,7 +361,7 @@ elif [ "${1}" == "run" ]; then
       --base-run-dir=$base_run_dir\
       ${passthru_args[@]}"
 
-    $podman_run --name crucible-rickshaw-run-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" "${container_build_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $rs_run_cmd
+    $podman_run --name crucible-rickshaw-run-${SESSION_ID} --tty "${container_common_args[@]}" "${container_rs_args[@]}" "${container_build_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $rs_run_cmd
     RC=$?
 
     if [ ${RC} == 0 ]; then


### PR DESCRIPTION
- this allows a SIGINT generated by typing CTRL-C to be delivered to rickshaw-run

- if --tty is added to ${container_rs_args[@]} it breaks result summary generation so only do it here