### PR TITLE
Fix auto-generated tag

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -43,6 +43,7 @@ jobs:
             if [ "${{ inputs.custom_tag }}" == "" ]; then
                 year="$(date +%Y)"
                 month="$(date +%m)"
+                month=${month#0}
                 quarter="$(((month-1)/3+1))"
                 echo "tag=$year.$quarter" >> $GITHUB_OUTPUT
             else


### PR DESCRIPTION
Remove leading zero from month, to avoid bash treating it as octal base number.