### PR TITLE
force the git-fetch calls to always get the latest repo status

### DIFF
--- a/bin/_git-fetch
+++ b/bin/_git-fetch
@@ -64,7 +64,7 @@ touch "${PROCESS_LOCK_FILE}"
 
                 if pushd ${repo_dir} > /dev/null; then
                     if [ -d "./.git" ]; then
-                        git_fetch_cmd="git fetch --all --prune --prune-tags --tags --verbose"
+                        git_fetch_cmd="git fetch --all --prune --prune-tags --tags --verbose --force"
                         echo "${git_fetch_cmd}"
                         ${git_fetch_cmd}
 

--- a/bin/_update-git
+++ b/bin/_update-git
@@ -63,7 +63,7 @@ if [ -d "./.git" ]; then
     fi
 
     # fetch updates from remote(s)
-    git_fetch_cmd="git fetch --all --prune --prune-tags --tags --verbose"
+    git_fetch_cmd="git fetch --all --prune --prune-tags --tags --verbose --force"
     echo "${git_fetch_cmd}"
     if ! ${git_fetch_cmd} 2>&1; then
 	echo "ERROR: could not git-fetch"


### PR DESCRIPTION
- Without the fetch an updated/changed tag can block the fetch from occuring -- if the tag is updated/changes then we definitely want to realize those changes