### PR TITLE
feat: guard against crucible update and service stops during active runs

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -946,6 +946,20 @@ function service_control() {
             ;;
     esac
 
+    if [ "${action}" == "stop" ]; then
+        local run_containers
+        run_containers=$(${podman_ps} --filter "name=crucible-rickshaw-run" --filter "status=running" --format "{{.Names}}")
+        if [ -n "${run_containers}" ]; then
+            echo "ERROR: Cannot stop services while a crucible run is active"
+            echo "ERROR: Active run container(s):"
+            echo "${run_containers}" | while read container; do
+                echo "ERROR:   ${container}"
+            done
+            echo "ERROR: Wait for the run(s) to complete or stop them manually before stopping services"
+            return 1
+        fi
+    fi
+
     action_rc=0
 
     while [ $# -gt 0 ]; do

--- a/bin/update
+++ b/bin/update
@@ -54,6 +54,17 @@ if [ -e "${UPDATE_STATUS_FILE}" ]; then
     rm "${UPDATE_STATUS_FILE}" "${UPDATE_STATUS_FILE}.log"
 fi
 
+run_containers=$(${podman_ps} --filter "name=crucible-rickshaw-run" --filter "status=running" --format "{{.Names}}")
+if [ -n "${run_containers}" ]; then
+    echo "ERROR: Cannot update while a crucible run is active"
+    echo "ERROR: Active run container(s):"
+    echo "${run_containers}" | while read container; do
+        echo "ERROR:   ${container}"
+    done
+    echo "ERROR: Wait for the run(s) to complete or stop them manually before updating"
+    exit 1
+fi
+
 case "${repo}" in
     "all"|"crucible"|"controller-image")
         echo


### PR DESCRIPTION
## Summary

- Prevent `crucible update` from running while a `crucible run` is active by checking for running `crucible-rickshaw-run-*` containers before stopping services
- Block `crucible stop` from stopping any services during an active run, since stopping valkey, image-sourcing, or other services would break the in-progress run
- Uses `podman ps` container check — authoritative and can't go stale (no lock files)
- Clear error messages listing the active run container(s)

## Test plan

- [ ] Start a run, then `crucible update` — should get a clear error and refuse to proceed
- [ ] Start a run, then `crucible stop all` — should get a clear error
- [ ] Start a run, then `crucible stop valkey` — should get a clear error
- [ ] No run active: `crucible update` — should work normally
- [ ] No run active: `crucible stop all` — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)