### PR TITLE
feat: make CDM query server port configurable

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -104,7 +104,9 @@ elif [ "${1}" == "get" ]; then
             EXIT_VAL=$?
         elif [ "${1}" == "metric" ]; then
             shift
-            cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-metric-data.sh $@"
+            local cdm_server_port
+            cdm_server_port=$(jq_query ${SERVICES_CFG} '."cdm-server".port')
+            cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-metric-data.sh --server-url http://localhost:${cdm_server_port}/api/v1/metric-data $@"
             ${podman_run} --name crucible-get-metric-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_query_cmd}
             EXIT_VAL=$?
         else

--- a/bin/base
+++ b/bin/base
@@ -641,9 +641,10 @@ function index_run() {
 
 function get_result_backend() {
     local RC
-    local cdm_query_cmd
+    local cdm_query_cmd cdm_server_port
 
-    cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-result-summary.sh $@"
+    cdm_server_port=$(jq_query ${SERVICES_CFG} '."cdm-server".port')
+    cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-result-summary.sh --server-url http://localhost:${cdm_server_port} $@"
     ${podman_run} --name crucible-get-result-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_query_cmd}
     RC=$?
     return ${RC}

--- a/bin/base
+++ b/bin/base
@@ -436,7 +436,9 @@ function stop_opensearch() {
 }
 
 function start_cdm_server() {
-    local RC cdm_server_cmd cdm_query_opt
+    local RC cdm_server_cmd cdm_query_opt cdm_server_port
+
+    cdm_server_port=$(jq_query ${SERVICES_CFG} '."cdm-server".port')
 
     echo -n "Checking for CDM server"
     if ! podman_running crucible-cdm-server; then
@@ -444,24 +446,26 @@ function start_cdm_server() {
         cdm_query_opt=$(run_manage_instances query-opt)
         cdm_server_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/start-server.sh ${cdm_query_opt}"
 
-        open_firewall_port 3000 tcp
-        ${podman_run} --name crucible-cdm-server "${container_common_args[@]}" "${container_cdm_server_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_server_cmd} > /dev/null
+        open_firewall_port ${cdm_server_port} tcp
+        ${podman_run} --name crucible-cdm-server --env "PORT=${cdm_server_port}" "${container_common_args[@]}" "${container_cdm_server_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_server_cmd} > /dev/null
         RC=$?
         if [ ${RC} != 0 ]; then
             echo "ERROR: Could not start CDM server"
         else
-            echo "Successfully started CDM server"
+            echo "Successfully started CDM server on port ${cdm_server_port}"
         fi
     fi
     return ${RC}
 }
 
 function stop_cdm_server() {
-    local RC=0
+    local RC=0 cdm_server_port
+
+    cdm_server_port=$(jq_query ${SERVICES_CFG} '."cdm-server".port')
 
     echo -n "Checking for CDM server"
     if podman_running crucible-cdm-server; then
-        close_firewall_port 3000 tcp
+        close_firewall_port ${cdm_server_port} tcp
         ${podman_stop} crucible-cdm-server > /dev/null
         RC=$?
         if [ ${RC} != 0 ]; then

--- a/config/services.json
+++ b/config/services.json
@@ -1,4 +1,7 @@
 {
+    "cdm-server": {
+        "port": 3000
+    },
     "image-sourcing": {
         "use": true,
         "start": true,

--- a/schema/services.json
+++ b/schema/services.json
@@ -53,6 +53,22 @@
                 "use"
             ]
         },
+        "cdm-server": {
+            "description": "The cdm-server object contains configuration settings for the CDM query server",
+            "type": "object",
+            "properties": {
+                "port": {
+                    "description": "This parameter contains the network port where the CDM query server listens",
+                    "type": "integer",
+                    "minimum": 1025,
+                    "maximum": 32768
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "port"
+            ]
+        },
         "valkey": {
             "description": "The valkey object contains configuration settings for the valkey service",
             "type": "object",
@@ -80,6 +96,7 @@
     },
     "additionalProperties": false,
     "required": [
+        "cdm-server",
         "image-sourcing",
         "valkey"
     ]


### PR DESCRIPTION
## Summary
- Add `cdm-server.port` to `config/services.json` (default 3000) and `schema/services.json`
- Update `start_cdm_server`/`stop_cdm_server` in `bin/base` to read the port from services.json and pass `PORT` env var to the container
- Update `get_result_backend` and `crucible get metric` to pass `--server-url` with the configured port to the CDM CLI tools

The CDM `server.js` already supports the `PORT` env var (`const PORT = process.env.PORT || 3000`), so no CDM repo changes are needed.

Addresses user reports of port 3000 conflicts with other services on the host.

## Test plan
- [ ] Verify `crucible start cdm-server` uses the configured port
- [ ] Verify `crucible get result` and `crucible get metric` connect to the configured port
- [ ] Change port to a non-default value and verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)