### PR TITLE
feat: add crucible ps and crucible images commands

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -16,7 +16,7 @@ _crucible_completions() {
     num_words=${#COMP_WORDS[@]} # Total number of words on the command
     let num_index=$num_words-1
     if [ $num_words -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo userenvs update run wrapper console start stop get rm index postprocess opensearch extract ls tags archive unarchive reset instances" -- "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "help log repo userenvs update run wrapper console start stop ps images get rm index postprocess opensearch extract ls tags archive unarchive reset instances" -- "${COMP_WORDS[1]}"))
     elif [ $num_words -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)

--- a/bin/_help
+++ b/bin/_help
@@ -46,6 +46,8 @@ function help() {
     echo "tags                          |  Manage the tags associated with run results"
     echo "archive <dir>                 |  Create an archive of the run result pointed to by <dir> and remove it from the run directory"
     echo "unarchive <archive>           |  Unpack an archive named <archive> and put it back in the run directory"
+    echo "ps                            |  Show running crucible containers"
+    echo "images                        |  Show crucible container images"
     echo "start <service list>          |  Start the specified service(s) manually.  Not required, Crucible will start the services it needs when it needs them."
     echo "                              |  A service list is a space separated list of one or more of: all, cdm-server, httpd, image-sourcing, opensearch, & valkey"
     echo "stop <service list>           |  Stop the specified service(s) manually.  See the start command for more details."

--- a/bin/_main
+++ b/bin/_main
@@ -85,6 +85,23 @@ elif [ "${1}" == "update" ]; then
         ${CRUCIBLE_HOME}/bin/update ${1}
         EXIT_VAL=$?
     fi
+elif [ "${1}" == "ps" ]; then
+    shift
+    podman ps --filter name=crucible "$@"
+    EXIT_VAL=0
+elif [ "${1}" == "images" ]; then
+    shift
+    controller_url=$(jq_query ${REGISTRIES_CFG} '.controller.url')
+    public_engine_url=$(jq_query ${REGISTRIES_CFG} '.engines.public.url // empty')
+    private_engine_url=$(jq_query ${REGISTRIES_CFG} '.engines.private.url // empty')
+    filter_pattern="${controller_url}"
+    for url in ${public_engine_url} ${private_engine_url}; do
+        if [ -n "${url}" ] && ! echo "${filter_pattern}" | grep -q "${url}"; then
+            filter_pattern="${filter_pattern}\|${url}"
+        fi
+    done
+    podman images "$@" | head -1; podman images "$@" | grep "${filter_pattern}"
+    EXIT_VAL=0
 elif [ "${1}" == "start" -o "${1}" == "stop" ]; then
     service_control "$@"
     EXIT_VAL=$?


### PR DESCRIPTION
## Summary

- Add `crucible ps` to show running crucible containers (filters by `name=crucible`)
- Add `crucible images` to show crucible container images (filters using controller and engine URLs from `registries.json`, supporting both public and private engine registries)
- Both commands pass through additional arguments to podman (e.g., `crucible ps -a` for stopped containers)
- Added to help output and tab completions

## Test plan

- [ ] `crucible ps` — shows only crucible containers
- [ ] `crucible ps -a` — includes stopped containers
- [ ] `crucible images` — shows controller and engine images with header
- [ ] `crucible help` — lists both commands
- [ ] Tab completion includes `ps` and `images`

🤖 Generated with [Claude Code](https://claude.com/claude-code)