### PR TITLE
fix: handle primary repo type in repo config update checkout

### DIFF
--- a/bin/repo
+++ b/bin/repo
@@ -492,8 +492,13 @@ function config_update_repo() {
         fi
     elif [ ${do_target_checkout} -eq 1 ]; then
         subproject_type=$(jq_query ${repos_json} --arg repo_name "${name}" '.official[], .unofficial[] | select(.name == $repo_name) | .type')
-        subproject_type_dir=$(get_project_type_dir "${subproject_type}")
-        if pushd ${CRUCIBLE_HOME}/subprojects/${subproject_type_dir}/${name} > /dev/null; then
+        if [ "${subproject_type}" == "primary" ]; then
+            checkout_dir=${CRUCIBLE_HOME}
+        else
+            subproject_type_dir=$(get_project_type_dir "${subproject_type}")
+            checkout_dir=${CRUCIBLE_HOME}/subprojects/${subproject_type_dir}/${name}
+        fi
+        if pushd ${checkout_dir} > /dev/null; then
             if ! git checkout ${checkout_target}; then
                 echo "ERROR: Failed to checkout target '${checkout_target}' for subproject '${name}'"
                 popd > /dev/null


### PR DESCRIPTION
## Summary
- `crucible repo config update name=crucible checkout-target=<branch>` failed because the checkout path was constructed as `subprojects/primary/crucible`, which doesn't exist — the crucible repo lives at `CRUCIBLE_HOME` directly
- Special-case repos with type "primary" to use `CRUCIBLE_HOME` as the checkout directory

## Test plan
- [x] `crucible repo config update name=crucible checkout-target=<branch>` successfully checks out the branch
- [x] `crucible repo config update name=crucible checkout-target=master` switches back
- [x] Subproject checkout-target updates still work (e.g., `name=rickshaw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)