### PR TITLE
feat: add tool-mlxreg to repos.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Crucible is a container-based performance testing framework built primarily in B
 Defined in `config/repos.json` with categories:
 - **core**: `rickshaw` (run orchestration), `multiplex`, `roadblock`, `workshop`, `CommonDataModel`, `toolbox`, `packrat`, `crucible-ci`
 - **benchmarks**: `cyclictest`, `fio`, `flexran`, `hwlatdetect`, `hwnoise`, `ilab`, `iperf`, `oslat`, `osnoise`, `pytorch`, `sleep`, `timerlat`, `tracer`, `trafficgen`, `uperf` (in `subprojects/benchmarks/`)
-- **tools**: `sysstat`, `procstat`, `ftrace`, `kernel`, `ovs`, `nvidia`, `power`, `forkstat`, `rt-trace-bpf` (in `subprojects/tools/`)
+- **tools**: `sysstat`, `procstat`, `ftrace`, `kernel`, `ovs`, `nvidia`, `power`, `forkstat`, `rt-trace-bpf`, `mlxreg` (in `subprojects/tools/`)
 - **docs**: `examples`, `testing` (in `subprojects/docs/`)
 
 Each entry in `repos.json` has: `name`, `type`, `repository`, `primary-branch`, and `checkout` config.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ uperf | Traditional network communication testing | https://github.com/perftool-
 forkstat | A tool to capture fork+exec statistics | https://github.com/perftool-incubator/tool-forkstat
 ftrace | Linux kernel tracing | https://github.com/perftool-incubator/tool-ftrace
 kernel | Various kernel tools (turbostat, perf, sst, tracing) | https://github.com/perftool-incubator/tool-kernel
+mlxreg | Mellanox register tool for collecting NIC register data | https://github.com/perftool-incubator/tool-mlxreg
 nvidia | NVIDIA GPU data collection | https://github.com/perftool-incubator/tool-nvidia
 ovs | Open vSwitch data collection | https://github.com/perftool-incubator/tool-ovs
 power | Power and thermal telemetry collection for Redfish-enabled devices | https://github.com/perftool-incubator/tool-power

--- a/config/repos.json
+++ b/config/repos.json
@@ -341,6 +341,16 @@
             }
         },
         {
+            "name": "mlxreg",
+            "type": "tool",
+            "repository": "https://github.com/perftool-incubator/tool-mlxreg",
+            "primary-branch": "main",
+            "checkout": {
+                "mode": "follow",
+                "target": "main"
+            }
+        },
+        {
             "name": "examples",
             "type": "doc",
             "repository": "https://github.com/perftool-incubator/crucible-examples",


### PR DESCRIPTION
## Summary
- Add tool-mlxreg (Mellanox register tool for collecting NIC register data) to repos.json, README.md, and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)