### PR TITLE
fix: set fail-fast to false and add --engine-registry to build-publish-controller

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   build-push:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - arch: x86_64
@@ -48,7 +48,7 @@ jobs:
           fi
           curl -L https://raw.githubusercontent.com/perftool-incubator/crucible/master/crucible-install.sh -o crucible-install.sh
           chmod +x crucible-install.sh
-          sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --verbose
+          sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --engine-registry quay.io/crucible/client-server --verbose
 
       - name: Login to quay.io
         run: |
@@ -77,7 +77,7 @@ jobs:
           fi
           curl -L https://raw.githubusercontent.com/perftool-incubator/crucible/master/crucible-install.sh -o crucible-install.sh
           chmod +x crucible-install.sh
-          sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --verbose
+          sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --engine-registry quay.io/crucible/client-server --verbose
 
       - name: Login to quay.io
         run: |


### PR DESCRIPTION
## Summary
- Set `fail-fast: false` so both architecture builds continue independently
- Add `--engine-registry` to crucible installer command (required argument even though engine images aren't used for controller builds)

These fixes were intended for #547 but the PR was merged before the fix commit was pushed.

## Test plan
- [ ] CI passes (should skip heavy CI — only workflow file changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)