### PR TITLE
Add jq to the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Crucible is a performance tool harness that integrates [multiple performance too
 
 ### Zero-touch Installation
 
-Crucible can be installed on a single Linux system (the crucible-controller), and does not require installation on any target host, cluster, or cloud that needs  testing. Crucible uses container images to satisfy software dependencies. The crucible-controller system only needs to have [git](https://git-scm.com) and [podman](https://podman.io) software installed. Endpoints (systems, clusters, clouds that are "under-test") only need the ability to pull container images. Most clusters/clouds have this ability already, and non-clouds (like a remote-host) only need podman.
+Crucible can be installed on a single Linux system (the crucible-controller), and does not require installation on any target host, cluster, or cloud that needs  testing. Crucible uses container images to satisfy software dependencies. The crucible-controller system only needs to have [git](https://git-scm.com) and [podman](https://podman.io) software installed, plus [jq](https://jqlang.github.io/jq/) to manipulate configuration in JSON format. Endpoints (systems, clusters, clouds that are "under-test") only need the ability to pull container images. Most clusters/clouds have this ability already, and non-clouds (like a remote-host) only need podman.
 
 ### Hybrid/Multi-cloud Capable
 

--- a/crucible-install.sh
+++ b/crucible-install.sh
@@ -5,7 +5,7 @@
 # Installer Settings
 IDENTITY="/root/.crucible/identity"
 SYSCONFIG="/etc/sysconfig/crucible"
-DEPENDENCIES="podman git"
+DEPENDENCIES="podman git jq"
 INSTALL_PATH="/opt/crucible"
 GIT_INSTALL_LOG="/tmp/crucible-git-install.log"
 CRUCIBLE_CONTROLLER_REGISTRY="quay.io/crucible/controller:latest"


### PR DESCRIPTION
jq is necessary to manipulate run file JSON, e.g. for extracting benchmarks to run.