### PR TITLE
docs: update plugin onboarding and simplify settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,4 @@
 {
-    "extraKnownMarketplaces": {
-        "crucible-dev-tools": {
-            "source": {
-                "source": "directory",
-                "path": "subprojects/core/crucible-dev-tools"
-            }
-        }
-    },
     "enabledPlugins": {
         "crucible-tools@crucible-dev-tools": true
     }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
             .github/workflows/fork-check.yaml
+            .claude/**
             docs/**
             spec/**
       - name: Display changes

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -36,6 +36,7 @@ jobs:
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
             .github/workflows/fork-check.yaml
+            .claude/**
             docs/**
             spec/**
       - name: Display changes

--- a/.github/workflows/crucible-release-ci.yaml
+++ b/.github/workflows/crucible-release-ci.yaml
@@ -35,6 +35,7 @@ jobs:
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
             .github/workflows/fork-check.yaml
+            .claude/**
             docs/**
             spec/**
       - name: Display changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,17 @@ Run Claude Code from `/opt/crucible` for most work — all subproject code is ac
 
 ## Developer Tools
 
-Crucible includes a Claude Code plugin (`crucible-dev-tools`) for development workflows. When opening this project, Claude Code will prompt you to install the crucible-tools plugin. Accept to get access to:
+Crucible includes a Claude Code plugin (`crucible-dev-tools`) for development
+workflows. New installations have the plugin repo already cloned. For existing
+installs, run `crucible update` first. Then register the plugin marketplace:
 
+```
+claude plugin marketplace add ${CRUCIBLE_HOME}/subprojects/core/crucible-dev-tools
+```
+
+Claude Code will prompt you to install the crucible-tools plugin — accept it.
+
+Available skills:
 - `/crucible-tools:repo-status` — git status across all crucible repos
 - `/crucible-tools:open-prs` — open PRs in the org (optionally filter by author)
 - `/crucible-tools:dev-activity` — development activity charts (commits, PRs, workflow runs)


### PR DESCRIPTION
## Summary

- Remove `extraKnownMarketplaces` from `.claude/settings.json` — directory sources don't work with this setting; marketplace registration must be done via `claude plugin marketplace add`
- Update CLAUDE.md Developer Tools section with correct installation instructions for new and existing installations

Companion to perftool-incubator/crucible-dev-tools#1 which restructures the plugin repo as a proper marketplace.

## Test plan

- [ ] `claude plugin marketplace add ${CRUCIBLE_HOME}/subprojects/core/crucible-dev-tools`
- [ ] `/reload-plugins` shows 1 plugin loaded
- [ ] `/crucible-tools:repo-status` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)