### PR TITLE
Generate token from app for pushing tags

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -25,6 +25,19 @@ on:    # yamllint disable-line rule:truthy
         default: push
 
 jobs:
+  app-token:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      token: ${{ steps.generate-token.outputs.token }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID__TAG_CRUCIBLE_RELEASE }}
+          private-key: ${{ secrets.PRIVATE_KEY__TAG_CRUCIBLE_RELEASE }}
+
   release-tag:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -68,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:
+      - app-token
       - release-tag
     steps:
       - name: checkout crucible default
@@ -76,6 +90,7 @@ jobs:
           repository: perftool-incubator/crucible
           ref: master
           path: crucible
+          token: ${{ needs.app-token.outputs.token }}
       - name: push/delete tag to/from the crucible repo
         if: ${{ inputs.dry_run == false }}
         env:
@@ -131,6 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
+      - app-token
       - release-tag
       - get-sub-projects
     strategy:
@@ -144,6 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: perftool-incubator/${{ matrix.repository }}
+          token: ${{ needs.app-token.outputs.token }}
       - name: push/delete release tag
         if: ${{ inputs.dry_run == false }}
         env:


### PR DESCRIPTION
Token is generated from the tag-crucible-release app, which is configured with write permission for pushing.