### PR TITLE
fix: add file completion for wrapper and global -o filenames

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -40,6 +40,9 @@ _crucible_completions() {
             run)
                 COMPREPLY=($(compgen -f -- "${COMP_WORDS[2]}"))
                 ;;
+            wrapper)
+                COMPREPLY=($(compgen -c -f -- "${COMP_WORDS[2]}"))
+                ;;
             start|stop)
                 COMPREPLY=($(compgen -W "httpd image-sourcing opensearch valkey" -- "${COMP_WORDS[2]}"))
                 ;;
@@ -132,4 +135,4 @@ _crucible_completions() {
     fi
 }
 
-complete -o nosort -F _crucible_completions crucible
+complete -o nosort -o filenames -F _crucible_completions crucible


### PR DESCRIPTION
## Summary
- Add command+file completion for `crucible wrapper` so it autocompletes both executables in `$PATH` and filesystem paths
- Add `-o filenames` to the global `complete` command so all file-completing subcommands (`run`, `wrapper`, `postprocess`, `archive`, `unarchive`) handle directory traversal correctly — appending `/` after directories instead of a space

## Test plan
- [ ] `crucible wrapper /opt/crucible/workshop/` completes into the directory
- [ ] `crucible run configs/` completes into the directory
- [ ] `crucible wrapper python3` completes commands from PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)