### PR TITLE
feat: add --raw, --head options and grep fix for log viewer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ crucible help [command]
 - **Podman usage**: Use `podman_wrapper()` and related functions from `bin/base`; never call podman directly
 - **JSON processing**: Use `jq_query()` helper from `bin/base`; validate configs against schemas in `schema/`
 - **Variable naming**: Lowercase with underscores for locals; uppercase for exported/environment variables (e.g., `CRUCIBLE_HOME`, `CRUCIBLE_CONTROLLER_IMAGE`)
+- **CLI parameters**: When adding a new CLI parameter, option, or subcommand, update all three locations: `bin/_help` (main help output), `bin/_crucible_completions` (bash tab completions), and the relevant command's own help text
 
 ## Language Strategy
 - **New code**: Write new functionality in Python 3 by default

--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -124,7 +124,7 @@ _crucible_completions() {
     elif [ ${COMP_WORDS[1]} == "log" -a "${COMP_WORDS[2]}" == "sessions" ]; then
         COMPREPLY=($(compgen -W "--grep --format --color --no-color --sort --order" -- "${COMP_WORDS[$num_index]}"))
     elif [ ${COMP_WORDS[1]} == "log" -a "${COMP_WORDS[2]}" == "view" ]; then
-        local log_view_flags="--stream --grep --since --until --format --color --no-color --count --tail --follow --raw"
+        local log_view_flags="--stream --grep --since --until --format --color --no-color --count --head --tail --follow --raw"
         if [ $num_words -eq 4 ]; then
             COMPREPLY=($(compgen -W "first last sessionid ${log_view_flags}" -- "${COMP_WORDS[3]}"))
         elif [ $num_words -eq 5 -a "${COMP_WORDS[3]}" == "sessionid" ]; then

--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -124,7 +124,7 @@ _crucible_completions() {
     elif [ ${COMP_WORDS[1]} == "log" -a "${COMP_WORDS[2]}" == "sessions" ]; then
         COMPREPLY=($(compgen -W "--grep --format --color --no-color --sort --order" -- "${COMP_WORDS[$num_index]}"))
     elif [ ${COMP_WORDS[1]} == "log" -a "${COMP_WORDS[2]}" == "view" ]; then
-        local log_view_flags="--stream --grep --since --until --format --color --no-color --count --tail --follow"
+        local log_view_flags="--stream --grep --since --until --format --color --no-color --count --tail --follow --raw"
         if [ $num_words -eq 4 ]; then
             COMPREPLY=($(compgen -W "first last sessionid ${log_view_flags}" -- "${COMP_WORDS[3]}"))
         elif [ $num_words -eq 5 -a "${COMP_WORDS[3]}" == "sessionid" ]; then

--- a/bin/_help
+++ b/bin/_help
@@ -11,7 +11,7 @@ function help() {
     echo "help                          |  Show this help message"
     echo "run <file>                    |  Run a benchmark"
     echo "log                           |  Manage the crucible log"
-    echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --tail, --follow, --color)"
+    echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --tail, --follow, --raw, --color)"
     echo "  sessions                    |    - List all sessions (supports --grep, --sort, --order, --color)"
     echo "  info [--json]               |    - Show log database summary"
     echo "  clear                       |    - Delete all log entries"

--- a/bin/_help
+++ b/bin/_help
@@ -11,7 +11,7 @@ function help() {
     echo "help                          |  Show this help message"
     echo "run <file>                    |  Run a benchmark"
     echo "log                           |  Manage the crucible log"
-    echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --tail, --follow, --raw, --color)"
+    echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --head, --tail, --follow, --raw, --color)"
     echo "  sessions                    |    - List all sessions (supports --grep, --sort, --order, --color)"
     echo "  info [--json]               |    - Show log database summary"
     echo "  clear                       |    - Delete all log entries"

--- a/bin/_log.py
+++ b/bin/_log.py
@@ -118,6 +118,8 @@ def main():
         parser.add_argument("--count", action="store_true", default=False)
         parser.add_argument("--tail", type=int, default=None,
                             help="Show only the last N lines per session")
+        parser.add_argument("--head", type=int, default=None,
+                            help="Show only the first N lines per session")
         parser.add_argument("--follow", action="store_true", default=False,
                             help="Follow new lines as they arrive (like tail -f)")
         parser.add_argument("--raw", action="store_true", default=False,
@@ -142,6 +144,7 @@ def main():
             use_color=use_color,
             count_only=args.count,
             tail=args.tail,
+            head=args.head,
             follow=args.follow,
             raw=args.raw,
         )
@@ -191,6 +194,7 @@ def main():
         print("    --grep <pattern>                 Search log lines")
         print("    --since <time>                   Filter by start time (abs or relative: 1h, 30m, 2d)")
         print("    --until <time>                   Filter by end time")
+        print("    --head <N>                       Show first N lines per session")
         print("    --tail <N>                       Show last N lines per session")
         print("    --follow                         Follow new lines as they arrive (like tail -f)")
         print("    --raw                            Show raw output without timestamps or headers")

--- a/bin/_log.py
+++ b/bin/_log.py
@@ -120,6 +120,8 @@ def main():
                             help="Show only the last N lines per session")
         parser.add_argument("--follow", action="store_true", default=False,
                             help="Follow new lines as they arrive (like tail -f)")
+        parser.add_argument("--raw", action="store_true", default=False,
+                            help="Show raw output without timestamps, stream labels, or session headers")
 
         args = parser.parse_args(sys.argv[3:])
 
@@ -141,6 +143,7 @@ def main():
             count_only=args.count,
             tail=args.tail,
             follow=args.follow,
+            raw=args.raw,
         )
         conn.close()
         return
@@ -190,6 +193,7 @@ def main():
         print("    --until <time>                   Filter by end time")
         print("    --tail <N>                       Show last N lines per session")
         print("    --follow                         Follow new lines as they arrive (like tail -f)")
+        print("    --raw                            Show raw output without timestamps or headers")
         print("    --format plain|json              Output format")
         print("    --color                          Colorize output")
         print("    --count                          Count matching lines only")

--- a/bin/_logger_lib/viewer.py
+++ b/bin/_logger_lib/viewer.py
@@ -18,7 +18,7 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
                   stream_filter=None, grep_pattern=None,
                   since=None, until=None, output_format="plain",
                   use_color=False, count_only=False, tail=None,
-                  follow=False, raw=False):
+                  head=None, follow=False, raw=False):
     conditions = []
     params = []
 
@@ -134,6 +134,7 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
         pending_lines = []
 
     last_line_id = 0
+    session_line_count = 0
 
     for row in cursor:
         session_id = row[0]
@@ -161,10 +162,15 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
 
         if session_ts != last_session_ts:
             _flush_pending()
+            session_line_count = 0
             dur = session_durations.get(session_id)
             dur_str = _format_duration(dur) if dur is not None else "n/a"
             pending_header = (session_ts_fmt, session_id, session_cmd, session_src, dur_str)
             last_session_ts = session_ts
+
+        session_line_count += 1
+        if head and session_line_count > head:
+            continue
 
         formatted = _format_line(line_ts_fmt, line_stream, line)
         if tail:

--- a/bin/_logger_lib/viewer.py
+++ b/bin/_logger_lib/viewer.py
@@ -18,7 +18,7 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
                   stream_filter=None, grep_pattern=None,
                   since=None, until=None, output_format="plain",
                   use_color=False, count_only=False, tail=None,
-                  follow=False):
+                  follow=False, raw=False):
     conditions = []
     params = []
 
@@ -95,6 +95,8 @@ def view_sessions(conn, filter_cmd=None, filter_arg=None,
     sep = "=" * 94
 
     def _format_line(line_ts_fmt, line_stream, line):
+        if raw:
+            return line
         if use_color and line_stream == "STDERR":
             return f"\033[2m[{line_ts_fmt}]\033[0m[\033[31m{line_stream}\033[0m] \033[31m{line}\033[0m"
         elif use_color:

--- a/bin/crucible
+++ b/bin/crucible
@@ -82,7 +82,7 @@ if [ "$1" == "log" ]; then
     if [ "$2" == "view" -o -z "$2" ]; then
         shift
         shift
-        if echo "$@" | grep -q "\-\-follow"; then
+        if echo "$@" | grep -qF -- "--follow"; then
             crucible_log view ${LOG_DB} "$@"
         else
             crucible_log view ${LOG_DB} "$@" | less -R -S -F


### PR DESCRIPTION
## Summary
- Fixes `grep` stray backslash warning in `--follow` detection by using `grep -F`
- Adds `--raw` flag to show log lines without timestamps or stream labels (session headers preserved)
- Adds `--head N` option to show only the first N lines per session (counterpart to `--tail`)
- Adds CLI parameter update checklist to CLAUDE.md code conventions

## Test plan
- [ ] `crucible log view last --raw` — verify no timestamps/stream labels, no grep warning
- [ ] `crucible log view last --head 10` — verify only first 10 lines shown
- [ ] `crucible log view last --follow` — verify no grep warning
- [ ] `crucible log view last --raw --tail 5` — verify raw + tail combination

🤖 Generated with [Claude Code](https://claude.com/claude-code)