### PR TITLE
fix: rename wrapper concurrency group to avoid collision

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -25,7 +25,7 @@ on:
         default: ""
 
 concurrency:
-  group: build-publish-controller
+  group: build-publish-controller-global
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Rename the concurrency group in `build-publish-controller.yaml` wrapper from `build-publish-controller` to `build-publish-controller-global` to avoid collision with the same group name used in caller workflows

## Test plan
- [ ] CI passes
- [ ] Cross-repo controller builds serialize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)