### PR TITLE
update the branch rulesets to make review dismissal required

### DIFF
--- a/.github/rulesets/branches/default-branch-required.json
+++ b/.github/rulesets/branches/default-branch-required.json
@@ -45,7 +45,7 @@
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
+        "dismiss_stale_reviews_on_push": true,
         "required_reviewers": [],
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/.github/rulesets/branches/releases-bypassable.json
+++ b/.github/rulesets/branches/releases-bypassable.json
@@ -19,7 +19,7 @@
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 1,
-        "dismiss_stale_reviews_on_push": true,
+        "dismiss_stale_reviews_on_push": false,
         "required_reviewers": [],
         "require_code_owner_review": false,
         "require_last_push_approval": false,

--- a/.github/rulesets/branches/releases-required.json
+++ b/.github/rulesets/branches/releases-required.json
@@ -22,7 +22,7 @@
       "type": "pull_request",
       "parameters": {
         "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
+        "dismiss_stale_reviews_on_push": true,
         "required_reviewers": [],
         "require_code_owner_review": false,
         "require_last_push_approval": false,


### PR DESCRIPTION
- IF a review is submitted for a PR then it must be dismissed if/when the PR is updated and it becomes stale; this requirement cannot be bypassed by anyone