### PR TITLE
fix: prevent logger crash on SQLite database lock contention

### DIFF
--- a/bin/_logger_lib/db.py
+++ b/bin/_logger_lib/db.py
@@ -57,7 +57,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_timestamp ON sessions (timestamp);
 
 
 def init_db(db_path):
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path), timeout=30)
     conn.executescript(INIT_SQL)
     conn.execute("INSERT OR REPLACE INTO db_state (timestamp) VALUES (?)", (time.time(),))
     conn.commit()
@@ -81,7 +81,7 @@ def _run_migrations(conn):
 
 
 def verify_db(db_path):
-    conn = sqlite3.connect(str(db_path), check_same_thread=False)
+    conn = sqlite3.connect(str(db_path), timeout=30, check_same_thread=False)
     try:
         conn.execute("SELECT timestamp FROM db_state")
     except sqlite3.OperationalError:
@@ -143,10 +143,18 @@ class LogInserter:
             (self.session_id, timestamp, message, stream_name),
         )
 
-    def commit(self):
+    def commit(self, max_retries=5, retry_delay=0.5):
         if self.in_transaction:
-            self.conn.commit()
-            self.in_transaction = False
+            for attempt in range(max_retries):
+                try:
+                    self.conn.commit()
+                    self.in_transaction = False
+                    return
+                except sqlite3.OperationalError:
+                    if attempt < max_retries - 1:
+                        time.sleep(retry_delay * (attempt + 1))
+                    else:
+                        raise
 
     def rollback(self):
         if self.in_transaction:


### PR DESCRIPTION
## Summary
- Add `timeout=30` to all `sqlite3.connect()` calls so SQLite waits for locks to clear instead of failing immediately (default was 0 seconds)
- Add retry logic with increasing backoff to `LogInserter.commit()` (up to 5 retries) as a safety net for extreme contention

The logger was crashing with `sqlite3.OperationalError: database is locked` when a viewer (`crucible log view`) or another process held a lock on the database during a commit.

## Test plan
- [ ] Run a benchmark and simultaneously run `crucible log view --follow` to create DB contention
- [ ] Verify the logger no longer crashes under concurrent access

🤖 Generated with [Claude Code](https://claude.com/claude-code)