### PR TITLE
feat: add --log-level to crucible run and clean up stale controller images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # Crucible - Container-Based Performance Testing Framework
 
+## Git Workflow
+
+NEVER commit code unless explicitly asked to commit. Stage changes and show a summary, but wait for user approval before running `git commit`.
+
+## Tool Usage
+
+Before using any CLI flag or API, verify it actually exists by checking `--help` output or documentation. Never assume a flag exists based on what seems logical.
+
+## Debugging
+
+When fixing a bug, first identify and confirm which component is actually responsible before making changes. Read the error trace carefully and validate your diagnosis before editing code.
+
 ## Project Overview
 
 Crucible is a container-based performance testing framework built primarily in Bash. It orchestrates benchmark execution, data collection, post-processing, and result indexing using Podman containers. The project is part of the `perftool-incubator` GitHub organization.
@@ -69,6 +81,10 @@ crucible run-ci
 # Full help
 crucible help [command]
 ```
+
+## Code Style
+
+Follow existing code style conventions exactly — check surrounding code for patterns before writing new code. When in doubt, match the existing style rather than introducing new conventions.
 
 ## Code Conventions
 
@@ -159,7 +175,7 @@ Available skills:
 
 ## Pull Requests and Contributions
 
-- **Branch strategy**: Always submit PRs from branches on the upstream repository, not from forks. Fork PRs cannot access org secrets and variables needed for CI workflows. All repos have a `fork-check` workflow that automatically closes fork PRs.
+- **Branch strategy**: Always create a feature branch first (`git checkout -b <descriptive-branch-name>`). Never push directly to main. Submit PRs from branches on the upstream repository, not from forks. Fork PRs cannot access org secrets and variables needed for CI workflows. All repos have a `fork-check` workflow that automatically closes fork PRs.
 - **Review requests**: When opening PRs, request review from the **Developers** team and self-assign the PR.
 - **Commit messages**: Use conventional commits format (`feat:`, `fix:`, `docs:`, etc.). Be precise and descriptive — prefer nuanced descriptions over broad generalizations.
 - **CLAUDE.md updates**: When making structural changes to a subproject, update that subproject's CLAUDE.md in the same PR. Claude should author CLAUDE.md content, not humans — the human role is review and approval.

--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -38,7 +38,7 @@ _crucible_completions() {
                 COMPREPLY=($(compgen -W "all crucible $(cd $CRUCIBLE_HOME/subprojects/; find . -type l | sed 'sX./XX')" -- "${COMP_WORDS[2]}"))
                 ;;
             run)
-                COMPREPLY=($(compgen -f -- "${COMP_WORDS[2]}"))
+                COMPREPLY=($(compgen -W "--log-level --help" -f -- "${COMP_WORDS[2]}"))
                 ;;
             wrapper)
                 COMPREPLY=($(compgen -c -f -- "${COMP_WORDS[2]}"))

--- a/bin/_help
+++ b/bin/_help
@@ -76,7 +76,7 @@ function help() {
     elif [ "${1}" == "update" ]; then
         ${CRUCIBLE_HOME}/bin/update help
     elif [ "${1}" == "run" ]; then
-        echo "please see https://github.com/perftool-incubator/crucible/tree/master/doc"
+        run_help
     else
         help
     fi

--- a/bin/_main
+++ b/bin/_main
@@ -242,23 +242,51 @@ elif [ "${1}" == "postprocess" ]; then
 elif [ "${1}" == "run" ]; then
     shift
 
-    if [ "${1}" == "--from-file" ]; then
-        # discard the optional '--from-file' parameter; it is still
-        # allowed for backwards compatability
-        shift
-    fi
+    run_file=""
+    run_log_level="normal"
 
-    run_file=${1}
-    if [ -n "${run_file}" ]; then
-        if [ ! -f $run_file ]; then
-            exit_error "File not found: ${run_file}"
-        fi
-    else
+    while [ $# -gt 0 ]; do
+        case "${1}" in
+            --from-file)
+                shift
+                ;;
+            --log-level)
+                shift
+                if [ $# -eq 0 ]; then
+                    exit_error "--log-level requires a value (normal, verbose, debug)"
+                fi
+                case "${1}" in
+                    normal|verbose|debug)
+                        run_log_level="${1}"
+                        ;;
+                    *)
+                        exit_error "Invalid --log-level value '${1}'. Must be one of: normal, verbose, debug"
+                        ;;
+                esac
+                shift
+                ;;
+            --help)
+                run_help
+                exit 0
+                ;;
+            --*)
+                exit_error "Unknown option '${1}'. See 'crucible help run' for usage."
+                ;;
+            *)
+                if [ -n "${run_file}" ]; then
+                    exit_error "Only one run-file can be specified."
+                fi
+                run_file="${1}"
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "${run_file}" ]; then
         exit_error "You must specify a JSON run-file."
     fi
-
-    if [ $# -gt 1 ]; then
-        exit_error "No other options can be specified with besides the JSON run-file."
+    if [ ! -f "${run_file}" ]; then
+        exit_error "File not found: ${run_file}"
     fi
 
     # extract the list of benchmarks from the run file
@@ -353,6 +381,7 @@ elif [ "${1}" == "run" ]; then
     rs_run_cmd+=" --external-userenvs-dir=${CRUCIBLE_HOME}/subprojects/userenvs"
     rs_run_cmd+=" --workshop-script=workshop.py"
     rs_run_cmd+=" ${image_sourcing_url}"
+    rs_run_cmd+=" --log-level=${run_log_level}"
     rs_run_cmd+=" ${rickshaw_run_args[@]}"
 
     echo "rickshaw-run command: $rs_run_cmd"

--- a/bin/base
+++ b/bin/base
@@ -1053,6 +1053,19 @@ function run_manage_instances() {
         "$@"
 }
 
+function run_help() {
+    echo "Usage: crucible run [OPTIONS] <run-file>"
+    echo ""
+    echo "Execute a benchmark run defined by a JSON run-file."
+    echo ""
+    echo "Options:"
+    echo "  --log-level <level>  Set logging verbosity (default: normal)"
+    echo "                       normal  - curated output for readability"
+    echo "                       verbose - includes detailed subsystem output"
+    echo "                       debug   - full diagnostic output"
+    echo "  --help               Show this help and exit"
+}
+
 # Helper function to get instance metadata (instance, cdmver_opt, access_opt)
 # Usage: get_instance_metadata [instance_name]
 # If instance_name is not provided, uses the default index instance

--- a/bin/update
+++ b/bin/update
@@ -121,8 +121,15 @@ case "${repo}" in
         echo
         echo "Checking for new controller image:"
         echo
+        old_id=$(podman images -q ${CRUCIBLE_CONTROLLER_IMAGE})
         if ! ${podman_pull} ${CRUCIBLE_CONTROLLER_IMAGE}; then
             RC=1
+        else
+            new_id=$(podman images -q ${CRUCIBLE_CONTROLLER_IMAGE})
+            if [ -n "${old_id}" ] && [ "${old_id}" != "${new_id}" ]; then
+                echo "Removing previous controller image ${old_id}"
+                podman rmi ${old_id} 2>/dev/null || true
+            fi
         fi
         ;;
     *)


### PR DESCRIPTION
## Summary
- Add `--log-level` (normal/verbose/debug) and `--help` options to `crucible run`, passed through to rickshaw-run
- Help text defined in `run_help()` in `bin/base`, shared by `bin/_main` and `bin/_help`
- Remove previous controller image after pulling a new version in `bin/update` to prevent dangling images
- Add CLAUDE.md guidelines for git workflow, tool usage, debugging, and code style

## Test plan
- [ ] `crucible run my-run.json` — works as before (normal level)
- [ ] `crucible run --log-level verbose my-run.json` — passes `--log-level=verbose` to rickshaw-run
- [ ] `crucible run --log-level invalid my-run.json` — errors with valid options listed
- [ ] `crucible run --help` — prints usage and exits without launching a container
- [ ] `crucible help run` — same output as `--help`
- [ ] `crucible update` — removes old controller image when a new version is pulled
- [ ] Tab completion offers `--log-level` and `--help` after `crucible run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)