### PR TITLE
feat: add per-architecture image sourcing service support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,26 @@ Follow existing code style conventions exactly — check surrounding code for pa
 - `~/.crucible/identity`: User identity (CRUCIBLE_NAME, CRUCIBLE_EMAIL)
 - Run data stored in `/var/lib/crucible/run/`
 
+## Multi-Architecture Image Sourcing
+
+Engine container images are built by the image sourcing service (SIS). `config/services.json` maps each CPU architecture to its own SIS instance under `image-sourcing.services`:
+
+```json
+{
+    "image-sourcing": {
+        "use": true,
+        "services": {
+            "x86_64": { "start": true, "location": { "address": "localhost", "port": 8888, "protocol": "http" } },
+            "aarch64": { "start": false, "location": { "address": "arm-builder.example.com", "port": 8888, "protocol": "http" } }
+        }
+    }
+}
+```
+
+- The repo ships with a `"default"` placeholder key; `bin/_migrate-services-config` resolves it to the host's native architecture (via `uname -m`) on install, update, and every command invocation
+- Only the native architecture can use `"start": true` (local service). Non-native architectures must use `"start": false` with a remote address pointing to a native builder — local cross-arch builds are not supported due to buildah/QEMU incompatibilities
+- `bin/_main` writes `image-sourcing-urls.json` to the run config directory mapping each architecture to its service URL; rickshaw reads this file to route image sourcing requests
+
 ## Dependencies
 
 Runtime: `podman`, `git`, `jq`

--- a/bin/_main
+++ b/bin/_main
@@ -351,19 +351,45 @@ elif [ "${1}" == "run" ]; then
     image_sourcing_url=""
     image_sourcing_use=$(jq_query ${SERVICES_CFG} '."image-sourcing".use')
     if [ "${image_sourcing_use}" == "true" ]; then
-           image_sourcing_start=$(jq_query ${SERVICES_CFG} '."image-sourcing".start')
-           if [ "${image_sourcing_start}" == "true" ]; then
-               start_image_sourcing
-           fi
+        if ! start_image_sourcing; then
+            exit_error "Failed to start image-sourcing service(s)"
+        fi
 
-           image_sourcing_address=$(jq_query ${SERVICES_CFG} '."image-sourcing".location.address')
-           image_sourcing_port=$(jq_query ${SERVICES_CFG} '."image-sourcing".location.port')
-           image_sourcing_protocol=$(jq_query ${SERVICES_CFG} '."image-sourcing".location.protocol')
+        # Build per-architecture URL mapping and write to run config
+        local native_arch urls_json first_url arch arch_address arch_port arch_protocol arch_url
+        native_arch=$(uname -m)
+        urls_json="{"
+        first_url=""
 
-           image_sourcing_url="${image_sourcing_protocol}://${image_sourcing_address}:${image_sourcing_port}"
-           echo "Using image-sourcing service @ ${image_sourcing_url}"
+        for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
+            arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.address")
+            arch_port=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.port")
+            arch_protocol=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.protocol")
+            arch_url="${arch_protocol}://${arch_address}:${arch_port}"
 
-           image_sourcing_url="--source-images-service-url=${image_sourcing_url}"
+            echo "Using ${arch} image-sourcing service @ ${arch_url}"
+
+            if [ "${urls_json}" != "{" ]; then
+                urls_json+=","
+            fi
+            urls_json+="\"${arch}\":\"${arch_url}\""
+
+            # Track the native arch URL for legacy --source-images-service-url
+            if [ "${arch}" == "${native_arch}" ]; then
+                first_url="${arch_url}"
+            elif [ -z "${first_url}" ]; then
+                first_url="${arch_url}"
+            fi
+        done
+
+        urls_json+="}"
+        echo "${urls_json}" | jq '.' > ${base_run_dir}/config/image-sourcing-urls.json
+        echo "Wrote per-architecture image sourcing URL mapping to ${base_run_dir}/config/image-sourcing-urls.json"
+
+        # Legacy --source-images-service-url for backward compatibility with old rickshaw
+        if [ -n "${first_url}" ]; then
+            image_sourcing_url="--source-images-service-url=${first_url}"
+        fi
     fi
 
     rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run.py"

--- a/bin/_migrate-services-config
+++ b/bin/_migrate-services-config
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+
+# Migrate config/services.json to the per-architecture image-sourcing format.
+# This script is idempotent and safe to run multiple times.
+#
+# It handles two cases:
+#   1. Old flat format (location/start/use directly under image-sourcing)
+#      → converted to per-arch services map with native arch as the key
+#   2. New format with "default" placeholder key
+#      → "default" replaced with the host's native architecture
+
+. /etc/sysconfig/crucible
+
+if [ -z "${CRUCIBLE_HOME}" ]; then
+    echo "CRUCIBLE_HOME not defined, exiting."
+    exit 1
+fi
+
+source ${CRUCIBLE_HOME}/bin/jqlib
+
+SERVICES_CFG=${CRUCIBLE_HOME}/config/services.json
+
+if [ ! -f "${SERVICES_CFG}" ]; then
+    echo "No services.json found, skipping migration"
+    exit 0
+fi
+
+native_arch=$(uname -m)
+
+# Check if this is the old flat format (has image-sourcing.location at top level)
+has_old_format=$(jq -r '."image-sourcing" | has("location")' ${SERVICES_CFG})
+
+if [ "${has_old_format}" == "true" ]; then
+    echo "Migrating services.json from flat image-sourcing format to per-architecture format..."
+
+    # Extract old values
+    old_start=$(jq -r '."image-sourcing".start' ${SERVICES_CFG})
+    old_address=$(jq -r '."image-sourcing".location.address' ${SERVICES_CFG})
+    old_port=$(jq -r '."image-sourcing".location.port' ${SERVICES_CFG})
+    old_protocol=$(jq -r '."image-sourcing".location.protocol' ${SERVICES_CFG})
+    old_use=$(jq -r '."image-sourcing".use' ${SERVICES_CFG})
+
+    # Rewrite the image-sourcing section in place
+    jq --indent 4 --arg arch "${native_arch}" \
+       --argjson start "${old_start}" \
+       --arg address "${old_address}" \
+       --argjson port "${old_port}" \
+       --arg protocol "${old_protocol}" \
+       --argjson use "${old_use}" \
+       '."image-sourcing" = {
+           "use": $use,
+           "services": {
+               ($arch): {
+                   "start": $start,
+                   "location": {
+                       "address": $address,
+                       "port": $port,
+                       "protocol": $protocol
+                   }
+               }
+           }
+       }' ${SERVICES_CFG} > ${SERVICES_CFG}.tmp && mv ${SERVICES_CFG}.tmp ${SERVICES_CFG}
+
+    echo "Migrated image-sourcing config to per-architecture format with key '${native_arch}'"
+    exit 0
+fi
+
+# Check if the new format has a "default" key that needs to be resolved
+has_default=$(jq -r '."image-sourcing".services | has("default")' ${SERVICES_CFG} 2>/dev/null)
+
+if [ "${has_default}" == "true" ]; then
+    echo "Resolving 'default' image-sourcing service key to '${native_arch}'..."
+
+    jq --indent 4 --arg arch "${native_arch}" \
+       '."image-sourcing".services[$arch] = ."image-sourcing".services["default"] |
+        del(."image-sourcing".services["default"])' \
+       ${SERVICES_CFG} > ${SERVICES_CFG}.tmp && mv ${SERVICES_CFG}.tmp ${SERVICES_CFG}
+
+    echo "Resolved 'default' to '${native_arch}'"
+    exit 0
+fi
+
+# Already migrated — silent exit

--- a/bin/base
+++ b/bin/base
@@ -275,71 +275,101 @@ function stop_valkey() {
 }
 
 function start_image_sourcing() {
-    local image_sourcing_start image_sourcing_service_address
-    local image_sourcing_port image_sourcing_protocol
     local image_sourcing_start_cmd image_sourcing_status_cmd
     local image_sourcing_available image_sourcing_timeout
     local count RC
+    local arch arch_start arch_address arch_port arch_protocol
+    local container_name native_arch
 
-    image_sourcing_start=$(jq_query ${SERVICES_CFG} '."image-sourcing".start')
-    if [ "${image_sourcing_start}" != "true" ]; then
-        echo "WARNING: The image sourcing service is disabled"
-        return 0
-    fi
-
-    image_sourcing_address=$(jq_query ${SERVICES_CFG} '."image-sourcing".location.address')
-    image_sourcing_port=$(jq_query ${SERVICES_CFG} '."image-sourcing".location.port')
-    image_sourcing_protocol=$(jq_query ${SERVICES_CFG} '."image-sourcing".location.protocol')
+    native_arch=$(uname -m)
 
     image_sourcing_start_cmd="${CRUCIBLE_HOME}/bin/services/start-image-sourcing.sh ${var_crucible}"
-    image_sourcing_status_cmd="curl --silent --show-error --stderr - -X GET  ${image_sourcing_protocol}://${image_sourcing_address}:${image_sourcing_port}/api/v1/health"
-    echo -n "Checking for image-sourcing service"
-    if ! podman_running crucible-image-sourcing; then
-        ${podman_run} --name crucible-image-sourcing --env "SIS_PORT=${image_sourcing_port}" "${container_common_args[@]}" "${container_image_sourcing_args[@]}" "${container_build_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${image_sourcing_start_cmd} > /dev/null
-        RC=$?
-        if [ ${RC} != 0 ]; then
-            echo "ERROR: Could not start image-sourcing service"
-        else
-            image_sourcing_available=0
-            count=1
-            image_sourcing_timeout=60
-            echo "Waiting for image-sourcing service to be available (${image_sourcing_timeout} seconds maximum)..."
-            while [ ${image_sourcing_available} != 1 -a ${count} -lt ${image_sourcing_timeout} ]; do
-                pod_name=crucible-image-sourcing-status-check-${SESSION_ID}-$(uuidgen)
-                status_check=$(${podman_run} --name ${pod_name} "${container_common_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} /bin/bash -c "${image_sourcing_status_cmd} | jq -r '. \"status\"'")
-                if [ "${status_check}" == "healthy" ]; then
-                    echo "image-sourcing service is online after ${count} seconds"
-                    image_sourcing_available=1
-                else
-                    sleep 1
-                fi
-                (( count += 1 ))
-            done
-            if [ ${image_sourcing_available} -eq 0 ]; then
-                echo "ERROR: image-sourcing service failed to launch properly"
-                RC=1
+
+    for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
+        arch_start=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".start")
+        if [ "${arch_start}" != "true" ]; then
+            continue
+        fi
+
+        if [ "${arch}" != "${native_arch}" ]; then
+            echo "ERROR: Cannot start a local image-sourcing service for non-native architecture '${arch}' (native is '${native_arch}')"
+            echo "ERROR: Local non-native architecture builds are not supported due to buildah/QEMU incompatibilities"
+            echo "ERROR: Configure the '${arch}' service in ${SERVICES_CFG} with 'start: false' and a remote address pointing to a native ${arch} builder"
+            return 1
+        fi
+
+        arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.address")
+        arch_port=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.port")
+        arch_protocol=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.protocol")
+
+        container_name="crucible-image-sourcing-${arch}"
+        image_sourcing_status_cmd="curl --silent --show-error --stderr - -X GET ${arch_protocol}://${arch_address}:${arch_port}/api/v1/health"
+
+        echo -n "Checking for ${arch} image-sourcing service"
+        if ! podman_running ${container_name}; then
+            ${podman_run} --name ${container_name} --env "SIS_PORT=${arch_port}" "${container_common_args[@]}" "${container_image_sourcing_args[@]}" "${container_build_args[@]}" "${container_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${image_sourcing_start_cmd} > /dev/null
+            RC=$?
+            if [ ${RC} != 0 ]; then
+                echo "ERROR: Could not start ${arch} image-sourcing service"
+                return ${RC}
             else
-                echo "Successfully started image-sourcing service on port ${image_sourcing_port}"
-                RC=0
+                image_sourcing_available=0
+                count=1
+                image_sourcing_timeout=60
+                echo "Waiting for ${arch} image-sourcing service to be available (${image_sourcing_timeout} seconds maximum)..."
+                while [ ${image_sourcing_available} != 1 -a ${count} -lt ${image_sourcing_timeout} ]; do
+                    pod_name=${container_name}-status-check-${SESSION_ID}-$(uuidgen)
+                    status_check=$(${podman_run} --name ${pod_name} "${container_common_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} /bin/bash -c "${image_sourcing_status_cmd} | jq -r '. \"status\"'")
+                    if [ "${status_check}" == "healthy" ]; then
+                        echo "${arch} image-sourcing service is online after ${count} seconds"
+                        image_sourcing_available=1
+                    else
+                        sleep 1
+                    fi
+                    (( count += 1 ))
+                done
+                if [ ${image_sourcing_available} -eq 0 ]; then
+                    echo "ERROR: ${arch} image-sourcing service failed to launch properly"
+                    return 1
+                else
+                    echo "Successfully started ${arch} image-sourcing service on port ${arch_port}"
+                fi
             fi
         fi
-    fi
-    return ${RC}
+    done
+
+    return 0
 }
 
 function stop_image_sourcing() {
-    local RC
+    local RC arch container_name
+    RC=0
 
-    echo -n "Checking for image-sourcing service"
+    for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
+        container_name="crucible-image-sourcing-${arch}"
+        echo -n "Checking for ${arch} image-sourcing service"
+        if podman_running ${container_name}; then
+            ${podman_stop} ${container_name} > /dev/null
+            if [ $? != 0 ]; then
+                echo "ERROR: Could not stop ${arch} image-sourcing service"
+                RC=1
+            else
+                echo "Successfully stopped ${arch} image-sourcing service"
+            fi
+        fi
+    done
+
+    # Also stop any legacy-named container from before multi-arch support
     if podman_running crucible-image-sourcing; then
         ${podman_stop} crucible-image-sourcing > /dev/null
-        RC=$?
-        if [ ${RC} != 0 ]; then
-            echo "ERROR: Could not stop image-sourcing service"
+        if [ $? != 0 ]; then
+            echo "ERROR: Could not stop legacy image-sourcing service"
+            RC=1
         else
-            echo "Successfully stopped image-sourcing service"
+            echo "Successfully stopped legacy image-sourcing service"
         fi
     fi
+
     return ${RC}
 }
 
@@ -1192,6 +1222,11 @@ source ${CRUCIBLE_HOME}/bin/jqlib
 
 SERVICES_CFG=${CRUCIBLE_HOME}/config/services.json
 SERVICES_CFG_SCHEMA=${CRUCIBLE_HOME}/schema/services.json
+
+# Ensure services.json is migrated to per-arch format
+if [ -x ${CRUCIBLE_HOME}/bin/_migrate-services-config ]; then
+    ${CRUCIBLE_HOME}/bin/_migrate-services-config
+fi
 INSTANCES_CFG=${CRUCIBLE_HOME}/config/instances.json
 REGISTRIES_CFG=${CRUCIBLE_HOME}/config/registries.json
 REGISTRIES_CFG_SCHEMA=${CRUCIBLE_HOME}/schema/registries.json

--- a/bin/update
+++ b/bin/update
@@ -113,6 +113,9 @@ esac
 case "${repo}" in
     "____all"|"____crucible")
         # any crucible specific post update logic goes here
+
+        # migrate services.json to per-arch image-sourcing format
+        ${CRUCIBLE_HOME}/bin/_migrate-services-config
         ;;
 esac
 

--- a/config/services.json
+++ b/config/services.json
@@ -7,11 +7,15 @@
     },
     "image-sourcing": {
         "use": true,
-        "start": true,
-        "location": {
-            "address": "localhost",
-            "port": 8888,
-            "protocol": "http"
+        "services": {
+            "default": {
+                "start": true,
+                "location": {
+                    "address": "localhost",
+                    "port": 8888,
+                    "protocol": "http"
+                }
+            }
         }
     },
     "valkey": {

--- a/crucible-install.sh
+++ b/crucible-install.sh
@@ -919,6 +919,11 @@ fi
 ${INSTALL_PATH}/bin/subprojects-install ${git_tag_arg} >> "${GIT_INSTALL_LOG}" 2>&1 ||
     exit_error "Failed to execute crucible subproject install, check ${GIT_INSTALL_LOG} for details" ${EC_FAIL_INSTALL}
 
+# Migrate services.json to per-architecture image-sourcing format
+if [ -x ${INSTALL_PATH}/bin/_migrate-services-config ]; then
+    ${INSTALL_PATH}/bin/_migrate-services-config
+fi
+
 SYSCONFIG_CRUCIBLE_ENGINE_REGISTRY="${CRUCIBLE_ENGINE_REGISTRY}"
 SYSCONFIG_CRUCIBLE_ENGINE_AUTH=""
 SYSCONFIG_CRUCIBLE_ENGINE_TLS_VERIFY=""

--- a/schema/services.json
+++ b/schema/services.json
@@ -4,53 +4,71 @@
     "type": "object",
     "properties": {
         "image-sourcing": {
-            "description": "The image-sourcing object contains configuration settings for the container image sourcing service",
+            "description": "The image-sourcing object contains configuration settings for the container image sourcing service(s). Multiple services can be configured, one per CPU architecture, to support multi-architecture image builds.",
             "type": "object",
             "properties": {
-                "location": {
-                    "description": "The location object contains configuration settings locate where the image sourcing service can be accessed",
+                "use": {
+                    "description": "This parameter controls whether the image sourcing service is used",
+                    "type": "boolean"
+                },
+                "services": {
+                    "description": "A map of CPU architecture to image sourcing service configuration. Each key is an architecture name (e.g., 'x86_64', 'aarch64') or the special value 'default' which is resolved to the host's native architecture during install/update. Services with 'start' set to true are started locally; non-native architectures are started under QEMU emulation.",
                     "type": "object",
-                    "properties": {
-                        "address": {
-                            "description": "This paramter contains the hostname or IP address that is used to access the image sourcing service",
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "port": {
-                            "descriptiopn": "This parameter contains the network port where the image sourcing service is running",
-                            "type": "integer",
-                            "minimum": 1025,
-                            "maximum": 32768
-                        },
-                        "protocol": {
-                            "description": "This parameter contains the protocol that is used to communicate with the image sourcing service",
-                            "type": "string",
-                            "enum": [
-                                "http"
+                    "minProperties": 1,
+                    "patternProperties": {
+                        "^(default|x86_64|aarch64|ppc64le|s390x)$": {
+                            "description": "Configuration for an image sourcing service that builds images for this architecture",
+                            "type": "object",
+                            "properties": {
+                                "start": {
+                                    "description": "This parameter controls whether this image sourcing service should be started locally. Only services matching the host's native architecture can be started locally; non-native architectures must use a remote service with start set to false.",
+                                    "type": "boolean"
+                                },
+                                "location": {
+                                    "description": "The location object contains configuration settings to locate where the image sourcing service can be accessed",
+                                    "type": "object",
+                                    "properties": {
+                                        "address": {
+                                            "description": "This parameter contains the hostname or IP address that is used to access the image sourcing service",
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "port": {
+                                            "description": "This parameter contains the network port where the image sourcing service is running",
+                                            "type": "integer",
+                                            "minimum": 1025,
+                                            "maximum": 32768
+                                        },
+                                        "protocol": {
+                                            "description": "This parameter contains the protocol that is used to communicate with the image sourcing service",
+                                            "type": "string",
+                                            "enum": [
+                                                "http"
+                                            ]
+                                        }
+                                    },
+                                    "additionalProperties": false,
+                                    "required": [
+                                        "address",
+                                        "port",
+                                        "protocol"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "start",
+                                "location"
                             ]
                         }
                     },
-                    "additionalProperties": false,
-                    "required": [
-                        "address",
-                        "port",
-                        "protocol"
-                    ]
-                },
-                "start": {
-                    "description": "This parameter controls whether the local image sourcing service should be started",
-                    "type": "boolean"
-                },
-                "use": {
-                    "description": "This paramter controls whether the image sourcing service is used",
-                    "type": "boolean"
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false,
             "required": [
-                "location",
-                "start",
-                "use"
+                "use",
+                "services"
             ]
         },
         "cdm-server": {


### PR DESCRIPTION
## Summary

- Migrate `image-sourcing` in `services.json` from a single service to a per-architecture services map, enabling multi-arch image builds via remote native builders
- Each architecture gets its own service entry with independent `start`/`location` configuration
- `bin/_main` writes a per-arch URL mapping file (`image-sourcing-urls.json`) to the run config directory for rickshaw consumption
- Non-native `start: true` entries are fatal — local cross-arch builds are not supported due to buildah/QEMU incompatibilities; non-native architectures must use a remote service
- New `bin/_migrate-services-config` script handles migration from the old flat format and resolves the `default` placeholder key to the host's native architecture; runs on install, update, and every command invocation
- Legacy `--source-images-service-url` CLI arg is still passed to rickshaw for backward compatibility during the transition period

## Key files

| File | Change |
|---|---|
| `config/services.json` | Per-arch services map with `default` placeholder key |
| `schema/services.json` | Updated schema with `patternProperties` for arch keys |
| `bin/base` | Multi-arch `start/stop_image_sourcing()`, fatal error for non-native start |
| `bin/_main` | Build per-arch URL mapping file, check `start_image_sourcing` return code |
| `bin/_migrate-services-config` | New — idempotent config migration script |
| `bin/update` | Call migration during `crucible update` |
| `crucible-install.sh` | Call migration after install |

## Multi-arch services.json example

```json
{
    "image-sourcing": {
        "use": true,
        "services": {
            "x86_64": {
                "start": true,
                "location": {
                    "address": "localhost",
                    "port": 8888,
                    "protocol": "http"
                }
            },
            "aarch64": {
                "start": false,
                "location": {
                    "address": "arm-builder.example.com",
                    "port": 8888,
                    "protocol": "http"
                }
            }
        }
    }
}
```

## Test plan

- [ ] Fresh install: verify `default` key is resolved to native arch by migration
- [ ] `crucible update`: verify migration runs and resolves `default` key
- [ ] Single-arch run: verify backward-compatible behavior (single service, `image-sourcing-urls.json` written)
- [ ] Multi-arch config with remote builder: verify both URLs appear in `image-sourcing-urls.json`
- [ ] Non-native `start: true`: verify fatal error with clear message
- [ ] Old flat-format `services.json`: verify migration converts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)