### PR TITLE
fix: add git safe.directory and improve error messages in controller-image.py

### DIFF
--- a/workshop/controller-image.py
+++ b/workshop/controller-image.py
@@ -116,6 +116,10 @@ def compute_hashes(crucible_home, repos):
     """
     repo_hashes = []
 
+    # Ensure git trusts all subproject directories (needed when running
+    # as root inside a container with repos owned by a different user)
+    run("git config --global --add safe.directory '*'", hide=True, warn=True)
+
     for name, rel_path in repos:
         repo_path = Path(crucible_home) / rel_path
         if not repo_path.is_dir():
@@ -124,7 +128,9 @@ def compute_hashes(crucible_home, repos):
 
         result = run(f"git -C {repo_path} rev-parse HEAD", hide=True, warn=True)
         if result.exited != 0:
-            print(f"ERROR: Could not get commit hash for '{name}'", file=sys.stderr)
+            print(f"ERROR: Could not get commit hash for '{name}' at '{repo_path}'", file=sys.stderr)
+            if result.stderr:
+                print(f"  git error: {result.stderr.strip()}", file=sys.stderr)
             sys.exit(1)
 
         commit_hash = result.stdout.strip()


### PR DESCRIPTION
## Summary
- Add `git config --global --add safe.directory '*'` before computing repo hashes to handle ownership mismatch when running as root inside `crucible wrapper` with repos owned by the CI runner user
- Include repo path and git stderr in error messages for better diagnostics

Fixes the `Could not get commit hash for 'rickshaw'` error seen in crucible-ci#214.

## Test plan
- [ ] CI passes
- [ ] crucible-ci#214 can be retried after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)