### PR TITLE
feat: add --set-release to installer for switching between releases

### DIFF
--- a/crucible-install.sh
+++ b/crucible-install.sh
@@ -16,6 +16,8 @@ DEFAULT_QUAY_EXPIRATION_LENGTH="13w"
 GIT_REPO=""
 GIT_BRANCH=""
 GIT_TAG=""
+SET_RELEASE=""
+SET_RELEASE_FORCE=0
 VERBOSE=0
 
 # User Exit Codes
@@ -38,6 +40,9 @@ EC_RELEASE_DEFAULT_REPO_ONLY=18
 EC_RELEASE_CONFLICTS_WITH_BRANCH=19
 EC_INVALID_QUAY_EXPIRATION_LENGTH=20
 EC_OAUTH_FILE_NOT_FOUND=21
+EC_SET_RELEASE_NO_INSTALL=22
+EC_SET_RELEASE_NOT_FOUND=23
+EC_SET_RELEASE_CHECKOUT_FAIL=24
 
 # remove a previous installation log
 if [ -e ${GIT_INSTALL_LOG} ]; then
@@ -150,11 +155,12 @@ function usage {
     Crucible installer script.
 
     Usage: $0 --engine-registry <value> [ opt ]
+           $0 --set-release <release|upstream|select> [--set-release-force]
+
+    Install mode (new installation):
 
         --engine-registry <full registry url>
-        Engine registry.
-
-    optional:
+        Engine registry (required for install).
 
         --quay-engine-expiration-refresh-token <authentication file>>
         Quay OAuth authentication token file for refreshing engine image expiration timestamps.
@@ -167,7 +173,7 @@ function usage {
 
         --engine-auth-file <authentication file>
         Authentication file for pushing images to the remote registry.
-  
+
         --engine-tls-verify true|false
         Use TLS verification.
 
@@ -190,8 +196,20 @@ function usage {
 	--verbose
         Verbose mode that provides more debugging info.
 
+    Release management (existing installation):
+
+        --set-release <release|upstream|select>
+        Switch an existing installation to a specific quarterly release or
+        back to upstream. Use 'select' for interactive release selection.
+
+        --set-release-force
+        Allow switching to unsupported (older) releases.
+        Use with --set-release.
+
+    General:
+
 	--list-releases
-        Show all available releases from the remote repository.
+        Show available releases from the remote repository.
 
     --help
     Displays this usage output.
@@ -202,13 +220,16 @@ _USAGE_
 # list available "supported" branches from the remote repository
 # the "supported" releases are the 4 most recent ones
 function list_releases {
-    # only default repo is supported for the release mechanism
+    local repo_url="${1:-https://github.com/perftool-incubator/crucible.git}"
     git ls-remote --heads \
         --sort='version:refname' \
-        https://github.com/perftool-incubator/crucible.git \
+        "${repo_url}" \
         | awk -F/ '{print$NF}' \
-        | grep -E '20[0-9]{2}\.[1234]' \
-        | tail -n 4
+        | grep -E '20[0-9]{2}\.[1234]'
+}
+
+function list_supported_releases {
+    list_releases "$@" | tail -n 4
 }
 
 # cleanup previous installation
@@ -286,7 +307,7 @@ function select_release {
     if [ "$release" == "select" ]; then
 	echo
         echo "Releases:"
-        releases=( $(list_releases) )
+        releases=( $(list_supported_releases) )
 
         numopt=${#releases[@]}
         if [ $numopt -eq 0 ]; then
@@ -306,6 +327,309 @@ function select_release {
         fi
     fi
     GIT_TAG="$release"
+}
+
+function set_release {
+    local release="${1}"
+    local force=${2}
+
+    if [ "${release}" == "--help" -o "${release}" == "help" ]; then
+        echo "Usage: crucible-install.sh --set-release [<release>|upstream|select]"
+        echo ""
+        echo "Switch an existing installation to a specific release or back to upstream."
+        echo ""
+        echo "  <release>   A quarterly release identifier (e.g., 2026.1)"
+        echo "  upstream    Switch back to following primary branches (rolling/dev mode)"
+        echo "  select      Interactive release selection"
+        echo "  --set-release-force  Allow unsupported (older) releases"
+        exit 0
+    fi
+
+    if [ "${release}" != "upstream" -a "${release}" != "select" ]; then
+        if ! echo "${release}" | grep -qE '^20[0-9]{2}\.[1234]$'; then
+            exit_error "'${release}' is not a valid release identifier (expected format: YYYY.Q, e.g., 2025.3)" ${EC_SET_RELEASE_NOT_FOUND}
+        fi
+    fi
+
+    if [ ! -e "${SYSCONFIG}" ]; then
+        exit_error "No existing crucible installation found (${SYSCONFIG} does not exist). Use a regular install instead." ${EC_SET_RELEASE_NO_INSTALL}
+    fi
+
+    source "${SYSCONFIG}"
+
+    if [ -z "${CRUCIBLE_HOME}" -o ! -d "${CRUCIBLE_HOME}" ]; then
+        exit_error "CRUCIBLE_HOME is not set or does not exist. Use a regular install instead." ${EC_SET_RELEASE_NO_INSTALL}
+    fi
+
+    local repos_json="${CRUCIBLE_HOME}/config/repos.json"
+
+    if [ ! -e "${repos_json}" ]; then
+        exit_error "repos.json not found at ${repos_json}. Installation may be corrupt." ${EC_SET_RELEASE_NO_INSTALL}
+    fi
+
+    source "${CRUCIBLE_HOME}/bin/jqlib"
+
+    local crucible_repo_url
+    crucible_repo_url=$(jq_query ${repos_json} '.official[] | select(.name == "crucible") | .repository')
+
+    if [ "${release}" == "upstream" ]; then
+        set_release_upstream "${repos_json}" "${crucible_repo_url}"
+        return $?
+    fi
+
+    if [ "${release}" == "select" ]; then
+        echo
+        echo "Releases:"
+        local releases
+        releases=( $(list_supported_releases "${crucible_repo_url}") )
+
+        local numopt=${#releases[@]}
+        if [ ${numopt} -eq 0 ]; then
+            exit_error "No available releases found." ${EC_SET_RELEASE_NOT_FOUND}
+        fi
+
+        PS3="Select release option # [1-${numopt}]: "
+        select release in ${releases[@]}; do
+            echo ${releases[@]} | grep -w -q "$release"
+            if [ $? -eq 0 ]; then
+                echo "Release '$REPLY) $release' has been selected."
+            else
+                echo "Invalid option '$REPLY'!"
+                exit 1
+            fi
+            break
+        done
+    fi
+
+    set_release_quarterly "${repos_json}" "${crucible_repo_url}" "${release}" ${force}
+}
+
+function stop_crucible_services {
+    if podman ps --format "{{.Names}}" 2>/dev/null | grep -q "crucible-logger"; then
+        exit_error "A crucible command is currently running (logger pod detected). Please wait for it to finish before switching releases." ${EC_SET_RELEASE_CHECKOUT_FAIL}
+    fi
+
+    local crucible_pods
+    crucible_pods=$(podman ps --format "{{.Names}}" 2>/dev/null | grep "crucible-" || true)
+    if [ -n "${crucible_pods}" ]; then
+        echo "Stopping crucible services..."
+        echo "${crucible_pods}" | while read pod; do
+            echo "  Stopping ${pod}..."
+            podman stop "${pod}" 2>/dev/null || true
+        done
+    fi
+}
+
+function set_release_quarterly {
+    local repos_json="${1}"
+    local crucible_repo_url="${2}"
+    local release="${3}"
+    local force=${4}
+
+    echo "Querying available releases from ${crucible_repo_url}..."
+    local all_releases
+    all_releases=$(list_releases "${crucible_repo_url}")
+
+    if [ -z "${all_releases}" ]; then
+        exit_error "No releases found on remote ${crucible_repo_url}" ${EC_SET_RELEASE_NOT_FOUND}
+    fi
+
+    local supported_releases
+    supported_releases=$(echo "${all_releases}" | tail -n 4)
+    local unsupported_releases
+    unsupported_releases=$(echo "${all_releases}" | head -n -4)
+
+    if ! echo "${all_releases}" | grep -qw "${release}"; then
+        echo "ERROR: Release '${release}' does not exist on the crucible remote"
+        echo "       Supported releases:   $(echo ${supported_releases} | tr '\n' ' ')"
+        if [ -n "${unsupported_releases}" ]; then
+            echo "       Unsupported releases: $(echo ${unsupported_releases} | tr '\n' ' ')"
+        fi
+        exit ${EC_SET_RELEASE_NOT_FOUND}
+    fi
+
+    if [ ${force} -eq 0 ]; then
+        if ! echo "${supported_releases}" | grep -qw "${release}"; then
+            echo "ERROR: Release '${release}' is not a supported release"
+            echo "       Supported releases:   $(echo ${supported_releases} | tr '\n' ' ')"
+            if [ -n "${unsupported_releases}" ]; then
+                echo "       Unsupported releases: $(echo ${unsupported_releases} | tr '\n' ' ')"
+            fi
+            echo "       Use --set-release-force to override this check"
+            exit ${EC_SET_RELEASE_NOT_FOUND}
+        fi
+    fi
+
+    stop_crucible_services
+
+    echo "Saving local repo configuration..."
+    local unofficial_repos
+    unofficial_repos=$(jq '.unofficial' ${repos_json})
+    local repo_urls
+    repo_urls=$(jq '[.official[] | {(.name): .repository}] | add' ${repos_json})
+
+    local original_ref
+    original_ref=$(git -C ${CRUCIBLE_HOME} rev-parse HEAD)
+    local repos_json_bak="${repos_json}.set-release-bak.$$"
+    cp ${repos_json} ${repos_json_bak}
+
+    echo "Switching crucible to release ${release}..."
+    local did_stash=0
+    if pushd ${CRUCIBLE_HOME} > /dev/null; then
+        if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet HEAD 2>/dev/null; then
+            :
+        else
+            git reset HEAD -- . 2>/dev/null || true
+        fi
+
+        if git stash --include-untracked 2>&1 | grep -q "Saved working directory"; then
+            did_stash=1
+        fi
+
+        git fetch origin
+
+        if ! git -c advice.detachedHead=false checkout ${release}; then
+            echo "ERROR: Failed to checkout release '${release}' for crucible"
+            if [ ${did_stash} -eq 1 ]; then
+                git stash pop 2>&1 || true
+            fi
+            mv ${repos_json_bak} ${repos_json}
+            popd > /dev/null
+            exit ${EC_SET_RELEASE_CHECKOUT_FAIL}
+        fi
+
+        local release_repos_json="${repos_json}.release.$$"
+        cp ${repos_json} ${release_repos_json}
+
+        if [ ${did_stash} -eq 1 ]; then
+            git stash pop 2>&1 || true
+            cp ${release_repos_json} ${repos_json}
+        fi
+        rm -f ${release_repos_json}
+
+        popd > /dev/null
+    fi
+
+    echo "Restoring local repo configuration..."
+    jq --indent 4 --argjson unofficial "${unofficial_repos}" --argjson urls "${repo_urls}" \
+        '.unofficial = $unofficial |
+         .official = [.official[] | if $urls[.name] then .repository = $urls[.name] else . end]' \
+        ${repos_json} > ${repos_json}.tmp \
+        && mv ${repos_json}.tmp ${repos_json}
+
+    echo "Updating checkout configuration for all official repos..."
+    jq --indent 4 --arg release "${release}" \
+        '(.official[] | .checkout.target) |= $release |
+         (.official[] | .checkout.mode) |= "locked"' \
+        ${repos_json} > ${repos_json}.tmp \
+        && mv ${repos_json}.tmp ${repos_json}
+
+    echo "Updating subprojects..."
+    if ! ${CRUCIBLE_HOME}/bin/subprojects-install; then
+        echo "ERROR: subprojects-install failed, rolling back..."
+        if pushd ${CRUCIBLE_HOME} > /dev/null; then
+            git -c advice.detachedHead=false checkout ${original_ref} 2>&1 || true
+            popd > /dev/null
+        fi
+        mv ${repos_json_bak} ${repos_json}
+        exit ${EC_SET_RELEASE_CHECKOUT_FAIL}
+    fi
+
+    rm -f ${repos_json_bak}
+
+    echo ""
+    echo "Successfully switched crucible installation to release ${release}"
+}
+
+function set_release_upstream {
+    local repos_json="${1}"
+    local crucible_repo_url="${2}"
+
+    local crucible_primary_branch
+    crucible_primary_branch=$(jq_query ${repos_json} '.official[] | select(.name == "crucible") | ."primary-branch"')
+
+    stop_crucible_services
+
+    echo "Saving local repo configuration..."
+    local unofficial_repos
+    unofficial_repos=$(jq '.unofficial' ${repos_json})
+    local repo_urls
+    repo_urls=$(jq '[.official[] | {(.name): .repository}] | add' ${repos_json})
+
+    local original_ref
+    original_ref=$(git -C ${CRUCIBLE_HOME} rev-parse HEAD)
+    local repos_json_bak="${repos_json}.set-release-bak.$$"
+    cp ${repos_json} ${repos_json_bak}
+
+    echo "Switching crucible to ${crucible_primary_branch} (upstream)..."
+    local did_stash=0
+    if pushd ${CRUCIBLE_HOME} > /dev/null; then
+        if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet HEAD 2>/dev/null; then
+            :
+        else
+            git reset HEAD -- . 2>/dev/null || true
+        fi
+
+        if git stash --include-untracked 2>&1 | grep -q "Saved working directory"; then
+            did_stash=1
+        fi
+
+        git fetch origin
+
+        if ! git checkout ${crucible_primary_branch}; then
+            echo "ERROR: Failed to checkout '${crucible_primary_branch}' for crucible"
+            if [ ${did_stash} -eq 1 ]; then
+                git stash pop 2>&1 || true
+            fi
+            mv ${repos_json_bak} ${repos_json}
+            popd > /dev/null
+            exit ${EC_SET_RELEASE_CHECKOUT_FAIL}
+        fi
+
+        if ! git pull --ff-only; then
+            echo "WARNING: Failed to fast-forward ${crucible_primary_branch}, continuing with current state"
+        fi
+
+        local release_repos_json="${repos_json}.release.$$"
+        cp ${repos_json} ${release_repos_json}
+
+        if [ ${did_stash} -eq 1 ]; then
+            git stash pop 2>&1 || true
+            cp ${release_repos_json} ${repos_json}
+        fi
+        rm -f ${release_repos_json}
+
+        popd > /dev/null
+    fi
+
+    echo "Restoring local repo configuration..."
+    jq --indent 4 --argjson unofficial "${unofficial_repos}" --argjson urls "${repo_urls}" \
+        '.unofficial = $unofficial |
+         .official = [.official[] | if $urls[.name] then .repository = $urls[.name] else . end]' \
+        ${repos_json} > ${repos_json}.tmp \
+        && mv ${repos_json}.tmp ${repos_json}
+
+    echo "Resetting checkout configuration to follow mode..."
+    jq --indent 4 \
+        '.official = [.official[] | .checkout.target = ."primary-branch" | .checkout.mode = "follow"]' \
+        ${repos_json} > ${repos_json}.tmp \
+        && mv ${repos_json}.tmp ${repos_json}
+
+    echo "Updating subprojects..."
+    if ! ${CRUCIBLE_HOME}/bin/subprojects-install; then
+        echo "ERROR: subprojects-install failed, rolling back..."
+        if pushd ${CRUCIBLE_HOME} > /dev/null; then
+            git -c advice.detachedHead=false checkout ${original_ref} 2>&1 || true
+            popd > /dev/null
+        fi
+        mv ${repos_json_bak} ${repos_json}
+        exit ${EC_SET_RELEASE_CHECKOUT_FAIL}
+    fi
+
+    rm -f ${repos_json_bak}
+
+    echo ""
+    echo "Successfully switched crucible installation to upstream (${crucible_primary_branch})"
 }
 
 function update_repos_config() {
@@ -375,11 +699,23 @@ longopts="name:,email:,help,list-releases,verbose"
 longopts+=",client-server-registry:,client-server-auth-file:,client-server-tls-verify:"
 longopts+=",engine-registry:,engine-auth-file:,engine-tls-verify:,quay-engine-expiration-length:"
 longopts+=",quay-engine-expiration-refresh-token:,quay-engine-expiration-refresh-api-url:"
-longopts+=",controller-registry:,git-repo:,git-branch:,release:"
+longopts+=",controller-registry:,git-repo:,git-branch:,release:,set-release:,set-release-force"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "$0" -- "$@");
 if [ $? -ne 0 ]; then
-    opts=$(echo "$@")
-    exit_error "Unrecognized option specified: ${opts}" ${EC_INVALID_OPTION}
+    if echo "$@" | grep -qw -- "--set-release"; then
+        echo "Usage: crucible-install.sh --set-release [<release>|upstream|select]"
+        echo ""
+        echo "Switch an existing installation to a specific release or back to upstream."
+        echo ""
+        echo "  <release>   A quarterly release identifier (e.g., 2026.1)"
+        echo "  upstream    Switch back to following primary branches (rolling/dev mode)"
+        echo "  select      Interactive release selection"
+        echo "  --set-release-force  Allow unsupported (older) releases"
+        exit 1
+    else
+        opts=$(echo "$@")
+        exit_error "Unrecognized option specified: ${opts}" ${EC_INVALID_OPTION}
+    fi
 fi
 eval set -- "$opts";
 while true; do
@@ -450,7 +786,7 @@ while true; do
             ;;
         --list-releases)
 	    shift;
-	    list_releases
+	    list_supported_releases
 	    exit
 	    ;;
 	--release)
@@ -458,6 +794,15 @@ while true; do
 	    select_release "$1"
 	    shift;
 	    ;;
+        --set-release)
+            shift;
+            SET_RELEASE="$1"
+            shift;
+            ;;
+        --set-release-force)
+            shift;
+            SET_RELEASE_FORCE=1
+            ;;
         --)
             shift;
             break;
@@ -478,6 +823,16 @@ if [ -n "${GIT_TAG}" ]; then
     if [ -n "${GIT_BRANCH}" ]; then
         exit_error "Cannot install from release and specify '--git-branch'." $EC_RELEASE_CONFLICTS_WITH_BRANCH
     fi
+fi
+
+# --set-release conflicts with install options
+if [ -n "${SET_RELEASE}" ]; then
+    if [ -n "${GIT_REPO}" -o -n "${GIT_BRANCH}" -o -n "${GIT_TAG}" ]; then
+        exit_error "Cannot use --set-release with --git-repo, --git-branch, or --release." $EC_INVALID_OPTION
+    fi
+
+    set_release "${SET_RELEASE}" ${SET_RELEASE_FORCE}
+    exit $?
 fi
 
 determine_git_install_source

--- a/tests/test-installer
+++ b/tests/test-installer
@@ -12,8 +12,8 @@ CRUCIBLE_DIR=$(pwd)
 GITHUB_RUNNER=1
 
 function start_test() {
-    local msg
-    msg="Test Number: $(( test_number += 1 ))"
+    local desc="${1}"
+    local msg="Test $(( test_number += 1 )): ${desc}"
     if [ ${GITHUB_RUNNER} -eq 1 ]; then
         echo "::group::${msg}"
     else
@@ -35,14 +35,12 @@ function stop_test() {
     fi
 }
 
-start_test
-# usage
+start_test "--help shows usage"
 stdout=$(./crucible-install.sh --help)
 [[ "$stdout" = *"Usage"* ]] || exit 1
 stop_test
 
-start_test
-# non-root
+start_test "non-root user rejected"
 ec=$(grep EC_FAIL_USER= crucible-install.sh | cut -d '=' -f2)
 ./crucible-install.sh \
   --git-repo ${CRUCIBLE_DIR} \
@@ -50,8 +48,7 @@ ec=$(grep EC_FAIL_USER= crucible-install.sh | cut -d '=' -f2)
 test "$?" = "$ec" || exit 1
 stop_test
 
-start_test
-# no args
+start_test "no engine registry specified"
 ec=$(grep EC_FAIL_REGISTRY_UNSET= crucible-install.sh | cut -d '=' -f2)
 sudo ./crucible-install.sh \
   --git-repo ${CRUCIBLE_DIR} \
@@ -60,9 +57,8 @@ test "$?" = "$ec" || exit 1
 stop_test
 
 for arg_mode in client-server engine; do
-    start_test
-    echo "testing arg_mode=${arg_mode}"
-    # auth file not found
+    start_test "auth file not found (${arg_mode})"
+    rm -f /tmp/auth-file.json
     ec=$(grep EC_AUTH_FILE_NOT_FOUND= crucible-install.sh | cut -d '=' -f2)
     sudo ./crucible-install.sh \
       --git-repo ${CRUCIBLE_DIR} \
@@ -73,8 +69,8 @@ for arg_mode in client-server engine; do
     stop_test
 done
 
-start_test
-# oauth file not found
+start_test "oauth file not found"
+rm -f /tmp/oauth-file.json
 ec=$(grep EC_OAUTH_FILE_NOT_FOUND= crucible-install.sh | cut -d '=' -f2)
 sudo ./crucible-install.sh \
      --git-repo ${CRUCIBLE_DIR} \
@@ -87,9 +83,7 @@ test "$?" = "$ec" || exit 1
 stop_test
 
 for arg_mode in client-server engine; do
-    start_test
-    echo "testing arg_mode=${arg_mode}"
-    # invalid tls verify value
+    start_test "invalid tls verify value (${arg_mode})"
     ec=$(grep EC_TLS_VERIFY_ERROR= crucible-install.sh | cut -d '=' -f2)
     sudo ./crucible-install.sh \
       --git-repo ${CRUCIBLE_DIR} \
@@ -100,8 +94,7 @@ for arg_mode in client-server engine; do
     stop_test
 done
 
-start_test
-# invalid quay expiration length
+start_test "invalid quay expiration length"
 touch /tmp/auth-file.json
 ec=$(grep EC_INVALID_QUAY_EXPIRATION_LENGTH= crucible-install.sh | cut -d '=' -f2)
 # TODO(rfolco): temporary workaround until we make it distro generic
@@ -115,9 +108,7 @@ test "$?" = "${ec}" || exit 1
 stop_test
 
 for arg_mode in client-server engine; do
-    start_test
-    echo "testing arg_mode=${arg_mode}"
-    # default args
+    start_test "install with default args (${arg_mode})"
     touch /tmp/auth-file.json
     cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
     regfile="/opt/crucible/config/registries.json"
@@ -136,12 +127,8 @@ for arg_mode in client-server engine; do
 done
 
 for arg_mode in client-server engine; do
-    start_test
-    echo "testing arg_mode=${arg_mode}"
-    # identity
+    start_test "install with identity (${arg_mode})"
     touch /tmp/auth-file.json
-    # Remove all previous installs
-    rm -rf /opt/crucible*
     cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
     idfile=$(grep IDENTITY= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
     # TODO(rfolco): temporary workaround until we make it distro generic
@@ -159,9 +146,7 @@ for arg_mode in client-server engine; do
 done
 
 for arg_mode in client-server engine; do
-    start_test
-    echo "testing arg_mode=${arg_mode}"
-    # override existing installation
+    start_test "override existing installation (${arg_mode})"
     touch /tmp/auth-file.json
     cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
     # TODO(rfolco): temporary workaround until we make it distro generic
@@ -176,8 +161,7 @@ for arg_mode in client-server engine; do
     stop_test
 done
 
-start_test
-# override existing installation
+start_test "override existing installation with quay expiration"
 touch /tmp/auth-file.json
 touch /tmp/oauth-file.json
 cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
@@ -195,9 +179,7 @@ ls -ld /opt/crucible-moved* || exit 1
 stop_test
 
 for arg_mode in client-server engine; do
-    start_test
-    echo "testing arg_mode=${arg_mode}"
-    # override existing installation, no auth-file arg
+    start_test "override existing installation, no auth-file (${arg_mode})"
     cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
     # TODO(rfolco): temporary workaround until we make it distro generic
     sudo mkdir -p $(dirname $cfgfile)
@@ -210,9 +192,7 @@ for arg_mode in client-server engine; do
     stop_test
 done
 
-start_test
-# RELEASE: --release and --list-releases
-## prep step: check branches in remote repo
+start_test "release: query available releases"
 releases=$(git ls-remote --heads \
                --sort='version:refname' \
                https://github.com/perftool-incubator/crucible.git \
@@ -221,8 +201,7 @@ releases=$(git ls-remote --heads \
                | tail -n 4)
 stop_test
 
-start_test
-## show releases, test rc and stdout
+start_test "release: --list-releases output matches"
 stdout=$(sudo ./crucible-install.sh \
     --git-repo ${CRUCIBLE_DIR} \
     --list-releases)
@@ -232,9 +211,7 @@ stop_test
 
 for arg_mode in client-server engine; do
     for release in $releases; do
-        start_test
-        echo "testing arg_mode=${arg_mode} release=${release}"
-        # install existing release with current installer
+        start_test "release: install ${release} (${arg_mode})"
         touch /tmp/auth-file.json
         cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
         # TODO(rfolco): temporary workaround until we make it distro generic
@@ -251,8 +228,7 @@ for arg_mode in client-server engine; do
     done
 done
 
-start_test
-## negative test: --release and --git-repo
+start_test "release: --release conflicts with --git-repo"
 ec=$(grep EC_RELEASE_DEFAULT_REPO_ONLY= crucible-install.sh | cut -d '=' -f2)
 sudo ./crucible-install.sh \
     --release DoesNotMatter --git-repo DoesNotMatter \
@@ -260,8 +236,7 @@ sudo ./crucible-install.sh \
 test "$?" = "$ec" || exit 1
 stop_test
 
-start_test
-## negative test: --release and --git-branch
+start_test "release: --release conflicts with --git-branch"
 ec=$(grep EC_RELEASE_CONFLICTS_WITH_BRANCH= crucible-install.sh | cut -d '=' -f2)
 sudo ./crucible-install.sh \
     --release DoesNotMatter --git-branch DoesNotMatter \
@@ -269,8 +244,7 @@ sudo ./crucible-install.sh \
 test "$?" = "$ec" || exit 1
 stop_test
 
-start_test
-## negative test: non-existent release
+start_test "release: non-existent release rejected"
 # for this test we cannot use --git-repo (because it's not allowed in
 # conjunction with --release) so we have to "hack" DEFAULT_GIT_REPO to
 # point where we need it to
@@ -282,4 +256,146 @@ sudo ./crucible-install.sh \
     --client-server-registry myregistry.io/crucible \
     --verbose
 test "$?" = "$ec" || exit 1
+stop_test
+
+#
+# SET-RELEASE tests
+#
+
+# query available releases for use in tests
+all_releases=$(git ls-remote --heads \
+                   --sort='version:refname' \
+                   https://github.com/perftool-incubator/crucible.git \
+                   | awk -F/ '{print$NF}' \
+                   | grep -E '20[0-9]{2}\.[1234]')
+supported_releases=$(echo "${all_releases}" | tail -n 4)
+latest_supported=$(echo "${supported_releases}" | tail -n 1)
+unsupported_releases=$(echo "${all_releases}" | head -n -4)
+newest_unsupported=$(echo "${unsupported_releases}" | tail -n 1)
+
+start_test "set-release: no value shows usage"
+stdout=$(./crucible-install.sh --set-release 2>&1)
+test "$?" = "1" || exit 1
+[[ "$stdout" = *"Usage"* ]] || exit 1
+stop_test
+
+start_test "set-release: --help shows usage"
+stdout=$(./crucible-install.sh --set-release --help 2>&1)
+test "$?" = "0" || exit 1
+[[ "$stdout" = *"Usage"* ]] || exit 1
+stop_test
+
+start_test "set-release: invalid format rejected"
+ec=$(grep EC_SET_RELEASE_NOT_FOUND= crucible-install.sh | cut -d '=' -f2)
+./crucible-install.sh --set-release NotARelease 2>&1
+test "$?" = "$ec" || exit 1
+stop_test
+
+start_test "set-release: conflicts with --git-repo"
+ec=$(grep EC_INVALID_OPTION= crucible-install.sh | cut -d '=' -f2)
+./crucible-install.sh --set-release ${latest_supported} --git-repo foo 2>&1
+test "$?" = "$ec" || exit 1
+stop_test
+
+start_test "set-release: conflicts with --git-branch"
+ec=$(grep EC_INVALID_OPTION= crucible-install.sh | cut -d '=' -f2)
+./crucible-install.sh --set-release ${latest_supported} --git-branch foo 2>&1
+test "$?" = "$ec" || exit 1
+stop_test
+
+start_test "set-release: conflicts with --release"
+ec=$(grep EC_INVALID_OPTION= crucible-install.sh | cut -d '=' -f2)
+./crucible-install.sh --set-release ${latest_supported} --release foo 2>&1
+test "$?" = "$ec" || exit 1
+stop_test
+
+start_test "set-release: no existing installation"
+ec=$(grep EC_SET_RELEASE_NO_INSTALL= crucible-install.sh | cut -d '=' -f2)
+cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
+sudo mv ${cfgfile} ${cfgfile}.test-bak 2>/dev/null || true
+./crucible-install.sh --set-release ${latest_supported} 2>&1
+test "$?" = "$ec" || exit 1
+sudo mv ${cfgfile}.test-bak ${cfgfile} 2>/dev/null || true
+stop_test
+
+# For positive tests (and tests that need a valid installation), install crucible
+start_test "set-release: install crucible for set-release tests"
+touch /tmp/auth-file.json
+cfgfile=$(grep SYSCONFIG= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
+sudo mkdir -p $(dirname $cfgfile)
+sudo ./crucible-install.sh \
+    --git-repo "https://github.com/perftool-incubator/crucible" \
+    --engine-registry myregistry.io/crucible \
+    --engine-auth-file /tmp/auth-file.json \
+    --verbose
+test "$?" = "0" || exit 1
+stop_test
+
+install_path=$(grep INSTALL_PATH= crucible-install.sh | cut -d '=' -f2 | sed 's/"//g')
+
+start_test "set-release: non-existent release rejected"
+ec=$(grep EC_SET_RELEASE_NOT_FOUND= crucible-install.sh | cut -d '=' -f2)
+sudo ./crucible-install.sh --set-release 2099.1 2>&1
+test "$?" = "$ec" || exit 1
+stop_test
+
+start_test "set-release: unsupported release rejected without --force"
+ec=$(grep EC_SET_RELEASE_NOT_FOUND= crucible-install.sh | cut -d '=' -f2)
+sudo ./crucible-install.sh --set-release ${newest_unsupported} 2>&1
+test "$?" = "$ec" || exit 1
+stop_test
+
+start_test "set-release: switch to supported release ${latest_supported}"
+sudo ./crucible-install.sh --set-release ${latest_supported} 2>&1
+test "$?" = "0" || exit 1
+mode=$(jq -r '.official[0].checkout.mode' ${install_path}/config/repos.json)
+target=$(jq -r '.official[0].checkout.target' ${install_path}/config/repos.json)
+test "${mode}" = "locked" || exit 1
+test "${target}" = "${latest_supported}" || exit 1
+branch=$(sudo git -C ${install_path} rev-parse --abbrev-ref HEAD)
+test "${branch}" = "${latest_supported}" || exit 1
+stop_test
+
+start_test "set-release: switch back to upstream"
+sudo ./crucible-install.sh --set-release upstream 2>&1
+test "$?" = "0" || exit 1
+mode=$(jq -r '.official[0].checkout.mode' ${install_path}/config/repos.json)
+test "${mode}" = "follow" || exit 1
+branch=$(sudo git -C ${install_path} rev-parse --abbrev-ref HEAD)
+[[ "${branch}" != 20* ]] || exit 1
+stop_test
+
+start_test "set-release: --force with unsupported release ${newest_unsupported}"
+sudo ./crucible-install.sh --set-release-force --set-release ${newest_unsupported} 2>&1
+test "$?" = "0" || exit 1
+target=$(jq -r '.official[0].checkout.target' ${install_path}/config/repos.json)
+test "${target}" = "${newest_unsupported}" || exit 1
+stop_test
+
+start_test "set-release: switch back to upstream for preservation tests"
+sudo ./crucible-install.sh --set-release upstream 2>&1
+test "$?" = "0" || exit 1
+stop_test
+
+start_test "set-release: unofficial repos preserved across release switch"
+jq --indent 4 '.unofficial = [{"name":"test-repo","type":"userenvs","repository":"https://github.com/perftool-incubator/crucible-ci-userenvs","primary-branch":"main","checkout":{"mode":"follow","target":"main"}}]' \
+    ${install_path}/config/repos.json > /tmp/repos.json.tmp \
+    && sudo mv /tmp/repos.json.tmp ${install_path}/config/repos.json
+sudo ./crucible-install.sh --set-release ${latest_supported} 2>&1
+test "$?" = "0" || exit 1
+unofficial_name=$(jq -r '.unofficial[0].name' ${install_path}/config/repos.json)
+test "${unofficial_name}" = "test-repo" || exit 1
+stop_test
+
+start_test "set-release: custom URLs preserved across release switch"
+sudo ./crucible-install.sh --set-release upstream 2>&1
+test "$?" = "0" || exit 1
+custom_test_url="https://github.com/perftool-incubator/rickshaw.git"
+jq --indent 4 --arg url "${custom_test_url}" '(.official[] | select(.name == "rickshaw") | .repository) |= $url' \
+    ${install_path}/config/repos.json > /tmp/repos.json.tmp \
+    && sudo mv /tmp/repos.json.tmp ${install_path}/config/repos.json
+sudo ./crucible-install.sh --set-release ${latest_supported} 2>&1
+test "$?" = "0" || exit 1
+custom_url=$(jq -r '.official[] | select(.name == "rickshaw") | .repository' ${install_path}/config/repos.json)
+test "${custom_url}" = "${custom_test_url}" || exit 1
 stop_test


### PR DESCRIPTION
## Summary
- Add `--set-release` option to `crucible-install.sh` for switching an existing installation between quarterly releases or back to upstream
- Preserves unofficial repos and custom repository URLs across release switches
- Stops crucible services before switching, rolls back on failure
- Includes 14 test cases in `tests/test-installer`

## Details
- `--set-release <release>` — switch to a quarterly release (locked mode)
- `--set-release upstream` — switch back to following primary branches
- `--set-release select` — interactive release selection
- `--set-release-force` — allow unsupported (older) releases

### Why the installer?
Switching releases checks out a different branch of the crucible repo, which
overwrites all repo-managed scripts. If the target release predates the
set-release feature, the command would not exist after the switch, leaving the
user unable to switch again. While the installer does live in the
release-managed code, it is a well established practice to manually download it
from the upstream repo (e.g., via curl/wget) without using a git clone
operation. This means a user can always acquire a current version of the
installer with the set-release feature regardless of which release is currently
checked out.

## Test plan
- [ ] CI passes test-installer (install job)
- [ ] Manual round-trip: upstream → release → different release → upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)