### PR TITLE
fix: use curl --json for quay.io tag API calls

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -125,8 +125,7 @@ jobs:
         run: |
           curl -s -X PUT \
             -H "Authorization: Bearer ${QUAY_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d '{"manifest_digest": "${{ steps.current.outputs.digest }}"}' \
+            --json '{"manifest_digest": "${{ steps.current.outputs.digest }}"}' \
             "https://quay.io/api/v1/repository/${REPO}/tag/previous"
           echo "Moved 'previous' to digest: ${{ steps.current.outputs.digest }}"
 
@@ -143,8 +142,7 @@ jobs:
         run: |
           curl -s -X PUT \
             -H "Authorization: Bearer ${QUAY_TOKEN}" \
-            -H "Content-Type: application/json" \
-            -d '{"manifest_digest": "${{ steps.new.outputs.digest }}"}' \
+            --json '{"manifest_digest": "${{ steps.new.outputs.digest }}"}' \
             "https://quay.io/api/v1/repository/${REPO}/tag/latest"
           echo "Moved 'latest' to digest: ${{ steps.new.outputs.digest }}"
 


### PR DESCRIPTION
## Summary
- Use curl's `--json` flag instead of `-d` with `-H "Content-Type: application/json"` for quay.io tag management API calls
- The previous approach resulted in quay.io responding with `Did not attempt to load JSON data because the request Content-Type was not 'application/json'`
- `--json` automatically sets both `Content-Type: application/json` and `Accept: application/json`

## Test plan
- [ ] CI passes
- [ ] controller-build workflow successfully moves latest/previous tags after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)