### PR TITLE
fix: use --authfile for registry push instead of podman login

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -46,18 +46,16 @@ jobs:
           chmod +x crucible-install.sh
           sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --engine-registry quay.io/crucible/client-server --verbose
 
-      - name: Login to quay.io
+      - name: Write registry auth
         env:
           REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}
-        run: |
-          sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
-          sudo podman login --authfile /root/quay-auth.json quay.io
+        run: sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
 
       - name: Build controller image
         run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py build
 
       - name: Push controller image
-        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py push
+        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py --authfile /root/quay-auth.json push
 
       - name: Cleanup
         if: always()
@@ -77,12 +75,10 @@ jobs:
           chmod +x crucible-install.sh
           sudo ./crucible-install.sh --name "crucible-ci" --email "crucible-ci@noreply" --engine-registry quay.io/crucible/client-server --verbose
 
-      - name: Login to quay.io
+      - name: Write registry auth
         env:
           REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}
-        run: |
-          sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
-          sudo podman login --authfile /root/quay-auth.json quay.io
+        run: sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
 
       - name: Determine manifest tag
         id: tag
@@ -94,7 +90,7 @@ jobs:
           fi
 
       - name: Create and push manifest
-        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py manifest ${{ steps.tag.outputs.tag }}
+        run: sudo crucible wrapper /opt/crucible/workshop/controller-image.py --authfile /root/quay-auth.json manifest ${{ steps.tag.outputs.tag }}
 
       - name: Cleanup
         if: always()

--- a/workshop/controller-image.py
+++ b/workshop/controller-image.py
@@ -287,7 +287,8 @@ def cmd_push(args):
     source = f"localhost/workshop/{conf['userenv_label']}_crucible-controller"
     destination = f"{controller_repo}:{tag}"
 
-    run(f"buildah push {source} {destination}")
+    authfile_arg = f"--authfile {args.authfile}" if args.authfile else ""
+    run(f"buildah push {authfile_arg} {source} {destination}")
 
 
 def cmd_manifest(args):
@@ -333,15 +334,20 @@ def cmd_manifest(args):
     if result.exited == 0:
         run(f"podman manifest rm {local_manifest}")
 
+    authfile_arg = f"--authfile {args.authfile}" if args.authfile else ""
     run(f"podman manifest create {local_manifest}")
     for image in images:
         run(f"podman manifest add {local_manifest} docker://{image}")
-    run(f"podman manifest push {local_manifest} {controller_repo}:{manifest_tag}")
+    run(f"podman manifest push {authfile_arg} {local_manifest} {controller_repo}:{manifest_tag}")
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Crucible controller image management tool"
+    )
+    parser.add_argument(
+        "--authfile", type=str, default=None,
+        help="Path to registry auth file for push/manifest operations"
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 


### PR DESCRIPTION
## Summary
- Add `--authfile` argument to `controller-image.py` for push and manifest subcommands
- Pass auth file directly to `buildah push` and `podman manifest push` instead of relying on `podman login`
- `podman login` writes credentials to a location not visible inside the `crucible wrapper` container, causing `unauthorized` errors on push
- Auth is only used for write operations (push), not reads (manifest add from public repo)

## Test plan
- [ ] CI passes
- [ ] controller-build workflow successfully pushes images after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)