### PR TITLE
Locked-down installs of crucible

### DIFF
--- a/bin/subprojects-install
+++ b/bin/subprojects-install
@@ -2,6 +2,8 @@
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 
+GIT_TAG=$1
+
 default_git_host_org="https://github.com/perftool-incubator"
 
 function exit_error() {
@@ -125,7 +127,11 @@ for subproject in "${!subprojects[@]}"; do
     sp_git_host_org=`echo $sp_git_user_host_org | sed -e 'sXhttps://XX' -e 'sXhttp://XX' -e 's/.*@//'`
     sp_git_user=`echo $sp_git_user_host_org | sed -e s,$sp_git_host_org,, -e 'sX://X:X'`
     sp_git_host_org=`echo $sp_git_host_org | sed -e 's,/,:,g'`
-    sp_branch=`echo ${subprojects[$subproject]} | awk '{print $4}'`
+    if [ -z "${GIT_TAG}" ]; then
+        sp_branch=`echo ${subprojects[$subproject]} | awk '{print $4}'`
+    else
+        sp_branch=$GIT_TAG
+    fi
     case "$sp_type" in
         "benchmark")
             sp_dir_prefix="benchmarks/"
@@ -157,11 +163,11 @@ for subproject in "${!subprojects[@]}"; do
             fi
         fi
         if pushd "${clone_user_host_org_proj_dir}" >/dev/null; then
-            cmd="git checkout ${sp_branch}"
-            echo "${cmd}"
-            if ! ${cmd}; then
-                exit_error "Could not checkout ${sp_branch} for ${sp_git_user_host_org}/${sp_git_proj}"
-            fi
+	    cmd="git checkout ${sp_branch}"
+	    echo "${cmd}"
+	    if ! ${cmd}; then
+	        exit_error "Could not checkout ${sp_branch} for ${sp_git_user_host_org}/${sp_git_proj}"
+	    fi
             popd >/dev/null
         else
             exit_error "Could not chdir to ${clone_user_host_org_proj_dir}"

--- a/tests/test-installer
+++ b/tests/test-installer
@@ -95,3 +95,35 @@ for arg_mode in client-server engine; do
     test "$?" = "0" || exit 1
     ls /opt/crucible-moved* || exit 1
 done
+
+# RELEASE: --release and --list-releases
+## prep step: check tags in remote repo
+tags=$(git ls-remote --tags \
+    --sort='version:refname' \
+    https://github.com/perftool-incubator/crucible.git \
+    | awk -F/ 'END{print$NF}')
+
+## show releases, test rc and stdout
+stdout=$(sudo ./crucible-install.sh \
+    --list-releases)
+test "$?" = "0" || exit 1
+[[ "$stdout" = *"$tags"* ]] || exit 1
+
+## negative test: --release and --git-repo
+ec=$(grep EC_RELEASE_DEFAULT_REPO_ONLY= crucible-install.sh | cut -d '=' -f2)
+sudo ./crucible-install.sh \
+    --release DoesNotMatter --git-repo DoesNotMatter
+test "$?" = "$ec" || exit 1
+
+## negative test: --release and --git-branch
+ec=$(grep EC_RELEASE_CONFLICTS_WITH_BRANCH= crucible-install.sh | cut -d '=' -f2)
+sudo ./crucible-install.sh \
+    --release DoesNotMatter --git-branch DoesNotMatter
+test "$?" = "$ec" || exit 1
+
+## negative test: non-existent tag
+ec=$(grep EC_FAIL_CHECKOUT= crucible-install.sh | cut -d '=' -f2)
+sudo ./crucible-install.sh \
+    --release NonExitentTag \
+    --client-server-registry myregistry.io/crucible
+test "$?" = "$ec" || exit 1


### PR DESCRIPTION
Add option for a locked-down version of Crucible.
Includes a --list-releases option to show tags.
Crucible installer --release <TAG> installs from
a <TAG>, or selects from a list if <TAG> is omitted (interactive mode).

Only default git repo is supported, and git branch cannot be specified if --release <TAG> option is used.