### PR TITLE
feat: remove Perl fallback mechanism for rickshaw scripts

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -366,7 +366,7 @@ elif [ "${1}" == "run" ]; then
            image_sourcing_url="--source-images-service-url=${image_sourcing_url}"
     fi
 
-    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run${rickshaw_python_ext}"
+    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run.py"
     rs_run_cmd+=" ${params_args}"
     rs_run_cmd+=" --id ${SESSION_ID}"
     rs_run_cmd+=" --bench-dir $benchmark_subproj_dir"

--- a/bin/base
+++ b/bin/base
@@ -4,9 +4,6 @@
 
 EC_FAIL_USER=2
 
-# To revert rickshaw scripts to Perl, change ".py" to ""
-rickshaw_python_ext=".py"
-
 function exit_error() {
     echo "ERROR: ${1}"
     shift
@@ -556,9 +553,9 @@ function post_process_run() {
     echo "Benchmark result is in ${RUN_DIR}"
     shift
 
-    rs_pp_b_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-bench${rickshaw_python_ext}"
+    rs_pp_b_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-bench.py"
     rs_pp_b_cmd+=" --base-run-dir=${RUN_DIR}"
-    rs_pp_t_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-tools${rickshaw_python_ext}"
+    rs_pp_t_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-post-process-tools.py"
     rs_pp_t_cmd+=" --base-run-dir=${RUN_DIR}"
 
     post_process_fail=0
@@ -613,7 +610,7 @@ function index_run() {
     fi
 
     # Generate the CDM documents
-    gen_docs_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-gen-docs${rickshaw_python_ext}"
+    gen_docs_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-gen-docs.py"
     gen_docs_cmd+=" --base-run-dir=${RUN_DIR} ${cdmver_opt}"
     echo "Generating CDM documents with ${gen_docs_cmd}"
     ${podman_run}\


### PR DESCRIPTION
## Summary
- Remove the `rickshaw_python_ext` variable from `bin/base` that allowed reverting rickshaw scripts to their Perl versions
- Hardcode `.py` extensions for rickshaw-run, rickshaw-post-process-bench, rickshaw-post-process-tools, and rickshaw-gen-docs
- The Python ports are stable and the Perl scripts are being removed from rickshaw

## Test plan
- [ ] `crucible run` invokes rickshaw-run.py correctly
- [ ] Post-processing invokes the .py scripts
- [ ] `crucible help run` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)