### PR TITLE
docs: update default-branch-required ruleset backup

### DIFF
--- a/.github/rulesets/branches/default-branch-required.json
+++ b/.github/rulesets/branches/default-branch-required.json
@@ -33,6 +33,10 @@
           {
             "context": "ci-complete",
             "integration_id": 15368
+          },
+          {
+            "context": "crucible-ci-complete",
+            "integration_id": 15368
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Update the backup of the `default-branch-required` ruleset to reflect the addition of `crucible-ci-complete` as a required status check

## Test plan
- [ ] Verify backup matches current ruleset configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)