### PR TITLE
bugfix: call manage_instances.py inside a podman pod

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -95,7 +95,14 @@ elif [ "${1}" == "get" ]; then
             EXIT_VAL=$?
         elif [ "${1}" == "metric" ]; then
             shift
-            cdm_query_opt=$(${CRUCIBLE_HOME}/bin/manage_instances.py --cfg ${INSTANCES_CFG} query-opt)
+            cdm_query_opt=$(${podman_run}\
+                --name crucible-manage-instances--${SESSION_ID}\
+                ${container_common_args[@]}\
+                ${container_non_service_args[@]}\
+                ${CRUCIBLE_CONTROLLER_IMAGE}\
+                ${CRUCIBLE_HOME}/bin/manage_instances.py\
+                --cfg ${INSTANCES_CFG}\
+                query-opt)
             cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-metric-data.sh $@ $cdm_query_opt"
             ${podman_run} --name crucible-get-metric-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_query_cmd}
             EXIT_VAL=$?


### PR DESCRIPTION
- if the controller's default python3 doesn't provide all the features that manage_instances.py expects it will break

- by using the controller's image and a podman pod we can ensure that the python3 version being used provides all the necessary features