### PR TITLE
fix: strip whitespace from quay.io OAuth token

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -107,10 +107,15 @@ jobs:
       QUAY_TOKEN: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
       REPO: crucible/controller
     steps:
+      - name: Prepare auth
+        run: |
+          QUAY_TOKEN_CLEAN=$(echo -n "${QUAY_TOKEN}" | tr -d '[:space:]')
+          echo "QUAY_TOKEN_CLEAN=${QUAY_TOKEN_CLEAN}" >> $GITHUB_ENV
+
       - name: Get current latest digest
         id: current
         run: |
-          digest=$(curl -s -H "Authorization: Bearer ${QUAY_TOKEN}" \
+          digest=$(curl -s -H "Authorization: Bearer ${QUAY_TOKEN_CLEAN}" \
             "https://quay.io/api/v1/repository/${REPO}/tag/?specificTag=latest" \
             | jq -r '.tags[0].manifest_digest // empty')
           echo "digest=${digest}" >> $GITHUB_OUTPUT
@@ -124,7 +129,7 @@ jobs:
         if: steps.current.outputs.digest != ''
         run: |
           response=$(curl -s -X PUT \
-            -H "Authorization: Bearer ${QUAY_TOKEN}" \
+            -H "Authorization: Bearer ${QUAY_TOKEN_CLEAN}" \
             -H "Content-Type: application/json" \
             --data-raw '{"manifest_digest":"${{ steps.current.outputs.digest }}"}' \
             "https://quay.io/api/v1/repository/${REPO}/tag/previous")
@@ -134,7 +139,7 @@ jobs:
       - name: Get new manifest digest
         id: new
         run: |
-          digest=$(curl -s -H "Authorization: Bearer ${QUAY_TOKEN}" \
+          digest=$(curl -s -H "Authorization: Bearer ${QUAY_TOKEN_CLEAN}" \
             "https://quay.io/api/v1/repository/${REPO}/tag/?specificTag=${{ needs.create-manifest.outputs.manifest_tag }}" \
             | jq -r '.tags[0].manifest_digest')
           echo "digest=${digest}" >> $GITHUB_OUTPUT
@@ -143,7 +148,7 @@ jobs:
       - name: Move latest tag to new manifest
         run: |
           response=$(curl -s -X PUT \
-            -H "Authorization: Bearer ${QUAY_TOKEN}" \
+            -H "Authorization: Bearer ${QUAY_TOKEN_CLEAN}" \
             -H "Content-Type: application/json" \
             --data-raw '{"manifest_digest":"${{ steps.new.outputs.digest }}"}' \
             "https://quay.io/api/v1/repository/${REPO}/tag/latest")


### PR DESCRIPTION
## Summary
- Strip all whitespace from the OAuth token before using it in curl API calls
- GitHub secrets can contain trailing newlines which corrupt the `Authorization` header
- The quay.io API returns a misleading `Content-Type was not application/json` error when this happens
- Root cause confirmed by reproducing the error locally with a newline-appended token
- Matches how existing Perl (`chomp`) and Python (`.strip()`) code handles tokens read from files

## Test plan
- [ ] CI passes
- [ ] controller-build workflow successfully moves latest/previous tags after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)