### PR TITLE
fix: use controller registry auth secret

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Write registry auth
         env:
-          REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}
+          REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_CONTROLLER_REGISTRY_AUTH }}
         run: sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
 
       - name: Build controller image
@@ -77,7 +77,7 @@ jobs:
 
       - name: Write registry auth
         env:
-          REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH }}
+          REGISTRY_AUTH: ${{ secrets.CRUCIBLE_PRODUCTION_CONTROLLER_REGISTRY_AUTH }}
         run: sudo bash -c "echo \"$REGISTRY_AUTH\" > /root/quay-auth.json"
 
       - name: Determine manifest tag


### PR DESCRIPTION
## Summary
- Use `CRUCIBLE_PRODUCTION_CONTROLLER_REGISTRY_AUTH` which has write access to `quay.io/crucible/controller`
- The previous secret (`CRUCIBLE_PRODUCTION_ENGINES_REGISTRY_AUTH`) only has access to the engines registry

## Test plan
- [ ] CI passes
- [ ] controller-build workflow successfully pushes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)