### PR TITLE
feat: make httpd port configurable and add port logging to services

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -171,27 +171,33 @@ function generate_rand_pass() {
 }
 
 function start_httpd() {
-    local RC httpd_cmd
+    local RC httpd_cmd httpd_port
+
+    httpd_port=$(jq_query ${SERVICES_CFG} '.httpd.port')
+
     httpd_cmd="/usr/sbin/httpd -DFOREGROUND"
     echo -n "Checking for httpd"
     if ! podman_running crucible-httpd; then
-        open_firewall_port 8080 tcp
-        ${podman_run} --name crucible-httpd "${container_common_args[@]}" "${container_httpd_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${httpd_cmd} > /dev/null
+        open_firewall_port ${httpd_port} tcp
+        ${podman_run} --name crucible-httpd --env "HTTPD_PORT=${httpd_port}" "${container_common_args[@]}" "${container_httpd_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${httpd_cmd} > /dev/null
         RC=$?
         if [ ${RC} != 0 ]; then
             echo "ERROR: Could not start httpd"
         else
-            echo "Successfully started httpd"
+            echo "Successfully started httpd on port ${httpd_port}"
         fi
     fi
     return ${RC}
 }
 
 function stop_httpd() {
-    local RC=0
+    local RC=0 httpd_port
+
+    httpd_port=$(jq_query ${SERVICES_CFG} '.httpd.port')
+
     echo -n "Checking for httpd"
     if podman_running crucible-httpd; then
-        close_firewall_port 8080 tcp
+        close_firewall_port ${httpd_port} tcp
         ${podman_stop} crucible-httpd > /dev/null
         RC=$?
         if [ ${RC} != 0 ]; then
@@ -316,7 +322,7 @@ function start_image_sourcing() {
                 echo "ERROR: image-sourcing service failed to launch properly"
                 RC=1
             else
-                echo "Successfully started image-sourcing service"
+                echo "Successfully started image-sourcing service on port ${image_sourcing_port}"
                 RC=0
             fi
         fi

--- a/config/httpd/conf/httpd.conf
+++ b/config/httpd/conf/httpd.conf
@@ -42,7 +42,7 @@ ServerRoot "/etc/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 8080
+Listen ${HTTPD_PORT}
 
 #
 # Dynamic Shared Object (DSO) Support

--- a/config/services.json
+++ b/config/services.json
@@ -2,6 +2,9 @@
     "cdm-server": {
         "port": 3000
     },
+    "httpd": {
+        "port": 8080
+    },
     "image-sourcing": {
         "use": true,
         "start": true,

--- a/schema/services.json
+++ b/schema/services.json
@@ -69,6 +69,22 @@
                 "port"
             ]
         },
+        "httpd": {
+            "description": "The httpd object contains configuration settings for the Apache HTTP server",
+            "type": "object",
+            "properties": {
+                "port": {
+                    "description": "This parameter contains the network port where the HTTP server listens",
+                    "type": "integer",
+                    "minimum": 1025,
+                    "maximum": 32768
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "port"
+            ]
+        },
         "valkey": {
             "description": "The valkey object contains configuration settings for the valkey service",
             "type": "object",
@@ -97,6 +113,7 @@
     "additionalProperties": false,
     "required": [
         "cdm-server",
+        "httpd",
         "image-sourcing",
         "valkey"
     ]


### PR DESCRIPTION
## Summary
- Add `httpd.port` to `config/services.json` (default 8080) with schema validation
- Update `config/httpd/conf/httpd.conf` to use `${HTTPD_PORT}` env var instead of hardcoded `Listen 8080`
- Pass `HTTPD_PORT` env var to the httpd container
- Use configured port for httpd firewall open/close
- Add startup port logging to httpd and image-sourcing services

All user-facing services now report their port on startup:
```
Successfully started httpd on port 8080
Successfully started CDM server on port 3000
Successfully started image-sourcing service on port 8888
```

Opensearch and valkey ports are intentionally not configurable via services.json — opensearch is managed through `instances.json`, and valkey's port is hardcoded in roadblock and endpoint code.

## Test plan
- [x] `crucible start all` / `crucible stop all` — all services start and stop cleanly
- [x] Schema validation passes
- [ ] CI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)