### PR TITLE
change the checkout action version to 3 instead of 4 in the crucible-…

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -74,7 +74,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY__TAG_CRUCIBLE_RELEASE }}
           owner: ${{ github.repository_owner }}  
       - name: checkout crucible default
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: perftool-incubator/crucible
           ref: master
@@ -150,7 +150,7 @@ jobs:
           private-key: ${{ secrets.PRIVATE_KEY__TAG_CRUCIBLE_RELEASE }}
           owner: ${{ github.repository_owner }}  
       - name: checkout sub-project repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: perftool-incubator/${{ matrix.repository }}
           path: ${{ matrix.repository }}


### PR DESCRIPTION
…release workflow

- see if the older version avoids the problems currently being seen (ie. failure to determine the default branch of the repository being checked out)