### PR TITLE
Add tool-dpdk to subproject registry

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -361,6 +361,16 @@
             }
         },
         {
+            "name": "dpdk",
+            "type": "tool",
+            "repository": "https://github.com/perftool-incubator/tool-dpdk",
+            "primary-branch": "main",
+            "checkout": {
+                "mode": "follow",
+                "target": "main"
+            }
+        },
+        {
             "name": "examples",
             "type": "doc",
             "repository": "https://github.com/perftool-incubator/crucible-examples",


### PR DESCRIPTION
## Summary
- Register tool-dpdk in config/repos.json as an official tool subproject

🤖 Generated with [Claude Code](https://claude.com/claude-code)