### PR TITLE
Add multibench support to all-in-one json

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -156,12 +156,6 @@ elif [ "${1}" == "postprocess" ]; then
 elif [ "${1}" == "run" ]; then
     arg_list="$@"
     shift
-    benchmark=${1}
-    benchmarks=`echo ${benchmark} | sed -e 's/,/-and-/g'`
-    shift
-    base_run_dir="${var_run_crucible}/${benchmarks}--${datetime}--${SESSION_ID}"
-
-    mkdir -pv "$base_run_dir/config" >/dev/null
 
     bench_params="bench-params.json"
     tool_params="tool-params.json"
@@ -170,57 +164,117 @@ elif [ "${1}" == "run" ]; then
     no_tools=0
 
     passthru_args=()
-    while [ $# -gt 0 ]; do
-        arg=${1}
-        shift
-        case "${arg}" in
-            "--mv-params")
-                val=${1}
-                shift
-                use_mv_params=1
-                mv_params=${val}
-                ;;
-            "--tags")
-                val=${1}
-                shift
-                passthru_args+=("${arg}")
-                passthru_args+=("${val}")
-                ;;
-            "--bench-params")
-                val=${1}
-                shift
-                bench_params=${val}
-                ;;
-            "--tool-params")
-                val=${1}
-                shift
-                tool_params=${1}
-                ;;
-            "--no-tools")
-                no_tools=1
-                ;;
-            "--from-file")
-                val=${1}
-                shift
-                run_file=${val}
-                mv_params=${base_run_dir}/config/mv-params.json
-                tool_params=${base_run_dir}/config/${tool_params}
-                python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config mv-params > $mv_params
-                python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config tool-params > $tool_params
-                tags_str=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config tags)
-                endpoint_str=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config endpoint)
-                passthru_blk=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config passthru-args)
-                passthru_str=$(sed -e 's/^"//' -e 's/"$//' <<< ${passthru_blk})
-                use_mv_params=1
-                ;;
-            *)
-                passthru_args+=("${arg}")
-                ;;
-        esac
-    done
 
-    if [ -n "${passthru_str}" -a -n "${passthru_args}" ]; then
-        exit_error "Error: --from-file option cannot be used with --tags or passthru args."
+    if [[ "${1}" == "--from-file" ]]; then
+        # use the crucible run file aka "all-in-one" / single json file
+        # crucible run --from-file <all-in-one-json>
+        shift
+        run_file=${1}
+        if [ ! -f $run_file ]; then
+            exit_error "File not found: $run_file"
+        fi
+        # only one arg is expected (json file)
+        if [ -n "$run_file" -a $# -gt 1 ]; then
+            exit_error "No other options must be speicifed with '--from-file <All-in-One-JSON>'."
+        fi
+
+        # extracts benchmark(s) from the json and convert to stream
+        # e.g. oslat,iperf,uperf,oslat
+        benchmark_ids=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config benchmarks)
+        IFS=','; read -ra bench <<< "$benchmark_ids"; IFS=' '
+        for b in "${bench[@]}"; do
+           benchmark+=$(echo ",$b" | cut -f1 -d:)
+        done
+        bench_list=$(sed -e 's/^,//' <<< $benchmark)
+        # convert from oslat,iperf to oslat-and-iperf
+        benchmarks=`echo ${bench_list} | sed -e 's/,/-and-/g'`
+
+        base_run_dir="${var_run_crucible}/${benchmarks}--${datetime}--${SESSION_ID}"
+        mkdir -pv "$base_run_dir/config" >/dev/null
+        
+        for bench in ${bench_list}; do
+            mv_params="${base_run_dir}/config/${bench}-mv-params.json"
+            bb_stdout=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config mv-params --benchmark ${bench})
+            if [ $? != 0 ]; then
+                exit_error "Error: blockbreaker rc=$? stdout=$bb_stdout"
+            fi
+            echo $bb_stdout > $mv_params
+        done
+
+        bb_stdout=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config tool-params)
+        if [ $? != 0 ]; then
+            exit_error "Error: blockbreaker rc=$? stdout=$bb_stdout"
+        fi
+        tool_params="${base_run_dir}/config/${tool_params}"
+        echo $bb_stdout > $tool_params
+
+        tags_str=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config tags)
+        if [ $? != 0 ]; then
+            exit_error "Error: blockbreaker rc=$? stdout=$tags_str"
+        fi
+
+        endpoint_str=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config endpoint)
+        if [ $? != 0 ]; then
+            exit_error "Error: blockbreaker rc=$? stdout=$endoint_str"
+        fi
+
+        passthru_blk=$(python3 ${RICKSHAW_HOME}/util/blockbreaker.py --json ${run_file} --config passthru-args)
+        if [ $? != 0 ]; then
+            exit_error "Error: blockbreaker rc=$? stdout=$passthru_blk"
+        fi
+        passthru_str=$(sed -e 's/^"//' -e 's/"$//' <<< ${passthru_blk})
+
+        use_mv_params=1
+    else
+        # backwards compatibility (separated JSON files)
+        # if not using all-in-one, benchmark must be 1st arg: crucible run <benchmark>
+        benchmark=${1}
+        shift
+        if [ -z "$benchmark" ]; then
+            exit_error "No benchmark specified."
+        fi
+        benchmarks=`echo ${benchmark} | sed -e 's/,/-and-/g'`
+        base_run_dir="${var_run_crucible}/${benchmarks}--${datetime}--${SESSION_ID}"
+        mkdir -pv "$base_run_dir/config" >/dev/null
+
+        while [ $# -gt 0 ]; do
+            arg=${1}
+            shift
+            case "${arg}" in
+                "--mv-params")
+                    val=${1}
+                    shift
+                    use_mv_params=1
+                    mv_params=${val}
+                    ;;
+                "--tags")
+                    val=${1}
+                    shift
+                    passthru_args+=("${arg}")
+                    passthru_args+=("${val}")
+                    ;;
+                "--bench-params")
+                    val=${1}
+                    shift
+                    bench_params=${val}
+                    ;;
+                "--tool-params")
+                    val=${1}
+                    shift
+                    tool_params=${1}
+                    ;;
+                "--no-tools")
+                    no_tools=1
+                    ;;
+                "--from-file")
+                    exit_error "Run 'crucible run --from-file <file.json>' with no other options"
+                    ;;
+                *)
+                    passthru_args+=("${arg}")
+                    ;;
+            esac
+        done
+
     fi
 
     if [ -n "${passthru_str}" ]; then
@@ -240,16 +294,21 @@ elif [ "${1}" == "run" ]; then
     if [ -z "$CRUCIBLE_CLIENT_SERVER_REPO" ]; then
         exit_error "CRUCIBLE_CLIENT_SERVER_REPO is not defined"
     fi
+
     if [ -z "$CRUCIBLE_CONTAINER_IMAGE" ]; then
         exit_error "Exiting because CRUCIBLE_CONTAINER_IMAGE is not defined"
     fi
+
     if [ -e "${var_run_crucible}/latest" ]; then
         /bin/rm "${var_run_crucible}/latest"
     fi
+
     ln -sf "$base_run_dir" "${var_run_crucible}/latest"
     rs_dir="${CRUCIBLE_HOME}"/subprojects/core/rickshaw
 
-    for this_benchmark in `echo $benchmark | sed -e 's/,/ /'`; do
+    benchmark=$(sed -e 's/^,//' <<< $benchmark)
+    bench_list=$(sed -e 's/,/ /' <<< $benchmark)
+    for this_benchmark in $bench_list; do
         this_benchmark_subproj_dir="${CRUCIBLE_HOME}"/subprojects/benchmarks/$this_benchmark
         if [ ! -e "$this_benchmark_subproj_dir" ]; then
             echo "ERROR: Running benchmark ${this_benchmark} requires that the subproject be"
@@ -266,7 +325,10 @@ elif [ "${1}" == "run" ]; then
     if [ ${use_mv_params} == 1 ]; then
         count=1
         bench_params=""
-        for this_mv_params in `echo ${mv_params} | sed -e 's/,/ /'`; do
+        # remove first comma from mv_params list of json files
+        # and replace commas with spaces
+        mv_params=`echo ${mv_params} | sed -e 's/^,//' | sed -e 's/,/ /g'`
+        for this_mv_params in ${mv_params}; do
             if [ ! -e "${this_mv_params}" ]; then
                 exit_error "The multi-value params file you specified with --mv-params (${this_mv_params}) does not exist!"
             else
@@ -274,7 +336,10 @@ elif [ "${1}" == "run" ]; then
                 this_benchmark_subproj_dir=`echo ${benchmark_subproj_dir} | cut -d, -f$count`
                 echo "Generating --bench-params from --mv-params..."
                 this_mv_params_run_dir=${base_run_dir}/config/${this_benchmark}-mv-params.json
-                cp ${this_mv_params} ${this_mv_params_run_dir}
+                # if mv-params come from the run file json, files are already there
+                if [ ! -f "${this_mv_params_run_dir}" ]; then
+                    cp ${this_mv_params} ${this_mv_params_run_dir}
+                fi
                 bench_params_run_file=${base_run_dir}/config/${this_benchmark}-bench-params.json
                 bench_params_run_output=${base_run_dir}/config/${this_benchmark}-bench-params.txt
     
@@ -340,12 +405,6 @@ elif [ "${1}" == "run" ]; then
     params_args+=" --bench-params ${bench_params}"
     params_args+=" --tool-params ${tool_params_file}"
 
-    start_redis
-    EXIT_VAL=$?
-    if [ ${EXIT_VAL} != 0 ]; then
-        exit ${EXIT_VAL}
-    fi
-
     ${CRUCIBLE_HOME}/bin/repo info > ${base_run_dir}/config/crucible.repo.info
     ${CRUCIBLE_HOME}/bin/repo details > ${base_run_dir}/config/crucible.repo.details
 
@@ -360,6 +419,19 @@ elif [ "${1}" == "run" ]; then
       --tools-dir=${CRUCIBLE_HOME}/subprojects/tools\
       --base-run-dir=$base_run_dir\
       ${passthru_args[@]}"
+
+    echo "rickshaw run command: $rs_run_cmd"
+
+    if [ -n "$CRUCIBLE_DRY_RUN" ]; then
+        echo "Warning: CRUCIBLE_DRY_RUN environment variable is set, exiting..."
+        exit 0
+    fi
+
+    start_redis
+    EXIT_VAL=$?
+    if [ ${EXIT_VAL} != 0 ]; then
+        exit ${EXIT_VAL}
+    fi
 
     $podman_run --name crucible-rickshaw-run-${SESSION_ID} --tty "${container_common_args[@]}" "${container_rs_args[@]}" "${container_build_args[@]}" $CRUCIBLE_CONTAINER_IMAGE $rs_run_cmd
     RC=$?


### PR DESCRIPTION
This patch integrates the multibench functionality into the crucible run files, aka all-in-one json. It includes single bench and multibench run mode when --from-file is used. Backwards compatibility takes care of the old run mode, which sets the benchmark from the cli with 'crucible run <benchmark(s)> [args]'.

A dry run mode is added through the env var CRUCIBLE_DRY_RUN=1 to help testing debugging param construction, parsing and validation.