### PR TITLE
Fix crucible-release workflow

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   release-tag:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     outputs:
       tag: ${{ steps.gen-release-tag.outputs.tag }}
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   crucible-tag:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
     - name: checkout crucible default
       uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
 
   get-sub-projects:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     outputs:
       repos: ${{ steps.get-repos.outputs.repos }}
     steps:
@@ -127,6 +127,8 @@ jobs:
       run: echo "$REPOS"
 
   projects-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs:
     - get-sub-projects
     strategy:


### PR DESCRIPTION
Required property is missing: runs-on

Adjust timeout values