### PR TITLE
bugfix: the quay expiration length input validation in the installer …

### DIFF
--- a/crucible-install.sh
+++ b/crucible-install.sh
@@ -502,8 +502,8 @@ for dep in $DEPENDENCIES; do
 done
 
 if [ -n "${CRUCIBLE_ENGINE_QUAY_EXPIRATION_LENGTH}" ]; then
-    if ! echo "${CRUCIBLE_ENGINE_QUAY_EXPIRATION_LENGTH}" | grep -q "[1-9][0-9]*[wm]"; then
-        exit_error "Invalid syntax for engine Quay expiration length.  Expecting either '<integer>w' (for weeks) or '<integer>m' (for months)" ${EC_INVALID_QUAY_EXPIRATION_LENGTH}
+    if ! echo "${CRUCIBLE_ENGINE_QUAY_EXPIRATION_LENGTH}" | grep -q "^[1-9][0-9]*[wd]$"; then
+        exit_error "Invalid syntax for engine Quay expiration length.  Expecting either '<integer>w' (for weeks) or '<integer>d' (for days)" ${EC_INVALID_QUAY_EXPIRATION_LENGTH}
     fi
 fi
 


### PR DESCRIPTION
…script is incorrect

- it should match what is in the registries.json schema which is the acceptance of an integer value followed by either a 'w' (for weeks) or a 'd' (for days).  For example:

  - 14d

  - 2w