### PR TITLE
Add tool-ethtool to subproject registry

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -351,6 +351,16 @@
             }
         },
         {
+            "name": "ethtool",
+            "type": "tool",
+            "repository": "https://github.com/perftool-incubator/tool-ethtool",
+            "primary-branch": "main",
+            "checkout": {
+                "mode": "follow",
+                "target": "main"
+            }
+        },
+        {
             "name": "examples",
             "type": "doc",
             "repository": "https://github.com/perftool-incubator/crucible-examples",


### PR DESCRIPTION
## Summary

Register the new `tool-ethtool` subproject in `config/repos.json` so it is automatically cloned and symlinked during `crucible install` and `crucible update`.

## What is tool-ethtool?

A crucible tool that collects all `ethtool -S` counters at configurable intervals during benchmark runs. Provides per-queue RX/TX packet/byte rates, aggregate NIC statistics (steer_missed, out_of_buffer, etc.), and per-channel completion queue stats as CDM metrics queryable via `crucible get metric`.

Supports both Mellanox (`rx0_packets`) and Intel (`rx_queue_0_packets`) per-queue naming conventions.

Repository: https://github.com/perftool-incubator/tool-ethtool

## Changes

- `config/repos.json`: add ethtool entry (type: tool, primary-branch: main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)