### PR TITLE
feat: switch to repository_dispatch for cross-repo controller builds

### DIFF
--- a/.github/workflows/build-publish-controller.yaml
+++ b/.github/workflows/build-publish-controller.yaml
@@ -1,17 +1,8 @@
 name: build-publish-controller
 
 on:
-  workflow_call:
-    inputs:
-      ci_target:
-        description: "Which subproject triggered the build"
-        required: true
-        type: string
-      manifest_tag:
-        description: "Tag for the multi-arch manifest (default: auto-generated)"
-        required: false
-        type: string
-        default: ""
+  repository_dispatch:
+    types: [controller-build]
   workflow_dispatch:
     inputs:
       ci_target:
@@ -25,13 +16,13 @@ on:
         default: ""
 
 concurrency:
-  group: build-publish-controller-global
+  group: build-publish-controller
   cancel-in-progress: true
 
 jobs:
   call-worker:
     uses: ./.github/workflows/build-publish-controller-worker.yaml
     with:
-      ci_target: ${{ inputs.ci_target }}
-      manifest_tag: ${{ inputs.manifest_tag }}
+      ci_target: ${{ github.event.client_payload.ci_target || inputs.ci_target }}
+      manifest_tag: ${{ github.event.client_payload.manifest_tag || inputs.manifest_tag || '' }}
     secrets: inherit

--- a/.github/workflows/controller-build.yaml
+++ b/.github/workflows/controller-build.yaml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   call-build-publish-controller:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: ./.github/workflows/build-publish-controller.yaml
+    uses: ./.github/workflows/build-publish-controller-worker.yaml
     with:
       ci_target: "crucible"
     secrets: inherit


### PR DESCRIPTION
## Summary
- Replace `workflow_call` with `repository_dispatch` in `build-publish-controller.yaml` so all controller builds run in crucible's context
- This gives us working cross-repo concurrency (single concurrency group in one repo) and eliminates cross-repo secret passing issues
- `controller-build.yaml` calls the worker directly for crucible-initiated builds, sharing the same concurrency group
- Subprojects will be updated separately to dispatch to crucible via a GitHub App token

## Test plan
- [ ] CI passes
- [ ] `workflow_dispatch` from crucible still works
- [ ] After subproject callers are updated, `repository_dispatch` triggers the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)