### PR TITLE
feat: add crucible userenvs command

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -16,11 +16,11 @@ _crucible_completions() {
     num_words=${#COMP_WORDS[@]} # Total number of words on the command
     let num_index=$num_words-1
     if [ $num_words -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo update run wrapper console start stop get rm index postprocess opensearch extract ls tags archive unarchive reset instances" -- "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "help log repo userenvs update run wrapper console start stop get rm index postprocess opensearch extract ls tags archive unarchive reset instances" -- "${COMP_WORDS[1]}"))
     elif [ $num_words -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)
-                COMPREPLY=($(compgen -W "log repo update run" -- "${COMP_WORDS[2]}"))
+                COMPREPLY=($(compgen -W "log repo userenvs update run" -- "${COMP_WORDS[2]}"))
                 ;;
             log)
                 COMPREPLY=($(compgen -W "clear info init tidy view" -- "${COMP_WORDS[2]}"))
@@ -30,6 +30,9 @@ _crucible_completions() {
                 ;;
             repo)
                 COMPREPLY=($(compgen -W "info details config" -- "${COMP_WORDS[2]}"))
+                ;;
+            userenvs)
+                COMPREPLY=($(compgen -W "list help" -- "${COMP_WORDS[2]}"))
                 ;;
             update)
                 COMPREPLY=($(compgen -W "all crucible $(cd $CRUCIBLE_HOME/subprojects/; find . -type l | sed 'sX./XX')" -- "${COMP_WORDS[2]}"))
@@ -104,6 +107,8 @@ _crucible_completions() {
                 COMPREPLY=($(compgen -W "add help remove show update" -- "${COMP_WORDS[3]}"))
                 ;;
         esac
+    elif [ ${COMP_WORDS[1]} == "userenvs" -a "${COMP_WORDS[2]}" == "list" ]; then
+        COMPREPLY=($(compgen -W "--official --external --deprecated" -- "${COMP_WORDS[$num_index]}"))
     elif [ "$(expr $num_words % 2)" -eq 0 -a ${COMP_WORDS[1]} == "rm" ]; then
         case "${COMP_WORDS[2]}" in
             --run)

--- a/bin/_help
+++ b/bin/_help
@@ -13,6 +13,7 @@ function help() {
     echo "log                           |  Manage with the crucible log"
     echo "registries                    |  Get info on or configure the container image registries"
     echo "repo                          |  Get info on or configure the crucible and subproject git repos"
+    echo "userenvs                      |  List available userenvs (official, external, deprecated)"
     echo "update                        |  Update all or part of the crucible software"
     echo "console                       |  Run user supplied programs inside a crucible wrapper for logging purposes"
     echo "wrapper                       |  Run a crucible subproject command directly, within a crucible container"
@@ -66,6 +67,8 @@ function help() {
         ${CRUCIBLE_HOME}/bin/log help
     elif [ "${1}" == "repo" ]; then
         ${CRUCIBLE_HOME}/bin/repo help
+    elif [ "${1}" == "userenvs" ]; then
+        ${CRUCIBLE_HOME}/bin/userenvs help
     elif [ "${1}" == "update" ]; then
         ${CRUCIBLE_HOME}/bin/update help
     elif [ "${1}" == "run" ]; then

--- a/bin/_main
+++ b/bin/_main
@@ -58,6 +58,15 @@ elif [ "${1}" == "registries" ]; then
         ${CRUCIBLE_HOME}/bin/registries "$@"
         EXIT_VAL=$?
     fi
+elif [ "${1}" == "userenvs" ]; then
+    shift
+    if [ -z "${1}" ]; then
+        ${CRUCIBLE_HOME}/bin/userenvs list
+        EXIT_VAL=$?
+    else
+        ${CRUCIBLE_HOME}/bin/userenvs "$@"
+        EXIT_VAL=$?
+    fi
 elif [ "${1}" == "repo" ]; then
     shift
     if [ -z "${1}" ]; then

--- a/bin/userenvs
+++ b/bin/userenvs
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+
+source /etc/sysconfig/crucible
+
+if [ ! -e "${CRUCIBLE_HOME}" ]; then
+    echo "Could not find $CRUCIBLE_HOME, exiting."
+    exit 1
+fi
+
+source "${CRUCIBLE_HOME}/bin/base"
+
+OFFICIAL_USERENVS_DIR="${CRUCIBLE_HOME}/subprojects/core/rickshaw/userenvs"
+EXTERNAL_USERENVS_DIR="${CRUCIBLE_HOME}/subprojects/userenvs"
+CI_EXCLUDES_FILE="${OFFICIAL_USERENVS_DIR}/ci-excludes.txt"
+
+# directories in the official userenvs dir that are not userenvs
+NON_USERENV_DIRS="components requirement-sources"
+
+function help() {
+    echo "Usage:"
+    echo "  userenvs <command> [options]"
+    echo ""
+    echo "The following commands are supported"
+    echo ""
+    echo "list                     |  List available userenvs (default)"
+    echo "  --official             |  Only show official userenvs (from rickshaw)"
+    echo "  --external             |  Only show external userenvs (from userenv repos)"
+    echo "  --deprecated           |  Show only deprecated userenvs (no longer supported)"
+    echo ""
+}
+
+function load_ci_excludes() {
+    local excludes=()
+    if [ -f "${CI_EXCLUDES_FILE}" ]; then
+        while IFS= read -r line; do
+            [ -n "${line}" ] && excludes+=("${line}")
+        done < "${CI_EXCLUDES_FILE}"
+    fi
+    echo "${excludes[@]}"
+}
+
+function is_ci_excluded() {
+    local name="${1}"
+    local exclude
+    for exclude in ${ci_excludes}; do
+        if [ "${name}" == "${exclude}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function is_non_userenv_dir() {
+    local name="${1}"
+    local dir
+    for dir in ${NON_USERENV_DIRS}; do
+        if [ "${name}" == "${dir}" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function list_official() {
+    # collect all entries first to compute column widths
+    local names=()
+    local labels=()
+    local pull_tokens=()
+    local notes_list=()
+    local max_name=4  # "Name"
+    local max_label=5  # "Label"
+    local max_pull=10  # "Pull Token"
+
+    for f in "${OFFICIAL_USERENVS_DIR}"/*.json; do
+        [ -f "${f}" ] || continue
+        local name=$(basename "${f}" .json)
+        local notes=""
+
+        if [ -L "${f}" ]; then
+            local target=$(readlink "${f}" | sed 's/\.json$//')
+            notes="alias -> ${target}"
+        fi
+
+        if is_ci_excluded "${name}"; then
+            notes="${notes}${notes:+, }not CI tested"
+        fi
+
+        local label=$(jq -r '.userenv.label // "—"' "${f}" 2>/dev/null)
+        local pull_token=$(jq -r '.userenv.origin."requires-pull-token" // "false"' "${f}" 2>/dev/null)
+        if [ "${pull_token}" == "true" ]; then
+            pull_token="yes"
+        else
+            pull_token="no"
+        fi
+
+        names+=("${name}")
+        labels+=("${label}")
+        pull_tokens+=("${pull_token}")
+        notes_list+=("${notes}")
+        [ ${#name} -gt ${max_name} ] && max_name=${#name}
+        [ ${#label} -gt ${max_label} ] && max_label=${#label}
+    done
+
+    local fmt="  %-${max_name}s  %-${max_label}s  %-${max_pull}s  %s\n"
+
+    echo "Official userenvs (from rickshaw):"
+    echo ""
+    printf "${fmt}" "Name" "Label" "Pull Token" "Notes"
+    printf "  %s  %s  %s  %s\n" "$(printf '%*s' ${max_name} '' | tr ' ' '-')" "$(printf '%*s' ${max_label} '' | tr ' ' '-')" "$(printf '%*s' ${max_pull} '' | tr ' ' '-')" "-----"
+
+    for i in "${!names[@]}"; do
+        printf "${fmt}" "${names[$i]}" "${labels[$i]}" "${pull_tokens[$i]}" "${notes_list[$i]}"
+    done
+
+    echo ""
+}
+
+function list_deprecated() {
+    local names=()
+    local max_name=4
+
+    for d in "${OFFICIAL_USERENVS_DIR}"/*/; do
+        [ -d "${d}" ] || continue
+        local name=$(basename "${d}")
+        is_non_userenv_dir "${name}" && continue
+        if [ ! -f "${OFFICIAL_USERENVS_DIR}/${name}.json" ]; then
+            names+=("${name}")
+            [ ${#name} -gt ${max_name} ] && max_name=${#name}
+        fi
+    done
+
+    if [ ${#names[@]} -eq 0 ]; then
+        echo "No deprecated userenvs found"
+        echo ""
+        return
+    fi
+
+    local fmt="  %-${max_name}s\n"
+
+    echo "Deprecated userenvs (no longer supported):"
+    echo ""
+    printf "${fmt}" "Name"
+    printf "  %s\n" "$(printf '%*s' ${max_name} '' | tr ' ' '-')"
+
+    for name in "${names[@]}"; do
+        printf "${fmt}" "${name}"
+    done
+
+    echo ""
+}
+
+function list_external() {
+    echo "External userenvs:"
+    echo ""
+
+    if [ ! -d "${EXTERNAL_USERENVS_DIR}" ]; then
+        echo "  No external userenvs directory found"
+        echo ""
+        return
+    fi
+
+    local names=()
+    local labels=()
+    local pull_tokens=()
+    local sources=()
+    local max_name=4
+    local max_label=5
+    local max_pull=10  # "Pull Token"
+
+    for repo_dir in "${EXTERNAL_USERENVS_DIR}"/*/; do
+        [ -d "${repo_dir}" ] || continue
+        local repo_name=$(basename "${repo_dir}")
+        for f in "${repo_dir}"/*.json; do
+            [ -f "${f}" ] || continue
+            local name=$(basename "${f}" .json)
+            local label=$(jq -r '.userenv.label // "—"' "${f}" 2>/dev/null)
+            local pull_token=$(jq -r '.userenv.origin."requires-pull-token" // "false"' "${f}" 2>/dev/null)
+            if [ "${pull_token}" == "true" ]; then
+                pull_token="yes"
+            else
+                pull_token="no"
+            fi
+            names+=("${name}")
+            labels+=("${label}")
+            pull_tokens+=("${pull_token}")
+            sources+=("${repo_name}")
+            [ ${#name} -gt ${max_name} ] && max_name=${#name}
+            [ ${#label} -gt ${max_label} ] && max_label=${#label}
+        done
+    done
+
+    if [ ${#names[@]} -eq 0 ]; then
+        echo "  No external userenvs found"
+        echo ""
+        return
+    fi
+
+    local fmt="  %-${max_name}s  %-${max_label}s  %-${max_pull}s  %s\n"
+    printf "${fmt}" "Name" "Label" "Pull Token" "Source"
+    printf "  %s  %s  %s  %s\n" "$(printf '%*s' ${max_name} '' | tr ' ' '-')" "$(printf '%*s' ${max_label} '' | tr ' ' '-')" "$(printf '%*s' ${max_pull} '' | tr ' ' '-')" "------"
+
+    for i in "${!names[@]}"; do
+        printf "${fmt}" "${names[$i]}" "${labels[$i]}" "${pull_tokens[$i]}" "${sources[$i]}"
+    done
+
+    echo ""
+}
+
+# parse arguments
+cmd="${1:-list}"
+shift 2>/dev/null
+
+show_official=0
+show_external=0
+show_deprecated=0
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+        --official)
+            show_official=1
+            shift
+            ;;
+        --external)
+            show_external=1
+            shift
+            ;;
+        --deprecated)
+            show_deprecated=1
+            shift
+            ;;
+        --help|-h)
+            help
+            exit 0
+            ;;
+        *)
+            echo "ERROR: Unknown option: ${1}"
+            help
+            exit 1
+            ;;
+    esac
+done
+
+# if neither --official, --external, nor --deprecated specified, show official + external
+if [ ${show_official} -eq 0 ] && [ ${show_external} -eq 0 ] && [ ${show_deprecated} -eq 0 ]; then
+    show_official=1
+    show_external=1
+fi
+
+ci_excludes=$(load_ci_excludes)
+
+case "${cmd}" in
+    list)
+        if [ ${show_official} -eq 1 ]; then
+            list_official
+        fi
+        if [ ${show_external} -eq 1 ]; then
+            list_external
+        fi
+        if [ ${show_deprecated} -eq 1 ]; then
+            list_deprecated
+        fi
+        ;;
+    help)
+        help
+        ;;
+    *)
+        echo "ERROR: Unknown command: ${cmd}"
+        help
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add `crucible userenvs` command to list available user environments (issue #476)
- Supports `--official`, `--external`, and `--deprecated` flags to filter output
- Formatted table with Name, Label, Pull Token, and Notes columns
- Symlink aliases shown with target, CI-excluded userenvs annotated, pull token requirement indicated
- Tab completion for command, subcommands, and flags

## Example output
```
Official userenvs (from rickshaw):

  Name                                        Label                                       Pull Token  Notes
  ------------------------------------------  ------------------------------------------  ----------  -----
  alma10                                      AlmaLinux 10                                no
  alma-latest                                 AlmaLinux 10                                no          alias -> alma10
  rhel-ai-ilab-nvidia-official-1.3.1          RHEL AI Instructlab Official 1.3.1          yes         not CI tested
  ...
```

## Test plan
- [x] `crucible userenvs list` — shows official + external
- [x] `crucible userenvs list --official` — only official
- [x] `crucible userenvs list --external` — only external
- [x] `crucible userenvs list --deprecated` — only deprecated
- [x] `crucible userenvs help` — shows usage
- [ ] CI passes

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)