### PR TITLE
feat: add crucible-dev-tools subproject and plugin integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+    "extraKnownMarketplaces": {
+        "crucible-dev-tools": {
+            "source": {
+                "source": "directory",
+                "path": "subprojects/core/crucible-dev-tools"
+            }
+        }
+    },
+    "enabledPlugins": {
+        "crucible-tools@crucible-dev-tools": true
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,3 +123,13 @@ This means:
 
 ### Recommended workflow
 Run Claude Code from `/opt/crucible` for most work — all subproject code is accessible, and cross-cutting changes have full visibility. Only run from a subproject root (e.g., `subprojects/core/rickshaw/`) for deep isolated work on that specific component.
+
+## Developer Tools
+
+Crucible includes a Claude Code plugin (`crucible-dev-tools`) for development workflows. When opening this project, Claude Code will prompt you to install the crucible-tools plugin. Accept to get access to:
+
+- `/crucible-tools:repo-status` — git status across all crucible repos
+- `/crucible-tools:open-prs` — open PRs in the org (optionally filter by author)
+- `/crucible-tools:dev-activity` — development activity charts (commits, PRs, workflow runs)
+- `/crucible-tools:weekly-summary` — weekly activity report with PR links
+- `ci-analyzer` agent — analyze GitHub Actions CI workflow runs to diagnose failures

--- a/config/repos.json
+++ b/config/repos.json
@@ -91,6 +91,16 @@
             }
         },
         {
+            "name": "crucible-dev-tools",
+            "type": "core",
+            "repository": "https://github.com/perftool-incubator/crucible-dev-tools",
+            "primary-branch": "main",
+            "checkout": {
+                "mode": "follow",
+                "target": "main"
+            }
+        },
+        {
             "name": "fio",
             "type": "benchmark",
             "repository": "https://github.com/perftool-incubator/bench-fio",


### PR DESCRIPTION
## Summary
- Add `crucible-dev-tools` as a core subproject in `repos.json`
- Add `.claude/settings.json` to auto-configure the plugin marketplace pointing at the local subproject clone
- Update `CLAUDE.md` with developer tools documentation
- The plugin repo (`perftool-incubator/crucible-dev-tools`) provides Claude Code skills and agents: repo-status, open-prs, dev-activity, weekly-summary, ci-analyzer

## How it works
- `crucible update` clones the plugin repo to `subprojects/core/crucible-dev-tools/`
- `.claude/settings.json` points Claude Code at the local clone as a plugin marketplace
- Claude Code prompts the user to install the plugin on first use
- Skills are invoked as `/crucible-tools:repo-status`, etc.

## Test plan
- [ ] CI passes
- [ ] `crucible update` clones the new subproject
- [ ] Plugin skills are available after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)