### PR TITLE
updates for the releases ruleset

### DIFF
--- a/.github/rulesets/branches/releases.json
+++ b/.github/rulesets/branches/releases.json
@@ -9,7 +9,8 @@
     "ref_name": {
       "exclude": [],
       "include": [
-        "refs/heads/20[2-9][0-9]\\.[1234]"
+        "refs/heads/20[2-9][0-9]\\.[1234]",
+        "refs/heads/ci-version-test"
       ]
     }
   },
@@ -35,5 +36,11 @@
       "type": "deletion"
     }
   ],
-  "bypass_actors": []
+  "bypass_actors": [
+    {
+      "actor_id": 962037,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ]
 }


### PR DESCRIPTION
- allow the "bot" to bypass the rules which is necessary for some if it's action (ie. update)

- include the 'ci-version-test' branch

  - since the "bot" can bypass the rules there is no reason to exclude this branch