### PR TITLE
feat: switch rickshaw scripts from Perl to Python

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -339,7 +339,7 @@ elif [ "${1}" == "run" ]; then
            image_sourcing_url="--source-images-service-url=${image_sourcing_url}"
     fi
 
-    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run"
+    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run${rickshaw_python_ext}"
     rs_run_cmd+=" ${params_args}"
     rs_run_cmd+=" --id ${SESSION_ID}"
     rs_run_cmd+=" --bench-dir $benchmark_subproj_dir"

--- a/bin/_main
+++ b/bin/_main
@@ -339,22 +339,22 @@ elif [ "${1}" == "run" ]; then
            image_sourcing_url="--source-images-service-url=${image_sourcing_url}"
     fi
 
-    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run\
-      ${params_args}\
-      --id ${SESSION_ID}\
-      --bench-dir $benchmark_subproj_dir\
-      --engine-dir=${CRUCIBLE_HOME}/subprojects/core/engine\
-      --roadblock-dir=${CRUCIBLE_HOME}/subprojects/core/roadblock\
-      --roadblock-password=$roadblock_password\
-      --workshop-dir=${CRUCIBLE_HOME}/subprojects/core/workshop\
-      --packrat-dir=${CRUCIBLE_HOME}/subprojects/core/packrat\
-      --tools-dir=${CRUCIBLE_HOME}/subprojects/tools\
-      --registries-json=${REGISTRIES_CFG}\
-      --base-run-dir=$base_run_dir\
-      --external-userenvs-dir=${CRUCIBLE_HOME}/subprojects/userenvs\
-      --workshop-script=workshop.py\
-      ${image_sourcing_url}\
-      ${rickshaw_run_args[@]}"
+    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run"
+    rs_run_cmd+=" ${params_args}"
+    rs_run_cmd+=" --id ${SESSION_ID}"
+    rs_run_cmd+=" --bench-dir $benchmark_subproj_dir"
+    rs_run_cmd+=" --engine-dir=${CRUCIBLE_HOME}/subprojects/core/engine"
+    rs_run_cmd+=" --roadblock-dir=${CRUCIBLE_HOME}/subprojects/core/roadblock"
+    rs_run_cmd+=" --roadblock-password=$roadblock_password"
+    rs_run_cmd+=" --workshop-dir=${CRUCIBLE_HOME}/subprojects/core/workshop"
+    rs_run_cmd+=" --packrat-dir=${CRUCIBLE_HOME}/subprojects/core/packrat"
+    rs_run_cmd+=" --tools-dir=${CRUCIBLE_HOME}/subprojects/tools"
+    rs_run_cmd+=" --registries-json=${REGISTRIES_CFG}"
+    rs_run_cmd+=" --base-run-dir=$base_run_dir"
+    rs_run_cmd+=" --external-userenvs-dir=${CRUCIBLE_HOME}/subprojects/userenvs"
+    rs_run_cmd+=" --workshop-script=workshop.py"
+    rs_run_cmd+=" ${image_sourcing_url}"
+    rs_run_cmd+=" ${rickshaw_run_args[@]}"
 
     echo "rickshaw-run command: $rs_run_cmd"
 

--- a/bin/_main
+++ b/bin/_main
@@ -104,7 +104,6 @@ elif [ "${1}" == "get" ]; then
             EXIT_VAL=$?
         elif [ "${1}" == "metric" ]; then
             shift
-            local cdm_server_port
             cdm_server_port=$(jq_query ${SERVICES_CFG} '."cdm-server".port')
             cdm_query_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/get-metric-data.sh --server-url http://localhost:${cdm_server_port}/api/v1/metric-data $@"
             ${podman_run} --name crucible-get-metric-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_query_cmd}

--- a/bin/base
+++ b/bin/base
@@ -4,6 +4,9 @@
 
 EC_FAIL_USER=2
 
+# To revert rickshaw scripts to Perl, change ".py" to ""
+rickshaw_python_ext=".py"
+
 function exit_error() {
     echo "ERROR: ${1}"
     shift
@@ -547,9 +550,9 @@ function post_process_run() {
     echo "Benchmark result is in ${RUN_DIR}"
     shift
 
-    rs_pp_b_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-bench"
+    rs_pp_b_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-bench${rickshaw_python_ext}"
     rs_pp_b_cmd+=" --base-run-dir=${RUN_DIR}"
-    rs_pp_t_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-tools"
+    rs_pp_t_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-tools${rickshaw_python_ext}"
     rs_pp_t_cmd+=" --base-run-dir=${RUN_DIR}"
 
     post_process_fail=0
@@ -604,7 +607,7 @@ function index_run() {
     fi
 
     # Generate the CDM documents
-    gen_docs_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-gen-docs"
+    gen_docs_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-gen-docs${rickshaw_python_ext}"
     gen_docs_cmd+=" --base-run-dir=${RUN_DIR} ${cdmver_opt}"
     echo "Generating CDM documents with ${gen_docs_cmd}"
     ${podman_run}\

--- a/bin/base
+++ b/bin/base
@@ -547,10 +547,10 @@ function post_process_run() {
     echo "Benchmark result is in ${RUN_DIR}"
     shift
 
-    rs_pp_b_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-bench\
-      --base-run-dir=${RUN_DIR}"
-    rs_pp_t_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-tools\
-      --base-run-dir=${RUN_DIR}"
+    rs_pp_b_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-bench"
+    rs_pp_b_cmd+=" --base-run-dir=${RUN_DIR}"
+    rs_pp_t_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-tools"
+    rs_pp_t_cmd+=" --base-run-dir=${RUN_DIR}"
 
     post_process_fail=0
     echo "Post-processing benchmark data with $rs_pp_b_cmd"
@@ -604,14 +604,16 @@ function index_run() {
     fi
 
     # Generate the CDM documents
+    gen_docs_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-gen-docs"
+    gen_docs_cmd+=" --base-run-dir=${RUN_DIR} ${cdmver_opt}"
+    echo "Generating CDM documents with ${gen_docs_cmd}"
     ${podman_run}\
         --name crucible-rickshaw-gen-docs-${SESSION_ID}\
         "${container_common_args[@]}"\
         "${container_rs_args[@]}"\
         "${container_non_service_args[@]}"\
         ${CRUCIBLE_CONTROLLER_IMAGE}\
-        ${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-gen-docs\
-        --base-run-dir=${RUN_DIR} ${cdmver_opt}
+        ${gen_docs_cmd}
     RC=$?
     if [ ${RC} == 0 ]; then
         echo "Opensearch documents have been created"
@@ -621,13 +623,16 @@ function index_run() {
     fi
 
     # Index the documents
+    index_docs_cmd="${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/add-run.sh"
+    index_docs_cmd+=" --dir ${RUN_DIR}/run/opensearch"
+    index_docs_cmd+=" ${access_opt}"
+    echo "Indexing CDM documents with ${index_docs_cmd}"
     ${podman_run}\
         --name crucible-cdm-index-${SESSION_ID}\
         "${container_common_args[@]}"\
         "${container_non_service_args[@]}"\
         ${CRUCIBLE_CONTROLLER_IMAGE}\
-        ${CRUCIBLE_HOME}/subprojects/core/CommonDataModel/queries/cdmq/add-run.sh\
-        --dir ${RUN_DIR}/run/opensearch $access_opt
+        ${index_docs_cmd}
     RC=$?
     if [ ${RC} == 0 ]; then
         echo "Benchmark result now in OpenSearch, using ${access_opt} $cdmver_opt" | sed -e 's/--userpass\s\S*\s//'

--- a/bin/repo
+++ b/bin/repo
@@ -99,7 +99,7 @@ function repo_info() {
         echo "ERROR: Failed to pushd to ${dir}"
     fi
 
-    printf "${fmt_line}\n" "${name}" "${type}" "${git_local_branch}" "${git_remote_url}" "${git_remote_branch}" "${git_remote_name}" "${local_changes}" "${current_commit}" "${updates_available}"
+    repo_info_rows+="${name}"$'\x1f'"${type}"$'\x1f'"${git_local_branch}"$'\x1f'"${git_remote_url}"$'\x1f'"${git_remote_branch}"$'\x1f'"${git_remote_name}"$'\x1f'"${local_changes}"$'\x1f'"${current_commit}"$'\x1f'"${updates_available}"$'\n'
 }
 
 function repo_details() {
@@ -211,8 +211,7 @@ function handle_scope() {
 }
 
 function config_show() {
-    fmt_line="%-20s  %-15s  %-13s  %-60s  %-20s  %-20s  %-20s"
-    printf "${fmt_line}\n" "Project Family" "Project Name" "Project Type" "Git Remote URL" "Primary Branch" "Checkout Mode" "Checkout Target"
+    local config_rows="Project Family"$'\x1f'"Project Name"$'\x1f'"Project Type"$'\x1f'"Git Remote URL"$'\x1f'"Primary Branch"$'\x1f'"Checkout Mode"$'\x1f'"Checkout Target"$'\n'
 
     for family in official unofficial; do
         projects=$(jq_query ${CRUCIBLE_HOME}/config/repos.json --arg family ${family} '.[$family][] | .name')
@@ -223,9 +222,11 @@ function config_show() {
             project_checkout_mode=$(jq_query ${CRUCIBLE_HOME}/config/repos.json --arg family ${family} --arg project_name ${project} '.[$family][] | select(.name == $project_name) | .checkout.mode')
             project_checkout_target=$(jq_query ${CRUCIBLE_HOME}/config/repos.json --arg family ${family} --arg project_name ${project} '.[$family][] | select(.name == $project_name) | .checkout.target')
 
-            printf "${fmt_line}\n" "${family}" "${project}" "${project_type}" "${project_repository}" "${project_primary_branch}" "${project_checkout_mode}" "${project_checkout_target}"
+            config_rows+="${family}"$'\x1f'"${project}"$'\x1f'"${project_type}"$'\x1f'"${project_repository}"$'\x1f'"${project_primary_branch}"$'\x1f'"${project_checkout_mode}"$'\x1f'"${project_checkout_target}"$'\n'
         done
     done
+
+    printf "%s" "${config_rows}" | column -t -s$'\x1f'
 }
 
 function subprojects_install() {
@@ -535,10 +536,11 @@ case "${command}" in
 
         case "${command}" in
             info)
-                fmt_line="%-15s  %-13s  %-16s  %-60s  %-17s  %-15s  %-13s  %-14s  %-13s"
-                printf "${fmt_line}\n" "Project Name" "Project Type" "Git Local Branch" "Git Remote URL" "Git Remote Branch" "Git Remote Name" "Local Changes" "Current Commit" "Updates"
+                repo_info_rows="Project Name"$'\x1f'"Project Type"$'\x1f'"Git Local Branch"$'\x1f'"Git Remote URL"$'\x1f'"Git Remote Branch"$'\x1f'"Git Remote Name"$'\x1f'"Local Changes"$'\x1f'"Current Commit"$'\x1f'"Updates"$'\n'
 
                 handle_scope info ${scope}
+
+                printf "%s" "${repo_info_rows}" | column -t -s$'\x1f'
                 ;;
             details)
                 handle_scope details ${scope}


### PR DESCRIPTION
## Summary
- Use += for multi-line command string building to avoid whitespace in printed output
- Switch rickshaw scripts (rickshaw-run, post-process-bench, post-process-tools, gen-docs) from Perl to Python via `rickshaw_python_ext` variable in bin/base — revertible by changing one line
- Auto-size column widths in `crucible repo info` and `crucible repo config show` using `column -t`
- Fix invalid `local` declaration in top-level elif block in bin/_main

The Python versions of the rickshaw scripts were merged in perftool-incubator/rickshaw#804. This PR enables them from the crucible side.

## Test plan
- [x] End-to-end tested with fio (3 iterations, random test order) and uperf+iperf (multi-benchmark, 4 clients/servers)
- [ ] CI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)