### PR TITLE
disable podman's internal logging in favor of crucible's built in logger

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -942,6 +942,7 @@ container_common_args+=("--ipc=host")
 container_common_args+=("--pid=host")
 container_common_args+=("--net=host")
 container_common_args+=("--security-opt=label=disable")
+container_common_args+=("--log-driver=none")
 
 container_log_args=()
 container_log_args+=("--mount=type=bind,source=${USER_STORE},destination=${USER_STORE}")


### PR DESCRIPTION
- besides being redundant there are potential performance/behavioral issues that this is causing such as the terminal output stream (ie. STDOUT) being overwhelmed and failing