### PR TITLE
Manage opensearch instances for crucible

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -40,6 +40,15 @@ elif [ "${1}" == "ls" -o "${1}" == "tags" -o "${1}" == "result-completion" ]; th
             EXIT_VAL=$?
             ;;
     esac
+elif [ "${1}" == "instances" ]; then
+    shift
+    if [ -z "${1}" ]; then
+        ${podman_run} --name crucible-manage-instances-${SESSION_ID} "${container_common_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${CRUCIBLE_HOME}/bin/manage_instances.py --cfg ${INSTANCES_CFG} info
+        EXIT_VAL=$?
+    else
+        ${podman_run} --name crucible-manage-instances-${SESSION_ID} "${container_common_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${CRUCIBLE_HOME}/bin/manage_instances.py --cfg ${INSTANCES_CFG} "$@"
+        EXIT_VAL=$?
+    fi
 elif [ "${1}" == "registries" ]; then
     shift
     if [ -z "${1}" ]; then

--- a/bin/base
+++ b/bin/base
@@ -981,6 +981,7 @@ podman_ps="podman_wrapper ps"
 # load the jqlib library
 source ${CRUCIBLE_HOME}/bin/jqlib
 
+INSTANCES_CFG=${CRUCIBLE_HOME}/config/instances.json
 REGISTRIES_CFG=${CRUCIBLE_HOME}/config/registries.json
 REGISTRIES_CFG_SCHEMA=${CRUCIBLE_HOME}/schema/registries.json
 

--- a/bin/manage_instances.py
+++ b/bin/manage_instances.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+
+import json
+import argparse
+import sys
+import os
+
+# Default structure for a new or empty JSON file,
+# used if the specified --cfg file is empty or not found (and then created).
+DEFAULT_DATA = {
+  "instances": [
+    {
+      "name": "local",
+      "host": "localhost:9200",
+      "cdmver": "v8dev"
+    }
+  ],
+  "index-to": "local",
+  "query-from": [
+    "local"
+  ]
+}
+
+write_required = False
+
+def load_json_data(filepath):
+    """
+    Loads JSON data from the specified file.
+    If the file doesn't exist, initializes with default data (and will be created on save).
+    If the file is empty, initializes with default data.
+    If the file is corrupt, prints an error and exits.
+    """
+    global write_required
+    try:
+        with open(filepath, 'r') as f:
+            if os.fstat(f.fileno()).st_size == 0:
+                print(f"Info: File '{filepath}' is empty. Initializing with default structure.")
+                return DEFAULT_DATA.copy()
+            data = json.load(f)
+            # Ensure essential keys exist
+            if "instances" not in data or not isinstance(data.get("instances"), list):
+                print(f"Warning: 'instances' key not found or not a list in {filepath}. Initializing 'instances'.")
+                data["instances"] = []
+            if "index-to" not in data:
+                data["index-to"] = None
+            if "query-from" not in data or not isinstance(data.get("query-from"), list):
+                print(f"Warning: 'query-from' key not found or not a list in {filepath}. Initializing 'query-from'.")
+                data["query-from"] = []
+            return data
+    except FileNotFoundError:
+        print(f"Info: File '{filepath}' not found. Will be created with default structure.")
+        write_required = True
+        return DEFAULT_DATA.copy()
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from '{filepath}'. The file might be corrupted.")
+        sys.exit(1)
+
+def save_json_data(filepath, data):
+    """Saves JSON data to the specified file with pretty printing."""
+    try:
+        with open(filepath, 'w') as f:
+            json.dump(data, f, indent=2)
+        print(f"Data successfully saved to '{filepath}'.")
+    except IOError:
+        print(f"Error: Could not write to file '{filepath}'.")
+        sys.exit(1)
+
+def add_instance(data, name, host, cdmver, userpass=None, set_query_from=False, set_index_to=False):
+    """
+    Adds a new instance to the data's 'instances' list.
+    Optionally updates 'query-from' and 'index-to' based on flags.
+    Returns True if adding to 'instances' list was successful, False otherwise.
+    """
+    if not isinstance(data.get("instances"), list):
+        print("Critical Error: 'instances' key is missing or not a list. Cannot add instance.")
+        return False
+
+    for instance in data["instances"]:
+        if instance.get("name") == name:
+            print(f"Error: Instance with name '{name}' already exists in 'instances'. No changes made.")
+            return False
+
+    new_instance_dict = {
+        "name": name,
+        "host": host,
+        "cdmver": cdmver
+    }
+    if userpass is not None:
+        new_instance_dict["userpass"] = userpass
+
+    data["instances"].append(new_instance_dict)
+    print(f"Instance '{name}' added to 'instances' list.")
+
+    if set_query_from:
+        if name not in data["query-from"]:
+            data["query-from"].append(name)
+            print(f"Instance '{name}' added to 'query-from' list.")
+        else:
+            print(f"Info: Instance '{name}' was already present in 'query-from' list.")
+
+    if set_index_to:
+        data["index-to"] = name
+        print(f"Value of 'index-to' has been set to '{name}'.")
+
+    return True
+
+def remove_instance(data, name):
+    """
+    Removes an instance by its name from the data's 'instances' list.
+    Also updates 'query-from' and 'index-to' if the removed instance was referenced.
+    Returns True if successful, False otherwise.
+    """
+    if not isinstance(data.get("instances"), list):
+        print("Critical Error: 'instances' key is missing or not a list. Cannot remove instance.")
+        return False
+
+    initial_len = len(data["instances"])
+    data["instances"] = [inst for inst in data["instances"] if inst.get("name") != name]
+
+    if len(data["instances"]) < initial_len:
+        print(f"Instance '{name}' removed from 'instances' list.")
+
+        if "query-from" in data and isinstance(data["query-from"], list) and name in data["query-from"]:
+            data["query-from"].remove(name)
+            print(f"Instance '{name}' also removed from 'query-from' list.")
+
+        if data.get("index-to") == name:
+            data["index-to"] = None
+            print(f"'index-to' was '{name}', now set to None. Warning: No instance is currently configured for 'index-to'.")
+        return True
+    else:
+        print(f"Error: Instance with name '{name}' not found in 'instances' list. No changes made.")
+        return False
+
+def update_instance(data, name, new_host=None, new_cdmver=None, new_userpass=None, set_index_to=False, add_to_query_from=False, remove_query_from=False,remove_userpass_flag=False):
+    """
+    Updates an existing instance.
+    Returns True if successful, False otherwise.
+    """
+    instance_to_update = None
+    for inst in data.get("instances", []):
+        if inst.get("name") == name:
+            instance_to_update = inst
+            break
+
+    if not instance_to_update:
+        print(f"Error: Instance with name '{name}' not found. Cannot update.")
+        return False
+
+    updated_fields_messages = []
+    changes_made = False
+
+    if new_host is not None:
+        instance_to_update["host"] = new_host
+        updated_fields_messages.append(f"host set to '{new_host}'")
+        changes_made = True
+
+    if new_cdmver is not None:
+        instance_to_update["cdmver"] = new_cdmver
+        updated_fields_messages.append(f"cdmver set to '{new_cdmver}'")
+        changes_made = True
+
+    if remove_userpass_flag:
+        if "userpass" in instance_to_update:
+            del instance_to_update["userpass"]
+            updated_fields_messages.append("userpass removed")
+            changes_made = True
+        else:
+            updated_fields_messages.append("userpass was not set, no change to userpass")
+    elif new_userpass is not None:
+        instance_to_update["userpass"] = new_userpass
+        updated_fields_messages.append(f"userpass set to '{new_userpass}'")
+        changes_made = True
+
+    if set_index_to:
+        if data.get("index-to") != name:
+            data["index-to"] = name
+            updated_fields_messages.append(f"'index-to' set to '{name}'")
+            changes_made = True
+        else:
+            updated_fields_messages.append(f"'index-to' was already '{name}'")
+
+    if add_to_query_from:
+        if "query-from" not in data or not isinstance(data["query-from"], list):
+            data["query-from"] = []
+
+        if name not in data["query-from"]:
+            data["query-from"].append(name)
+            updated_fields_messages.append(f"'{name}' added to 'query-from'")
+            changes_made = True
+        else:
+            updated_fields_messages.append(f"'{name}' was already in 'query-from'")
+
+    if remove_query_from:
+        if "query-from" in data and name in data["query-from"]:
+            data["query-from"].remove(name)
+            updated_fields_messages.append(f"'{name}' removed from 'query-from'")
+            if not data["query-from"]:
+                updated_fields_messages.append(f"Warning: No instance is currently configured for 'query-from'")
+            changes_made = True
+        else:
+            updated_fields_messages.append(f"'{name}' was not present in 'query-from'")
+
+    if changes_made:
+        print(f"Instance '{name}' updated: {'; '.join(updated_fields_messages)}.")
+    else:
+        print(f"Info: Instance '{name}' found, but no update parameters provided or no changes were applicable.")
+        return False
+
+    return True
+
+
+def display_info(filepath, data):
+    """Displays the current configuration in a human-readable format."""
+    print(f"Current configuration from '{filepath}':")
+    print(json.dumps(data, indent=2))
+
+def find_instance(instances, target_name):
+    """
+    Finds the first instance in an array of instances where the 'name' field matches the target string.
+
+    Args:
+        instances: A list of instances.
+        target_name: The string to match against the 'name' field.
+
+    Returns:
+        The matching instance if found, otherwise None.
+    """
+    for instance in instances:
+        if "name" in instance:
+            if instance["name"] == target_name:
+                return instance
+    return None
+
+def query_opt(filepath, data):
+    """Displays cmdline options to be passed to cdmq (in project CDM)."""
+    cmdline = ""
+    for instance_name in data["query-from"]:
+        instance_obj = find_instance(data["instances"], instance_name)
+        if instance_obj != None:
+            cmdline = cmdline + " --host " + instance_obj["host"]
+            if "userpass" in instance_obj:
+                cmdline = cmdline + " --userpass " + instance_obj["userpass"]
+
+    print(cmdline)
+
+def main():
+    """Main function to parse arguments and dispatch actions."""
+    global write_required
+    parser = argparse.ArgumentParser(
+        description="Manage instances in a JSON configuration file.",
+        prog="manage_instances.py"
+    )
+    parser.add_argument(
+        '--cfg',
+        type=str,
+        required=True,
+        help='Path to the JSON configuration file (required).'
+    )
+
+    # Create subparsers for actions
+    subparsers = parser.add_subparsers(dest='action', required=True, title='actions',
+                                       description='Valid actions:', help='Action to perform')
+
+    # --- Add action ---
+    parser_add = subparsers.add_parser('add', help='Add a new instance to the configuration.')
+    parser_add.add_argument('--name', type=str, required=True, help='Name of the instance.')
+    parser_add.add_argument('--host', type=str, required=True, help='Host of the instance.')
+    parser_add.add_argument('--cdmver', type=str, required=True, help='CDM version of the instance.')
+    parser_add.add_argument('--userpass', type=str, nargs='?', const="", default=None, help='Optional user/password file path.')
+    parser_add.add_argument('--query', action='store_true', help='Also adds the instance name to "query-from".')
+    parser_add.add_argument('--index', action='store_true', help='Also sets "index-to" to this instance name.')
+
+    # --- Remove action ---
+    parser_remove = subparsers.add_parser('remove', help='Remove an instance from the configuration by name.')
+    parser_remove.add_argument('--name', type=str, required=True, help='Name of the instance to remove.')
+
+    # --- Update action ---
+    parser_update = subparsers.add_parser('update', help='Update an existing instance.')
+    parser_update.add_argument('--name', type=str, required=True, help='Name of the instance to update.')
+    parser_update.add_argument('--host', type=str, help='New host for the instance.')
+    parser_update.add_argument('--cdmver', type=str, help='New CDM version for the instance.')
+    parser_update.add_argument('--userpass', type=str, nargs='?', const="", default=None, help='New user/password file path. Use --remove-userpass to clear.')
+    parser_update.add_argument('--remove-userpass', action='store_true', help='Removes the userpass field.')
+    parser_update.add_argument('--query', action='store_true', help='Adds/ensures the instance name is in "query-from".')
+    parser_update.add_argument('--no-query', action='store_true', help='Removes the instance name from "query-from".')
+    parser_update.add_argument('--index', action='store_true', help='Sets "index-to" to this instance name.')
+
+    # --- Info action ---
+    parser_info = subparsers.add_parser('info', help='Display the current configuration from the JSON file.')
+    parser_info = subparsers.add_parser('query-opt', help='Display the cmdline options to pass to CDM queries.')
+    # No specific arguments for info other than the global --cfg
+
+    args = parser.parse_args()
+
+    config_filepath = args.cfg
+    data = load_json_data(config_filepath)
+
+    if args.action == 'add':
+        # argparse for subparser 'add' already handles required fields like name, host, cdmver
+        if add_instance(data, args.name, args.host, args.cdmver, args.userpass, args.query, args.index):
+            write_required = True
+    elif args.action == 'remove':
+        # argparse for subparser 'remove' already handles required field name
+        if remove_instance(data, args.name):
+            write_required = True
+    elif args.action == 'update':
+        # argparse for subparser 'update' already handles required field name
+        update_action_specified = any([
+            args.host is not None,
+            args.cdmver is not None,
+            args.userpass is not None, # This will be true if --userpass is present, even if it's the const ""
+            args.remove_userpass,
+            args.index,
+            args.query,
+            args.no_query
+        ])
+        if not update_action_specified:
+            # This error should ideally be caught by making at least one of these options part of a required group
+            # within the subparser, but for simplicity, we check it here.
+            # Alternatively, the subparser itself could be made to require one of these.
+            # For now, this check suffices.
+            parser_update.error("At least one update field (--host, --cdmver, --userpass, --remove-userpass, --index, --query) must be specified.")
+
+        effective_userpass = args.userpass if not args.remove_userpass else None
+        if update_instance(data, args.name, args.host, args.cdmver, effective_userpass, args.index, args.query, args.no_query, args.remove_userpass):
+            write_required = True
+    elif args.action == 'info':
+        display_info(config_filepath, data)
+
+    elif args.action == 'query-opt':
+        query_opt(config_filepath, data)
+
+    if write_required:
+        print("writing config file");
+        save_json_data(config_filepath, data)
+
+if __name__ == "__main__":
+    main()

--- a/bin/test_instances.py
+++ b/bin/test_instances.py
@@ -1,0 +1,324 @@
+import unittest
+import json
+import os
+import shutil # For copying file
+from unittest.mock import patch, mock_open # For mocking file operations and sys.exit
+import sys
+
+# Add the directory containing manage_instances.py to the Python path
+# This assumes test_manage_instances.py is in the same directory as manage_instances.py
+# or that manage_instances.py is installed/accessible in the PYTHONPATH.
+# For simplicity in this environment, we'll assume they are in the same directory
+# and manage_instances can be imported directly.
+import manage_instances # The script we are testing
+
+class TestManageInstances(unittest.TestCase):
+
+    def setUp(self):
+        """Set up for test methods."""
+        self.test_dir = "test_json_data_dir"
+        os.makedirs(self.test_dir, exist_ok=True)
+        self.test_file_path = os.path.join(self.test_dir, "test_instances.json")
+
+        # manage_instances.py still defines DEFAULT_DATA
+        self.default_data_backup = manage_instances.DEFAULT_DATA.copy()
+
+        self.initial_data = {
+            "instances": [
+                {"name": "test1", "host": "host1", "cdmver": "v1"},
+                {"name": "test2", "host": "host2", "cdmver": "v2", "userpass": "pass2"}
+            ],
+            "index-to": "test1",
+            "query-from": ["test1", "test2"]
+        }
+        # Create a fresh test file for each test
+        with open(self.test_file_path, 'w') as f:
+            json.dump(self.initial_data.copy(), f, indent=2) # Use a copy
+
+    def tearDown(self):
+        """Tear down after test methods."""
+        if os.path.exists(self.test_file_path):
+            os.remove(self.test_file_path)
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir) # Remove the test directory
+        manage_instances.DEFAULT_DATA = self.default_data_backup # Restore default data
+
+    # --- Test load_json_data ---
+    def test_load_json_data_existing_file(self):
+        data = manage_instances.load_json_data(self.test_file_path)
+        self.assertEqual(data, self.initial_data)
+
+    def test_load_json_data_non_existent_file(self):
+        non_existent_file = os.path.join(self.test_dir, "non_existent.json")
+        data = manage_instances.load_json_data(non_existent_file)
+        self.assertEqual(data, manage_instances.DEFAULT_DATA)
+
+
+    def test_load_json_data_empty_file(self):
+        empty_file = os.path.join(self.test_dir, "empty.json")
+        with open(empty_file, 'w') as f:
+            pass # Create an empty file
+        data = manage_instances.load_json_data(empty_file)
+        self.assertEqual(data, manage_instances.DEFAULT_DATA)
+
+
+    def test_load_json_data_missing_keys(self):
+        corrupt_data = {"instances": [{"name": "corrupt", "host": "ch", "cdmver": "cv"}]} # Missing index-to, query-from
+        corrupt_file = os.path.join(self.test_dir, "corrupt_missing_keys.json")
+        with open(corrupt_file, 'w') as f:
+            json.dump(corrupt_data, f)
+
+        loaded_data = manage_instances.load_json_data(corrupt_file)
+        self.assertIn("instances", loaded_data)
+        self.assertEqual(loaded_data["instances"], corrupt_data["instances"])
+        self.assertIsNone(loaded_data["index-to"]) # Should be initialized
+        self.assertEqual(loaded_data["query-from"], []) # Should be initialized
+
+    @patch('builtins.print') # Mock print to suppress output during test
+    @patch('sys.exit') # Mock sys.exit
+    def test_load_json_data_invalid_json(self, mock_exit, mock_print):
+        invalid_json_file = os.path.join(self.test_dir, "invalid.json")
+        with open(invalid_json_file, 'w') as f:
+            f.write("{not_json: ") # Invalid JSON content
+
+        manage_instances.load_json_data(invalid_json_file)
+        mock_exit.assert_called_once_with(1)
+
+
+    # --- Test save_json_data ---
+    def test_save_json_data(self):
+        data_to_save = {"instances": [{"name": "new", "host": "new_host", "cdmver": "new_v"}], "index-to": "new", "query-from": ["new"]}
+        manage_instances.save_json_data(self.test_file_path, data_to_save)
+        with open(self.test_file_path, 'r') as f:
+            saved_data = json.load(f)
+        self.assertEqual(saved_data, data_to_save)
+
+    # --- Test add_instance ---
+    def test_add_instance_new(self):
+        data = self.initial_data.copy()
+        result = manage_instances.add_instance(data, "test3", "host3", "v3")
+        self.assertTrue(result)
+        self.assertEqual(len(data["instances"]), 3)
+        self.assertEqual(data["instances"][-1]["name"], "test3")
+
+    def test_add_instance_with_userpass(self):
+        data = self.initial_data.copy()
+        result = manage_instances.add_instance(data, "test_up", "host_up", "v_up", userpass="secret")
+        self.assertTrue(result)
+        self.assertEqual(data["instances"][-1]["userpass"], "secret")
+
+    def test_add_instance_empty_userpass(self):
+        data = self.initial_data.copy()
+        result = manage_instances.add_instance(data, "test_empty_up", "host_empty_up", "v_empty_up", userpass="")
+        self.assertTrue(result)
+        self.assertIn("userpass", data["instances"][-1])
+        self.assertEqual(data["instances"][-1]["userpass"], "")
+
+    def test_add_instance_existing(self):
+        data = self.initial_data.copy()
+        result = manage_instances.add_instance(data, "test1", "host_new", "v_new")
+        self.assertFalse(result)
+        self.assertEqual(len(data["instances"]), 2)
+
+    def test_add_instance_set_index_to(self):
+        data = self.initial_data.copy()
+        manage_instances.add_instance(data, "test_idx", "host_idx", "v_idx", set_index_to=True)
+        self.assertEqual(data["index-to"], "test_idx")
+
+    def test_add_instance_add_to_query_from(self):
+        data = self.initial_data.copy()
+        manage_instances.add_instance(data, "test_qf", "host_qf", "v_qf", set_query_from=True)
+        self.assertIn("test_qf", data["query-from"])
+
+    def test_add_instance_add_to_query_from_already_exists(self):
+        data = self.initial_data.copy()
+        manage_instances.add_instance(data, "test1_new", "h", "v", set_query_from=True)
+        data["query-from"].append("test1")
+        manage_instances.add_instance(data, "test_qf_again", "h_qfa", "v_qfa", set_query_from=True)
+        self.assertIn("test_qf_again", data["query-from"])
+
+    # --- Test remove_instance ---
+    def test_remove_instance_existing(self):
+        data = self.initial_data.copy()
+        result = manage_instances.remove_instance(data, "test1")
+        self.assertTrue(result)
+        self.assertEqual(len(data["instances"]), 1)
+        self.assertNotIn("test1", [inst["name"] for inst in data["instances"]])
+        self.assertNotIn("test1", data["query-from"])
+        self.assertIsNone(data["index-to"])
+
+    def test_remove_instance_non_existing(self):
+        data = self.initial_data.copy()
+        result = manage_instances.remove_instance(data, "non_existent_instance")
+        self.assertFalse(result)
+        self.assertEqual(len(data["instances"]), 2)
+
+    def test_remove_instance_updates_query_from(self):
+        data = self.initial_data.copy()
+        manage_instances.remove_instance(data, "test2")
+        self.assertNotIn("test2", data["query-from"])
+
+    def test_remove_instance_updates_index_to_and_warns(self):
+        data = self.initial_data.copy()
+        data["index-to"] = "test2"
+        with patch('builtins.print') as mock_print:
+            manage_instances.remove_instance(data, "test2")
+            self.assertIsNone(data["index-to"])
+            mock_print.assert_any_call("'index-to' was 'test2', now set to None. Warning: No instance is currently configured for 'index-to'.")
+
+    # --- Test update_instance ---
+    def test_update_instance_existing_host_cdmver(self):
+        data = self.initial_data.copy()
+        result = manage_instances.update_instance(data, "test1", new_host="new_host1", new_cdmver="v1_new")
+        self.assertTrue(result)
+        self.assertEqual(data["instances"][0]["host"], "new_host1")
+        self.assertEqual(data["instances"][0]["cdmver"], "v1_new")
+
+    def test_update_instance_userpass(self):
+        data = self.initial_data.copy()
+        manage_instances.update_instance(data, "test1", new_userpass="pass1_new")
+        self.assertEqual(data["instances"][0]["userpass"], "pass1_new")
+        manage_instances.update_instance(data, "test2", new_userpass="pass2_updated")
+        self.assertEqual(data["instances"][1]["userpass"], "pass2_updated")
+
+    def test_update_instance_remove_userpass(self):
+        data = self.initial_data.copy()
+        self.assertIn("userpass", data["instances"][1])
+        manage_instances.update_instance(data, "test2", remove_userpass_flag=True)
+        self.assertNotIn("userpass", data["instances"][1])
+
+    def test_update_instance_remove_userpass_not_set(self):
+        data = self.initial_data.copy()
+        self.assertNotIn("userpass", data["instances"][0])
+        with patch('builtins.print') as mock_print:
+            result = manage_instances.update_instance(data, "test1", remove_userpass_flag=True)
+            self.assertFalse(result) # Expect False as no actual data change occurred
+            expected_print_msg = "Info: Instance 'test1' found, but no update parameters provided or no changes were applicable."
+            mock_print.assert_any_call(expected_print_msg)
+        self.assertNotIn("userpass", data["instances"][0])
+
+
+    def test_update_instance_set_index_to(self):
+        data = self.initial_data.copy()
+        manage_instances.update_instance(data, "test2", set_index_to=True)
+        self.assertEqual(data["index-to"], "test2")
+
+    def test_update_instance_add_to_query_from(self):
+        data = self.initial_data.copy()
+        data["query-from"] = ["test1"]
+        manage_instances.update_instance(data, "test2", add_to_query_from=True)
+        self.assertIn("test2", data["query-from"])
+
+    def test_update_instance_non_existing(self):
+        data = self.initial_data.copy()
+        result = manage_instances.update_instance(data, "non_existent_instance", new_host="dummy")
+        self.assertFalse(result)
+
+    def test_update_instance_no_changes_specified(self):
+        data = self.initial_data.copy()
+        with patch('builtins.print') as mock_print:
+            result = manage_instances.update_instance(data, "test1")
+            self.assertFalse(result)
+            mock_print.assert_any_call("Info: Instance 'test1' found, but no update parameters provided or no changes were applicable.")
+
+    # --- Test display_info ---
+    @patch('builtins.print')
+    def test_display_info(self, mock_print):
+        data = self.initial_data.copy()
+        manage_instances.display_info(self.test_file_path, data)
+        mock_print.assert_any_call(f"Current configuration from '{self.test_file_path}':")
+        args, _ = mock_print.call_args_list[1]
+        self.assertEqual(json.loads(args[0]), data)
+
+
+    # --- Test main function (basic argument parsing checks) ---
+    @patch('manage_instances.load_json_data')
+    @patch('manage_instances.add_instance')
+    @patch('manage_instances.save_json_data')
+    def test_main_add_action(self, mock_save, mock_add, mock_load):
+        mock_load.return_value = self.initial_data.copy()
+        mock_add.return_value = True
+        # Updated test_args for subcommand 'add'
+        test_args = ['manage_instances.py', '--cfg', self.test_file_path, 'add', '--name', 'new_inst', '--host', 'h', '--cdmver', 'cv']
+        with patch.object(sys, 'argv', test_args):
+            manage_instances.main()
+        mock_load.assert_called_once_with(self.test_file_path)
+        mock_add.assert_called_once_with(self.initial_data, 'new_inst', 'h', 'cv', None, False, False)
+        mock_save.assert_called_once()
+
+    @patch('manage_instances.load_json_data')
+    @patch('manage_instances.remove_instance')
+    @patch('manage_instances.save_json_data')
+    def test_main_remove_action(self, mock_save, mock_remove, mock_load):
+        mock_load.return_value = self.initial_data.copy()
+        mock_remove.return_value = True
+        # Updated test_args for subcommand 'remove'
+        test_args = ['manage_instances.py', '--cfg', self.test_file_path, 'remove', '--name', 'test1']
+        with patch.object(sys, 'argv', test_args):
+            manage_instances.main()
+        mock_remove.assert_called_once_with(self.initial_data, 'test1')
+        mock_save.assert_called_once()
+
+    @patch('manage_instances.load_json_data')
+    @patch('manage_instances.update_instance')
+    @patch('manage_instances.save_json_data')
+    def test_main_update_action(self, mock_save, mock_update, mock_load):
+        mock_load.return_value = self.initial_data.copy()
+        mock_update.return_value = True
+        # Updated test_args for subcommand 'update'
+        test_args = ['manage_instances.py', '--cfg', self.test_file_path, 'update', '--name', 'test1', '--host', 'new_h']
+        with patch.object(sys, 'argv', test_args):
+            manage_instances.main()
+        mock_update.assert_called_once_with(self.initial_data, 'test1', 'new_h', None, None, False, False, False, False)
+        mock_save.assert_called_once()
+
+    @patch('manage_instances.load_json_data')
+    @patch('manage_instances.display_info')
+    #@patch('sys.exit')
+    #def test_main_info_action(self, mock_sys_exit, mock_display, mock_load):
+    def test_main_info_action(self, mock_display, mock_load):
+        mock_load.return_value = self.initial_data.copy()
+        # Updated test_args for subcommand 'info'
+        test_args = ['manage_instances.py', '--cfg', self.test_file_path, 'info']
+        with patch.object(sys, 'argv', test_args):
+            manage_instances.main()
+        mock_display.assert_called_once_with(self.test_file_path, self.initial_data)
+        #mock_sys_exit.assert_called_once_with(0)
+
+    @patch('argparse.ArgumentParser.error')
+    def test_main_add_missing_args(self, mock_argparse_error):
+        mock_argparse_error.side_effect = SystemExit(2)
+        # Updated test_args for subcommand 'add' with missing args
+        test_args = ['manage_instances.py', '--cfg', self.test_file_path, 'add', '--name', 'only_name'] # Missing --host, --cdmver
+        with patch.object(sys, 'argv', test_args):
+            with self.assertRaises(SystemExit):
+                 manage_instances.main()
+        # Argparse error for missing required args in a subparser
+        mock_argparse_error.assert_called_once_with("the following arguments are required: --host, --cdmver")
+
+
+    @patch('argparse.ArgumentParser.error')
+    def test_main_update_missing_action_args(self, mock_argparse_error):
+        mock_argparse_error.side_effect = SystemExit(2)
+        # Updated test_args for subcommand 'update' with no action fields
+        test_args = ['manage_instances.py', '--cfg', self.test_file_path, 'update', '--name', 'test1']
+        with patch.object(sys, 'argv', test_args):
+            with self.assertRaises(SystemExit):
+                manage_instances.main()
+        # This specific error message comes from parser_update.error() in manage_instances.py
+        mock_argparse_error.assert_called_once_with("At least one update field (--host, --cdmver, --userpass, --remove-userpass, --index, --query) must be specified.")
+
+    @patch('argparse.ArgumentParser.error')
+    def test_main_missing_cfg_arg(self, mock_argparse_error):
+        mock_argparse_error.side_effect = SystemExit(2)
+        test_args = ['manage_instances.py', 'add', '--name', 'n', '--host', 'h', '--cdmver', 'v'] # Missing --cfg
+        with patch.object(sys, 'argv', test_args):
+            with self.assertRaises(SystemExit):
+                manage_instances.main()
+        # Argparse error for missing top-level required argument
+        mock_argparse_error.assert_called_once_with('the following arguments are required: --cfg')
+
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+


### PR DESCRIPTION
- Soon crucible wil be able to use multiple opensearch instances.  This code manages a json file to track those instances, much like 'crucible repo' and 'crucible registry' do.
- This commit does not yet enable multiple instance usage.  A different commit will do that, where before calling get-result-summary.js and get-metric-data.js a call to manage_instances will be made to find instances to query-from and get the correct query-option that is passed to get-metric-data/get-result-summary