### PR TITLE
Get urls instead of repo names

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -116,8 +116,8 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE
             cd crucible/config
-            # get first column (repo name) and add to a bash array ( a b c )
-            projects=( $(grep -v ^# default_subprojects | awk {'print $1'} ) )
+            # get 3rd column (repo URL) and add to a bash array ( a b c )
+            projects=( $(grep -v ^# default_subprojects | awk {'print $3'} ) )
             # builtin implict join array a,b,c
             printf -v list '"%s",' "${projects[@]}"
             # convert to a comma separated list [a,b,c]


### PR DESCRIPTION
Fix get-sub-projects job to clone crucible projects by getting the repository matrix containing the repo urls.