### PR TITLE
add HEAD as an acceptable primary-branch in the repos.json schema

### DIFF
--- a/schema/repos.json
+++ b/schema/repos.json
@@ -42,6 +42,7 @@
                     "primary-branch": {
                         "type": "string",
                         "enum": [
+                            "HEAD",
                             "main",
                             "master"
                         ]


### PR DESCRIPTION
- in the CI environment the config of the repository being tested deviates from the norm

- in order for 'crucible repo config *' commands to work in that environment the repos.json schema needs to support that deviation, otherwise validations will fail and the commands cannot complete