### PR TITLE
feat: add --follow mode to crucible log view

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -124,7 +124,7 @@ _crucible_completions() {
     elif [ ${COMP_WORDS[1]} == "log" -a "${COMP_WORDS[2]}" == "sessions" ]; then
         COMPREPLY=($(compgen -W "--grep --format --color --no-color --sort --order" -- "${COMP_WORDS[$num_index]}"))
     elif [ ${COMP_WORDS[1]} == "log" -a "${COMP_WORDS[2]}" == "view" ]; then
-        local log_view_flags="--stream --grep --since --until --format --color --no-color --count --tail"
+        local log_view_flags="--stream --grep --since --until --format --color --no-color --count --tail --follow"
         if [ $num_words -eq 4 ]; then
             COMPREPLY=($(compgen -W "first last sessionid ${log_view_flags}" -- "${COMP_WORDS[3]}"))
         elif [ $num_words -eq 5 -a "${COMP_WORDS[3]}" == "sessionid" ]; then

--- a/bin/_help
+++ b/bin/_help
@@ -11,7 +11,7 @@ function help() {
     echo "help                          |  Show this help message"
     echo "run <file>                    |  Run a benchmark"
     echo "log                           |  Manage the crucible log"
-    echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --tail, --color)"
+    echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --tail, --follow, --color)"
     echo "  sessions                    |    - List all sessions (supports --grep, --sort, --order, --color)"
     echo "  info [--json]               |    - Show log database summary"
     echo "  clear                       |    - Delete all log entries"

--- a/bin/_log.py
+++ b/bin/_log.py
@@ -118,6 +118,8 @@ def main():
         parser.add_argument("--count", action="store_true", default=False)
         parser.add_argument("--tail", type=int, default=None,
                             help="Show only the last N lines per session")
+        parser.add_argument("--follow", action="store_true", default=False,
+                            help="Follow new lines as they arrive (like tail -f)")
 
         args = parser.parse_args(sys.argv[3:])
 
@@ -138,6 +140,7 @@ def main():
             use_color=use_color,
             count_only=args.count,
             tail=args.tail,
+            follow=args.follow,
         )
         conn.close()
         return
@@ -186,6 +189,7 @@ def main():
         print("    --since <time>                   Filter by start time (abs or relative: 1h, 30m, 2d)")
         print("    --until <time>                   Filter by end time")
         print("    --tail <N>                       Show last N lines per session")
+        print("    --follow                         Follow new lines as they arrive (like tail -f)")
         print("    --format plain|json              Output format")
         print("    --color                          Colorize output")
         print("    --count                          Count matching lines only")

--- a/bin/_logger_lib/viewer.py
+++ b/bin/_logger_lib/viewer.py
@@ -17,7 +17,8 @@ def format_ts(epoch):
 def view_sessions(conn, filter_cmd=None, filter_arg=None,
                   stream_filter=None, grep_pattern=None,
                   since=None, until=None, output_format="plain",
-                  use_color=False, count_only=False, tail=None):
+                  use_color=False, count_only=False, tail=None,
+                  follow=False):
     conditions = []
     params = []
 
@@ -130,6 +131,8 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
         pending_header = None
         pending_lines = []
 
+    last_line_id = 0
+
     for row in cursor:
         session_id = row[0]
         session_ts = row[1]
@@ -171,6 +174,85 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
             print(formatted)
 
     _flush_pending()
+
+    if not follow:
+        return
+
+    import sys
+    # Flush stdout after every print in follow mode since the container
+    # may not have a TTY and Python defaults to full buffering
+    sys.stdout.reconfigure(line_buffering=True)
+
+    # Enable WAL mode for concurrent read/write access and switch to
+    # autocommit so each poll sees the latest committed data
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.isolation_level = None
+
+    # Get the highest line ID for the follow query starting point
+    row = conn.execute("SELECT MAX(id) FROM lines").fetchone()
+    last_line_id = row[0] if row[0] else 0
+
+    # Build the follow query with the same filters
+    follow_conditions = list(conditions)
+    follow_conditions.append("lines.id > ?")
+    follow_where = "WHERE " + " AND ".join(follow_conditions)
+
+    follow_query = (
+        "SELECT "
+        "sessions.session_id, sessions.timestamp, commands.command, "
+        "sources.source, lines.timestamp, lines.line, streams.stream, lines.id "
+        "FROM sessions "
+        "JOIN lines ON sessions.id = lines.session "
+        "JOIN streams ON streams.id = lines.stream "
+        "JOIN sources ON sources.id = sessions.source "
+        "JOIN commands ON commands.id = sessions.command "
+        f"{follow_where} "
+        "ORDER BY lines.id"
+    )
+
+    last_follow_session_id = None
+
+    try:
+        while True:
+            follow_params = list(params) + [last_line_id]
+            new_rows = conn.execute(follow_query, follow_params).fetchall()
+
+            for row in new_rows:
+                session_id = row[0]
+                session_ts = row[1]
+                session_cmd = row[2]
+                session_src = row[3]
+                line_ts = row[4]
+                line = row[5] or ""
+                line_stream = row[6]
+                line_id = row[7]
+
+                last_line_id = line_id
+
+                if grep_pattern and not re.search(grep_pattern, line):
+                    continue
+
+                if output_format == "json":
+                    print(json.dumps({
+                        "session_id": session_id,
+                        "timestamp": line_ts,
+                        "stream": line_stream,
+                        "line": line,
+                    }))
+                else:
+                    session_ts_fmt = format_ts(session_ts)
+                    line_ts_fmt = format_ts(line_ts)
+
+                    if session_id != last_follow_session_id:
+                        dur_str = "active"
+                        _print_session_header(session_ts_fmt, session_id, session_cmd, session_src, dur_str)
+                        last_follow_session_id = session_id
+
+                    print(_format_line(line_ts_fmt, line_stream, line))
+
+            time.sleep(0.25)
+    except KeyboardInterrupt:
+        print()
 
 
 def show_info(conn, db_path=None, output_format="plain"):

--- a/bin/crucible
+++ b/bin/crucible
@@ -82,7 +82,11 @@ if [ "$1" == "log" ]; then
     if [ "$2" == "view" -o -z "$2" ]; then
         shift
         shift
-        crucible_log view ${LOG_DB} "$@" | less -R -S -F
+        if echo "$@" | grep -q "\-\-follow"; then
+            crucible_log view ${LOG_DB} "$@"
+        else
+            crucible_log view ${LOG_DB} "$@" | less -R -S -F
+        fi
         exit $?
     elif [ "$2" == "sessions" ]; then
         shift


### PR DESCRIPTION
## Summary
- Adds `--follow` flag to `crucible log view` for live tailing of active sessions (like `tail -f`)
- Polls SQLite DB every 250ms for new lines using WAL journal mode for concurrent read/write access
- Shows existing lines first, then follows new ones
- Re-prints session headers when switching between parallel sessions
- Skips `less` pipe when `--follow` is active
- Works with all existing view filters (`--stream`, `--grep`, `--color`, etc.)
- Clean exit on Ctrl-C

## Test plan
- [ ] Start `crucible run` in one terminal, run `crucible log view last --follow` in another — verify live output
- [ ] Ctrl-C the follow — verify clean exit
- [ ] `crucible log view last --follow --stream stderr` — verify filtering in follow mode
- [ ] `crucible log view last --follow --grep "ERROR"` — verify grep in follow mode
- [ ] `crucible log view last` (without --follow) — verify normal behavior unchanged
- [ ] Run two crucible commands in parallel with unfiltered `--follow` — verify session headers re-print on switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)