### PR TITLE
feat: block fork PRs and skip CI for fork-originated pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
             .github/workflows/controller-build.yaml
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
+            .github/workflows/fork-check.yaml
             docs/**
             spec/**
       - name: Display changes
@@ -42,7 +43,7 @@ jobs:
 
   install:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     runs-on: [ self-hosted, aws-cloud-1 ]
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +52,7 @@ jobs:
 
   faux-install:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "faux-install complete"'

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -35,6 +35,7 @@ jobs:
             .github/workflows/controller-build.yaml
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
+            .github/workflows/fork-check.yaml
             docs/**
             spec/**
       - name: Display changes
@@ -42,7 +43,7 @@ jobs:
 
   call-real-core-release-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
       ci_target: "crucible"
@@ -54,7 +55,7 @@ jobs:
 
   call-faux-core-release-crucible-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:

--- a/.github/workflows/crucible-release-ci.yaml
+++ b/.github/workflows/crucible-release-ci.yaml
@@ -34,6 +34,7 @@ jobs:
             .github/workflows/controller-build.yaml
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
+            .github/workflows/fork-check.yaml
             docs/**
             spec/**
       - name: Display changes
@@ -41,7 +42,7 @@ jobs:
 
   call-crucible-release-remove:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: ./.github/workflows/crucible-release.yaml
     with:
       custom_release: "ci-version-test"
@@ -52,7 +53,7 @@ jobs:
 
   call-crucible-release-create:
     needs: call-crucible-release-remove
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: ./.github/workflows/crucible-release.yaml
     with:
       custom_release: "ci-version-test"
@@ -62,7 +63,7 @@ jobs:
 
   call-crucible-release-update:
     needs: call-crucible-release-create
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: ./.github/workflows/crucible-release.yaml
     with:
       custom_release: "ci-version-test"
@@ -72,7 +73,7 @@ jobs:
 
   faux-crucible-release-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "faux-crucible-release-ci-complete"

--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -1,0 +1,27 @@
+name: fork-check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  block-fork-pr:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close fork PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'This PR was opened from a fork. PRs must be opened from branches on the upstream repository so that CI workflows have access to required secrets and variables.\n\nPlease push your branch to this repository and open a new PR.\n\nClosing this PR automatically.'
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
## Summary
- Add `fork-check.yaml` workflow that automatically comments and closes PRs from forks
- Add fork guard (`github.event.pull_request.head.repo.fork != true`) to all PR-triggered CI workflows
- Add `fork-check.yaml` to CI exclusion lists

Part of an org-wide rollout across all repos.

## Test plan
- [ ] CI passes (should skip heavy CI — only workflow files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)