### PR TITLE
fix: move concurrency to caller and fix registry auth

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -24,10 +24,6 @@ on:
         type: string
         default: ""
 
-concurrency:
-  group: build-publish-controller
-  cancel-in-progress: true
-
 jobs:
   build-push:
     strategy:

--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -50,7 +50,7 @@ jobs:
         env:
           REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}
         run: |
-          sudo -E bash -c 'printenv REGISTRY_AUTH > /root/quay-auth.json'
+          sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
           sudo podman login --authfile /root/quay-auth.json quay.io
 
       - name: Build controller image
@@ -81,7 +81,7 @@ jobs:
         env:
           REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}
         run: |
-          sudo -E bash -c 'printenv REGISTRY_AUTH > /root/quay-auth.json'
+          sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
           sudo podman login --authfile /root/quay-auth.json quay.io
 
       - name: Determine manifest tag

--- a/.github/workflows/controller-build.yaml
+++ b/.github/workflows/controller-build.yaml
@@ -12,6 +12,10 @@ on:
       - .github/workflows/controller-build.yaml
   workflow_dispatch:
 
+concurrency:
+  group: build-publish-controller
+  cancel-in-progress: true
+
 jobs:
   call-build-publish-controller:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
Two fixes for the build-publish-controller workflow:

1. **Move concurrency group to caller** — the concurrency group on the reusable workflow interferes with matrix job execution (x86_64 and aarch64 serialized against each other). Moved to the caller workflow.

2. **Use sudo bash echo pattern for registry auth** — the secrets are stored with escaped characters. The `printenv` approach preserved the raw escaped value, producing invalid JSON. The `sudo bash -c "echo \"$VAR\""` pattern (used elsewhere in CI) performs shell interpretation that unescapes the content correctly.

## Test plan
- [ ] CI passes
- [ ] controller-build workflow authenticates to quay.io and builds successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)