### PR TITLE
feat: remove legacy --source-images-service-url from rickshaw command

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -348,7 +348,6 @@ elif [ "${1}" == "run" ]; then
         exit_error "Could not find the valkey service password.  Consider restarting valkey"
     fi
 
-    image_sourcing_url=""
     image_sourcing_use=$(jq_query ${SERVICES_CFG} '."image-sourcing".use')
     if [ "${image_sourcing_use}" == "true" ]; then
         if ! start_image_sourcing; then
@@ -356,10 +355,8 @@ elif [ "${1}" == "run" ]; then
         fi
 
         # Build per-architecture URL mapping and write to run config
-        local native_arch urls_json first_url arch arch_address arch_port arch_protocol arch_url
-        native_arch=$(uname -m)
+        local urls_json arch arch_address arch_port arch_protocol arch_url
         urls_json="{"
-        first_url=""
 
         for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
             arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.address")
@@ -373,23 +370,11 @@ elif [ "${1}" == "run" ]; then
                 urls_json+=","
             fi
             urls_json+="\"${arch}\":\"${arch_url}\""
-
-            # Track the native arch URL for legacy --source-images-service-url
-            if [ "${arch}" == "${native_arch}" ]; then
-                first_url="${arch_url}"
-            elif [ -z "${first_url}" ]; then
-                first_url="${arch_url}"
-            fi
         done
 
         urls_json+="}"
         echo "${urls_json}" | jq '.' > ${base_run_dir}/config/image-sourcing-urls.json
         echo "Wrote per-architecture image sourcing URL mapping to ${base_run_dir}/config/image-sourcing-urls.json"
-
-        # Legacy --source-images-service-url for backward compatibility with old rickshaw
-        if [ -n "${first_url}" ]; then
-            image_sourcing_url="--source-images-service-url=${first_url}"
-        fi
     fi
 
     rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run.py"
@@ -406,7 +391,6 @@ elif [ "${1}" == "run" ]; then
     rs_run_cmd+=" --base-run-dir=$base_run_dir"
     rs_run_cmd+=" --external-userenvs-dir=${CRUCIBLE_HOME}/subprojects/userenvs"
     rs_run_cmd+=" --workshop-script=workshop.py"
-    rs_run_cmd+=" ${image_sourcing_url}"
     rs_run_cmd+=" --log-level=${run_log_level}"
     rs_run_cmd+=" ${rickshaw_run_args[@]}"
 


### PR DESCRIPTION
## Summary

- Remove the legacy `--source-images-service-url` CLI arg from the rickshaw-run command line
- Rickshaw now reads per-arch service URLs from `image-sourcing-urls.json` (written by `bin/_main`), making the old single-URL arg dead code
- Removes the `image_sourcing_url` variable, the native arch URL tracking logic in the services loop, and the arg from the command string

## Depends on

- [crucible#584](https://github.com/perftool-incubator/crucible/pull/584) (merged) — per-arch services.json and image-sourcing-urls.json
- [rickshaw#818](https://github.com/perftool-incubator/rickshaw/pull/818) (merged) — rickshaw reads image-sourcing-urls.json, ignores legacy arg

## Test plan

- [ ] `crucible run` with single-arch config — verify run succeeds without `--source-images-service-url` in the command
- [ ] Verify `image-sourcing-urls.json` is still written and used

🤖 Generated with [Claude Code](https://claude.com/claude-code)