### PR TITLE
Fix empty force push

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -55,7 +55,7 @@ jobs:
             if [ ${{ inputs.force_push == true }} ]; then
                 echo "force='-f'" >> $GITHUB_OUTPUT
             else
-                echo "force=" >> $GITHUB_OUTPUT
+                echo "force=''" >> $GITHUB_OUTPUT
 
   display-params:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When force_push is false, force var still needs to be assigned

echo "force=" >> $GITHUB_OUTPUT

This results in syntax error: unexpected end of file