### PR TITLE
bugfix: return the proper substring from the project's repository url…

### DIFF
--- a/.github/workflows/crucible-release.yaml
+++ b/.github/workflows/crucible-release.yaml
@@ -119,7 +119,7 @@ jobs:
             # get 3rd column (repo URL) without the starting '/' (remove first char),
             # so repo urls /a /b /c are extracted to a b c
             # and add to a bash array ( a b c )
-            projects=( $(jq -r '.official[] | select(.name != "crucible") | .name' repos.json) )
+            projects=( $(jq -r '.official[] | select(.name != "crucible") | .repository | sub(".*\/"; "")' repos.json) )
             # builtin implict join array "a","b","c" (double quotes for a valid json)
             printf -v list '"%s",' "${projects[@]}"
             # convert to a comma separated list ["a","b","c"]


### PR DESCRIPTION
… in order to have valid GitHub project names in the crucible-release workflow