### PR TITLE
fix: use --data-raw for quay.io tag API and add response logging

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -123,10 +123,12 @@ jobs:
       - name: Move previous tag to current latest
         if: steps.current.outputs.digest != ''
         run: |
-          curl -s -X PUT \
+          response=$(curl -s -X PUT \
             -H "Authorization: Bearer ${QUAY_TOKEN}" \
-            --json '{"manifest_digest": "${{ steps.current.outputs.digest }}"}' \
-            "https://quay.io/api/v1/repository/${REPO}/tag/previous"
+            -H "Content-Type: application/json" \
+            --data-raw '{"manifest_digest":"${{ steps.current.outputs.digest }}"}' \
+            "https://quay.io/api/v1/repository/${REPO}/tag/previous")
+          echo "API response: ${response}"
           echo "Moved 'previous' to digest: ${{ steps.current.outputs.digest }}"
 
       - name: Get new manifest digest
@@ -140,10 +142,12 @@ jobs:
 
       - name: Move latest tag to new manifest
         run: |
-          curl -s -X PUT \
+          response=$(curl -s -X PUT \
             -H "Authorization: Bearer ${QUAY_TOKEN}" \
-            --json '{"manifest_digest": "${{ steps.new.outputs.digest }}"}' \
-            "https://quay.io/api/v1/repository/${REPO}/tag/latest"
+            -H "Content-Type: application/json" \
+            --data-raw '{"manifest_digest":"${{ steps.new.outputs.digest }}"}' \
+            "https://quay.io/api/v1/repository/${REPO}/tag/latest")
+          echo "API response: ${response}"
           echo "Moved 'latest' to digest: ${{ steps.new.outputs.digest }}"
 
       - name: Summary


### PR DESCRIPTION
## Summary
- Use `--data-raw` instead of `--json` or `-d` for quay.io PUT tag API calls
- Add API response logging to see what quay.io actually returns
- Both `--json` and `-d` with `-H Content-Type` failed with the same error — trying `--data-raw` with explicit header as a different approach

## Test plan
- [ ] CI passes
- [ ] API response logging reveals the actual issue if this still fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)