### PR TITLE
feat: use repository_dispatch for crucible's own controller builds

### DIFF
--- a/.github/workflows/controller-build.yaml
+++ b/.github/workflows/controller-build.yaml
@@ -12,14 +12,24 @@ on:
       - .github/workflows/controller-build.yaml
   workflow_dispatch:
 
-concurrency:
-  group: build-publish-controller
-  cancel-in-progress: true
-
 jobs:
-  call-build-publish-controller:
+  dispatch:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: ./.github/workflows/build-publish-controller-worker.yaml
-    with:
-      ci_target: "crucible"
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID__CRUCIBLE_WORKFLOW_DISPATCH }}
+          private-key: ${{ secrets.PRIVATE_KEY__CRUCIBLE_WORKFLOW_DISPATCH }}
+          owner: perftool-incubator
+          repositories: crucible
+
+      - name: Dispatch controller build
+        run: |
+          curl -s -X POST \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/perftool-incubator/crucible/dispatches" \
+            -d '{"event_type":"controller-build","client_payload":{"ci_target":"crucible"}}'


### PR DESCRIPTION
## Summary
- Make crucible's `controller-build.yaml` follow the same `repository_dispatch` pattern as all subproject callers
- Previously crucible called the worker directly while subprojects dispatched — this created two different code paths
- Now all controller builds (from any repo including crucible itself) follow the same flow: generate app token → dispatch to crucible → concurrency group → worker

## Test plan
- [ ] CI passes
- [ ] `workflow_dispatch` triggers the dispatch → build chain correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)