### PR TITLE
change the end of the update process to be explicit when errors have …

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -203,4 +203,8 @@ ${CRUCIBLE_HOME}/bin/repo info
 echo
 ${CRUCIBLE_HOME}/bin/repo config show
 
+if [ ${RC} != 0 ]; then
+    echo
+    echo "WARNING: An error occured.  Please review the log for details."
+fi
 exit ${RC}


### PR DESCRIPTION
…occurred

- if errors occurr during the update process it is possible that they are very far up the log and not easily seen so make it obvious to the user that something happened that should be looked into

- previously the user would have had to explicitly check the return code which is probably rarely done to know that something broke