### PR TITLE
run the jobs from the crucible-release workflow on the workflow overh…

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -32,7 +32,7 @@ on:    # yamllint disable-line rule:truthy
 
 jobs:
   release-tag:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     outputs:
       tag: ${{ steps.gen-release-tag.outputs.tag }}
@@ -131,7 +131,7 @@ jobs:
         run: echo "$REPOS"
 
   projects-tag:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs:
       - release-tag


### PR DESCRIPTION
…ead runners

- avoid conflicts with other long running jobs (ie. crucible-ci)