### PR TITLE
feat: add automated controller image build and publish workflow

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -1,0 +1,162 @@
+name: build-publish-controller
+
+on:
+  workflow_call:
+    inputs:
+      ci_target:
+        description: "Which subproject triggered the build"
+        required: true
+        type: string
+      manifest_tag:
+        description: "Tag for the multi-arch manifest (default: auto-generated)"
+        required: false
+        type: string
+        default: ""
+  workflow_dispatch:
+    inputs:
+      ci_target:
+        description: "Which subproject triggered the build"
+        required: true
+        type: string
+      manifest_tag:
+        description: "Tag for the multi-arch manifest (default: auto-generated)"
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: build-publish-controller
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: x86_64
+            runner_arch: X64
+          - arch: aarch64
+            runner_arch: ARM64
+    runs-on: [self-hosted, aws-cloud-2, "${{ matrix.runner_arch }}"]
+    timeout-minutes: 120
+    steps:
+      - name: Install crucible
+        run: |
+          if [ -d /opt/crucible ]; then
+            sudo rm -rf /opt/crucible
+          fi
+          curl -L https://raw.githubusercontent.com/perftool-incubator/crucible/master/crucible-install.sh -o crucible-install.sh
+          chmod +x crucible-install.sh
+          sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --verbose
+
+      - name: Login to quay.io
+        run: |
+          echo '${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}' > /tmp/quay-auth.json
+          sudo podman login --authfile /tmp/quay-auth.json quay.io
+
+      - name: Build controller image
+        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py build
+
+      - name: Push controller image
+        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py push
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/quay-auth.json
+
+  create-manifest:
+    needs: build-push
+    runs-on: [self-hosted, aws-cloud-2, X64]
+    timeout-minutes: 30
+    steps:
+      - name: Install crucible
+        run: |
+          if [ -d /opt/crucible ]; then
+            sudo rm -rf /opt/crucible
+          fi
+          curl -L https://raw.githubusercontent.com/perftool-incubator/crucible/master/crucible-install.sh -o crucible-install.sh
+          chmod +x crucible-install.sh
+          sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --verbose
+
+      - name: Login to quay.io
+        run: |
+          echo '${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}' > /tmp/quay-auth.json
+          sudo podman login --authfile /tmp/quay-auth.json quay.io
+
+      - name: Determine manifest tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.manifest_tag }}" ]; then
+            echo "tag=${{ inputs.manifest_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=$(date -u +%Y-%m-%d_%H%M%S)_${{ inputs.ci_target }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push manifest
+        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py manifest ${{ steps.tag.outputs.tag }}
+
+      - name: Cleanup
+        if: always()
+        run: rm -f /tmp/quay-auth.json
+
+    outputs:
+      manifest_tag: ${{ steps.tag.outputs.tag }}
+
+  update-tags:
+    needs: create-manifest
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      QUAY_TOKEN: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
+      REPO: crucible/controller
+    steps:
+      - name: Get current latest digest
+        id: current
+        run: |
+          digest=$(curl -s -H "Authorization: Bearer ${QUAY_TOKEN}" \
+            "https://quay.io/api/v1/repository/${REPO}/tag/?specificTag=latest" \
+            | jq -r '.tags[0].manifest_digest // empty')
+          echo "digest=${digest}" >> $GITHUB_OUTPUT
+          if [ -n "${digest}" ]; then
+            echo "Current 'latest' digest: ${digest}"
+          else
+            echo "No existing 'latest' tag found"
+          fi
+
+      - name: Move previous tag to current latest
+        if: steps.current.outputs.digest != ''
+        run: |
+          curl -s -X PUT \
+            -H "Authorization: Bearer ${QUAY_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"manifest_digest": "${{ steps.current.outputs.digest }}"}' \
+            "https://quay.io/api/v1/repository/${REPO}/tag/previous"
+          echo "Moved 'previous' to digest: ${{ steps.current.outputs.digest }}"
+
+      - name: Get new manifest digest
+        id: new
+        run: |
+          digest=$(curl -s -H "Authorization: Bearer ${QUAY_TOKEN}" \
+            "https://quay.io/api/v1/repository/${REPO}/tag/?specificTag=${{ needs.create-manifest.outputs.manifest_tag }}" \
+            | jq -r '.tags[0].manifest_digest')
+          echo "digest=${digest}" >> $GITHUB_OUTPUT
+          echo "New manifest digest: ${digest}"
+
+      - name: Move latest tag to new manifest
+        run: |
+          curl -s -X PUT \
+            -H "Authorization: Bearer ${QUAY_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"manifest_digest": "${{ steps.new.outputs.digest }}"}' \
+            "https://quay.io/api/v1/repository/${REPO}/tag/latest"
+          echo "Moved 'latest' to digest: ${{ steps.new.outputs.digest }}"
+
+      - name: Summary
+        run: |
+          echo "## Controller Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Manifest tag:** ${{ needs.create-manifest.outputs.manifest_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by:** ${{ inputs.ci_target }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous digest:** ${{ steps.current.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **New digest:** ${{ steps.new.outputs.digest }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,10 +32,10 @@ jobs:
             .github/workflows/crucible-release.yaml
             .github/workflows/crucible-ci.yaml
             .github/workflows/ci.yaml
+            .github/workflows/controller-build.yaml
+            .github/workflows/build-publish-controller.yaml
             docs/**
             spec/**
-            workshop/create-manifest.sh
-            workshop/push-controller.sh
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 

--- a/.github/workflows/controller-build.yaml
+++ b/.github/workflows/controller-build.yaml
@@ -1,0 +1,21 @@
+name: controller-build
+
+on:
+  pull_request_target:
+    types: [ closed ]
+    branches: [ master ]
+    paths:
+      - workshop/crucible-controller-requirements.json
+      - workshop/crucible-controller-userenv.json
+      - workshop/controller-image.py
+      - workshop/controller.json
+      - .github/workflows/controller-build.yaml
+  workflow_dispatch:
+
+jobs:
+  call-build-publish-controller:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    uses: ./.github/workflows/build-publish-controller.yaml
+    with:
+      ci_target: "crucible"
+    secrets: inherit

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -32,10 +32,10 @@ jobs:
             .github/workflows/crucible-release.yaml
             .github/workflows/crucible-ci.yaml
             .github/workflows/ci.yaml
+            .github/workflows/controller-build.yaml
+            .github/workflows/build-publish-controller.yaml
             docs/**
             spec/**
-            workshop/create-manifest.sh
-            workshop/push-controller.sh
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 

--- a/.github/workflows/crucible-release-ci.yaml
+++ b/.github/workflows/crucible-release-ci.yaml
@@ -31,10 +31,10 @@ jobs:
             .github/workflows/crucible-release-ci.yaml
             .github/workflows/crucible-ci.yaml
             .github/workflows/ci.yaml
+            .github/workflows/controller-build.yaml
+            .github/workflows/build-publish-controller.yaml
             docs/**
             spec/**
-            workshop/create-manifest.sh
-            workshop/push-controller.sh
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 


### PR DESCRIPTION
## Summary
- Add `build-publish-controller.yaml` reusable workflow automating the full controller image lifecycle:
  - Build on x86_64 and aarch64 (matrix strategy, aws-cloud-2 runners)
  - Push architecture-specific images to quay.io with composite hash tags
  - Create and push multi-arch manifest
  - Update `latest`/`previous` tags via quay.io API
- Add `controller-build.yaml` caller workflow triggered on merge of PRs that modify controller-affecting files
- Update CI workflow exclusion lists to skip heavy CI for controller-build workflow changes
- Clean up stale references to deleted scripts (push-controller.sh, create-manifest.sh)

## How it works
Subprojects call the reusable workflow from their own `controller-build.yaml` (to be added in follow-up PRs). The workflow uses `secrets: inherit` for registry credentials. A concurrency group ensures only one controller build runs at a time.

## Test plan
- [ ] CI passes (should skip heavy CI since only workflow files changed)
- [ ] Manual workflow_dispatch test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)