### PR TITLE
fix: restore Fedora 44 and python3-pip changes

### DIFF
--- a/workshop/crucible-controller-requirements.json
+++ b/workshop/crucible-controller-requirements.json
@@ -14,7 +14,7 @@
         "core-utils",
         "build-libraries",
         "build-tools",
-        "python39",
+        "python3-pip",
         "valkey",
         "redis-compat",
         "container-tools",
@@ -65,11 +65,10 @@
       }
     },
     {
-      "name": "python39",
+      "name": "python3-pip",
       "type": "distro",
       "distro_info": {
         "packages": [
-          "python39",
           "python3-pip"
         ]
       }

--- a/workshop/crucible-controller-userenv.json
+++ b/workshop/crucible-controller-userenv.json
@@ -6,10 +6,10 @@
   },
   "userenv": {
     "name": "crucible-controller",
-    "label": "Fedora 43",
+    "label": "Fedora 44",
     "origin": {
       "image": "registry.fedoraproject.org/fedora",
-      "tag": "43"
+      "tag": "44"
     },
     "properties": {
       "platform": [


### PR DESCRIPTION
## Summary
- Reverts the DO_NOT_MERGE commit that was accidentally included in PR #576
- Restores the Fedora 43 → 44 upgrade in the controller userenv
- Restores the python39 → python3-pip change in controller requirements

## Test plan
- [ ] Controller image builds successfully
- [ ] All services start (especially OpenSearch)
- [ ] Benchmark run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)