### PR TITLE
Add CDM server as companion service to OpenSearch

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -331,6 +331,13 @@ function start_opensearch() {
             else
                 echo "Successfully started OpenSearch"
                 RC=0
+                # Start the CDM server companion service
+                start_cdm_server
+                local CDM_RC=$?
+                if [ ${CDM_RC} != 0 ]; then
+                    echo "WARNING: OpenSearch started but CDM server failed to start"
+                    RC=${CDM_RC}
+                fi
             fi
         fi
     fi
@@ -339,16 +346,63 @@ function start_opensearch() {
 
 function stop_opensearch() {
     local RC=0
+
+    # Stop the CDM server first
+    stop_cdm_server
+    local CDM_RC=$?
+    if [ ${CDM_RC} != 0 ]; then
+        RC=${CDM_RC}
+    fi
+
     echo -n "Checking for OpenSearch"
     if podman_running crucible-opensearch; then
         close_firewall_port 9200 tcp
         close_firewall_port 9300 tcp
         ${podman_stop} crucible-opensearch > /dev/null
-        RC=$?
-        if [ ${RC} != 0 ]; then
+        local OS_RC=$?
+        if [ ${OS_RC} != 0 ]; then
             echo "ERROR: Could not stop OpenSearch"
+            RC=${OS_RC}
         else
             echo "Successfully stopped OpenSearch"
+        fi
+    fi
+    return ${RC}
+}
+
+function start_cdm_server() {
+    local RC cdm_server_cmd cdm_query_opt
+
+    echo -n "Checking for CDM server"
+    if ! podman_running crucible-cdm-server; then
+        # Get the OpenSearch connection options (--host, --userpass, --ver)
+        cdm_query_opt=$(run_manage_instances query-opt)
+        cdm_server_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/start-server.sh ${cdm_query_opt}"
+
+        open_firewall_port 3000 tcp
+        ${podman_run} --name crucible-cdm-server "${container_common_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_server_cmd} > /dev/null
+        RC=$?
+        if [ ${RC} != 0 ]; then
+            echo "ERROR: Could not start CDM server"
+        else
+            echo "Successfully started CDM server"
+        fi
+    fi
+    return ${RC}
+}
+
+function stop_cdm_server() {
+    local RC=0
+
+    echo -n "Checking for CDM server"
+    if podman_running crucible-cdm-server; then
+        close_firewall_port 3000 tcp
+        ${podman_stop} crucible-cdm-server > /dev/null
+        RC=$?
+        if [ ${RC} != 0 ]; then
+            echo "ERROR: Could not stop CDM server"
+        else
+            echo "Successfully stopped CDM server"
         fi
     fi
     return ${RC}
@@ -796,6 +850,10 @@ function service_control() {
         case "${service}" in
             "httpd"|"opensearch"|"valkey")
                 ${action}_${service}
+                service_rc=$?
+                ;;
+            "cdm-server")
+                ${action}_cdm_server
                 service_rc=$?
                 ;;
             *)

--- a/bin/base
+++ b/bin/base
@@ -380,7 +380,7 @@ function start_cdm_server() {
         cdm_server_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/start-server.sh ${cdm_query_opt}"
 
         open_firewall_port 3000 tcp
-        ${podman_run} --name crucible-cdm-server "${container_common_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_server_cmd} > /dev/null
+        ${podman_run} --name crucible-cdm-server "${container_common_args[@]}" "${container_cdm_server_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_server_cmd} > /dev/null
         RC=$?
         if [ ${RC} != 0 ]; then
             echo "ERROR: Could not start CDM server"
@@ -1037,6 +1037,7 @@ container_common_args+=("--net=host")
 container_common_args+=("--security-opt=label=disable")
 
 container_service_args=()
+container_service_args+=("-d")
 container_service_args+=("--log-driver=journald")
 
 container_non_service_args=()
@@ -1047,16 +1048,15 @@ container_log_args+=("--mount=type=bind,source=${USER_STORE},destination=${USER_
 container_log_args+=("--mount=type=bind,source=/tmp,destination=/tmp")
 
 container_valkey_args=()
-container_valkey_args+=("-d")
 container_valkey_args+=("--mount=type=bind,source=$CRUCIBLE_HOME/config/valkey.conf,destination=/etc/valkey/valkey.conf")
 
 container_httpd_args=()
-container_httpd_args+=("-d")
 container_httpd_args+=("--mount=type=bind,source=$CRUCIBLE_HOME/config/httpd/,destination=/etc/httpd/")
 
 container_opensearch_args=()
-container_opensearch_args+=("-d")
 container_opensearch_args+=("--mount=type=bind,source=${opensearch_dir}/,destination=/usr/share/opensearch/data/")
+
+container_cdm_server_args=()
 
 container_build_args=()
 container_build_args+=("--mount=type=bind,source=/var/lib/containers,destination=/var/lib/containers")


### PR DESCRIPTION
## Summary
Implement automatic startup and management of the CommonDataModel REST API server whenever OpenSearch is started. This provides a persistent HTTP endpoint for querying metric data.

## Changes
- Add `start_cdm_server()` and `stop_cdm_server()` functions to `bin/base`
- Integrate CDM server into OpenSearch lifecycle (starts after OpenSearch, stops before OpenSearch)
- Add support for `crucible start/stop cdm-server` commands via `service_control()`
- Use same OpenSearch connection options as metric queries (via `run_manage_instances query-opt`)
- Server runs on port 3000 with automatic firewall configuration

## Implementation Details

### Service Integration
The CDM server automatically:
- Starts after OpenSearch successfully launches
- Stops before OpenSearch is shut down
- Can be controlled independently via `crucible start/stop cdm-server`

### Container Configuration
- Container name: `crucible-cdm-server`
- Runs in detached mode with journald logging (same as other services)
- Opens/closes firewall port 3000
- Uses same container mounts and args as other crucible services

### Dependency
Requires the `start-server.sh` wrapper script added to CommonDataModel in PR #151 (now merged to master).

## Related PRs
- perftool-incubator/CommonDataModel#151 - Add REST API server wrapper script (merged)

## Test Plan
1. Start OpenSearch: `crucible start opensearch`
   - Verify both OpenSearch and CDM server containers are running
   - Verify port 3000 is open
2. Test CDM server health: `curl http://localhost:3000/health`
3. Stop OpenSearch: `crucible stop opensearch`
   - Verify both containers are stopped
   - Verify port 3000 is closed
4. Test independent control: `crucible start/stop cdm-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)