### PR TITLE
add the fuse-overlayfs package to the controller image

### DIFF
--- a/workshop/controller-workshop.json
+++ b/workshop/controller-workshop.json
@@ -130,7 +130,8 @@
         "packages": [
           "buildah",
           "podman",
-          "skopeo"
+          "skopeo",
+          "fuse-overlayfs"
         ]
       }
     },


### PR DESCRIPTION
- I believe this package was always "just there" before for some reason but it is now being left out and it is required for us to be able to build images using buildah inside our container

- a bug in crucible-ci allowed the switch to Fedora 40 for the controller image to slip through before despite this problem but that is believed to be resolved now