### PR TITLE
fix: resolve image-sourcing default key at runtime

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -371,10 +371,11 @@ elif [ "${1}" == "run" ]; then
         # Build per-architecture URL mapping and write to run config
         urls_json="{"
 
-        for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
-            arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.address")
-            arch_port=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.port")
-            arch_protocol=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.protocol")
+        for arch in $(get_image_sourcing_arches); do
+            config_key=$(get_image_sourcing_config_key ${arch})
+            arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".location.address")
+            arch_port=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".location.port")
+            arch_protocol=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".location.protocol")
             arch_url="${arch_protocol}://${arch_address}:${arch_port}"
 
             echo "Using ${arch} image-sourcing service @ ${arch_url}"

--- a/bin/_migrate-services-config
+++ b/bin/_migrate-services-config
@@ -7,9 +7,9 @@
 #
 # It handles three migration cases (applied in order):
 #   1. Old flat format (location/start/use directly under image-sourcing)
-#      → converted to per-arch services map with native arch as the key
-#   2. New format with "default" placeholder key
-#      → "default" replaced with the host's native architecture
+#      → converted to per-arch services map with "default" as the key
+#   2. Previously resolved native arch key (e.g., "x86_64") without "default"
+#      → renamed back to "default" for portability
 #   3. Standalone instances.json exists
 #      → merged into services.json under the "opensearch" key
 
@@ -34,8 +34,6 @@ fi
 # when this migration script runs.  Use raw jq here; schema validation
 # happens later when bin/base loads and validates the config.
 
-native_arch=$(uname -m)
-
 # Check if this is the old flat format (has image-sourcing.location at top level)
 has_old_format=$(jq -r '."image-sourcing" | has("location")' ${SERVICES_CFG})
 
@@ -49,7 +47,7 @@ if [ "${has_old_format}" == "true" ]; then
     old_protocol=$(jq -r '."image-sourcing".location.protocol' ${SERVICES_CFG})
     old_use=$(jq -r '."image-sourcing".use' ${SERVICES_CFG})
 
-    jq --indent 4 --arg arch "${native_arch}" \
+    jq --indent 4 \
        --argjson start "${old_start}" \
        --arg address "${old_address}" \
        --argjson port "${old_port}" \
@@ -58,7 +56,7 @@ if [ "${has_old_format}" == "true" ]; then
        '."image-sourcing" = {
            "use": $use,
            "services": {
-               ($arch): {
+               "default": {
                    "start": $start,
                    "location": {
                        "address": $address,
@@ -69,22 +67,25 @@ if [ "${has_old_format}" == "true" ]; then
            }
        }' ${SERVICES_CFG} > ${SERVICES_CFG}.tmp && mv ${SERVICES_CFG}.tmp ${SERVICES_CFG}
 
-    echo "Migrated image-sourcing config to per-architecture format with key '${native_arch}'"
+    echo "Migrated image-sourcing config to per-architecture format with key 'default'"
     exit 0
 fi
 
-# Check if the new format has a "default" key that needs to be resolved
+# If a previous migration resolved "default" to the native architecture,
+# convert it back to "default" so the config file stays portable.
+native_arch=$(uname -m)
+has_native=$(jq -r --arg arch "${native_arch}" '."image-sourcing".services | has($arch)' ${SERVICES_CFG} 2>/dev/null)
 has_default=$(jq -r '."image-sourcing".services | has("default")' ${SERVICES_CFG} 2>/dev/null)
 
-if [ "${has_default}" == "true" ]; then
-    echo "Resolving 'default' image-sourcing service key to '${native_arch}'..."
+if [ "${has_native}" == "true" -a "${has_default}" != "true" ]; then
+    echo "Converting resolved '${native_arch}' image-sourcing key back to 'default'..."
 
     jq --indent 4 --arg arch "${native_arch}" \
-       '."image-sourcing".services[$arch] = ."image-sourcing".services["default"] |
-        del(."image-sourcing".services["default"])' \
+       '."image-sourcing".services["default"] = ."image-sourcing".services[$arch] |
+        del(."image-sourcing".services[$arch])' \
        ${SERVICES_CFG} > ${SERVICES_CFG}.tmp && mv ${SERVICES_CFG}.tmp ${SERVICES_CFG}
 
-    echo "Resolved 'default' to '${native_arch}'"
+    echo "Converted '${native_arch}' to 'default'"
 fi
 
 # Migrate instances.json into the opensearch section of services.json

--- a/bin/base
+++ b/bin/base
@@ -309,19 +309,41 @@ function stop_valkey() {
     return ${RC}
 }
 
+function get_image_sourcing_arches() {
+    local native_arch config_key
+    native_arch=$(uname -m)
+    for config_key in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
+        if [ "${config_key}" == "default" ]; then
+            echo "${native_arch}"
+        else
+            echo "${config_key}"
+        fi
+    done
+}
+
+function get_image_sourcing_config_key() {
+    local arch=${1}
+    if jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\"" | grep -q "null"; then
+        echo "default"
+    else
+        echo "${arch}"
+    fi
+}
+
 function start_image_sourcing() {
     local image_sourcing_start_cmd image_sourcing_status_cmd
     local image_sourcing_available image_sourcing_timeout
     local count RC
-    local arch arch_start arch_address arch_port arch_protocol
+    local arch config_key arch_start arch_address arch_port arch_protocol
     local container_name native_arch
 
     native_arch=$(uname -m)
 
     image_sourcing_start_cmd="${CRUCIBLE_HOME}/bin/services/start-image-sourcing.sh ${var_crucible}"
 
-    for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
-        arch_start=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".start")
+    for arch in $(get_image_sourcing_arches); do
+        config_key=$(get_image_sourcing_config_key ${arch})
+        arch_start=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".start")
         if [ "${arch_start}" != "true" ]; then
             continue
         fi
@@ -333,9 +355,9 @@ function start_image_sourcing() {
             return 1
         fi
 
-        arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.address")
-        arch_port=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.port")
-        arch_protocol=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${arch}\".location.protocol")
+        arch_address=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".location.address")
+        arch_port=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".location.port")
+        arch_protocol=$(jq_query ${SERVICES_CFG} ".\"image-sourcing\".services.\"${config_key}\".location.protocol")
 
         container_name="crucible-image-sourcing-${arch}"
 
@@ -350,7 +372,7 @@ function start_image_sourcing() {
                 jq_update_validated ${SERVICES_CFG} \
                                     ${SERVICES_CFG_SCHEMA} \
                                     "services:image-sourcing-${arch}-port-search" \
-                                    --arg arch "${arch}" \
+                                    --arg arch "${config_key}" \
                                     ".\"image-sourcing\".services[\$arch].location.port = ${actual_port}"
                 arch_port=${actual_port}
             fi
@@ -394,7 +416,7 @@ function stop_image_sourcing() {
     local RC arch container_name
     RC=0
 
-    for arch in $(jq_query ${SERVICES_CFG} '."image-sourcing".services | keys[]'); do
+    for arch in $(get_image_sourcing_arches); do
         container_name="crucible-image-sourcing-${arch}"
         echo -n "Checking for ${arch} image-sourcing service"
         if podman_running ${container_name}; then

--- a/config/services.json
+++ b/config/services.json
@@ -8,7 +8,7 @@
     "image-sourcing": {
         "use": true,
         "services": {
-            "x86_64": {
+            "default": {
                 "start": true,
                 "location": {
                     "address": "localhost",

--- a/schema/services.json
+++ b/schema/services.json
@@ -12,7 +12,7 @@
                     "type": "boolean"
                 },
                 "services": {
-                    "description": "A map of CPU architecture to image sourcing service configuration. Each key is an architecture name (e.g., 'x86_64', 'aarch64') or the special value 'default' which is resolved to the host's native architecture during install/update. Services with 'start' set to true are started locally; non-native architectures are started under QEMU emulation.",
+                    "description": "A map of CPU architecture to image sourcing service configuration. Each key is an architecture name (e.g., 'x86_64', 'aarch64') or the special value 'default' which is resolved to the host's native architecture at runtime. Services with 'start' set to true are started locally; non-native architectures must use a remote service with start set to false.",
                     "type": "object",
                     "minProperties": 1,
                     "patternProperties": {


### PR DESCRIPTION
## Summary
- Resolve the image-sourcing `"default"` placeholder key to the native architecture at runtime instead of destructively rewriting `config/services.json`
- Add reverse migration to convert previously resolved native arch keys (e.g., `"x86_64"`) back to `"default"` for portability
- Fixes accidental commit of resolved `x86_64` key in PR#592

## Test plan
- [ ] Verify `crucible start image-sourcing` works with `"default"` key in services.json
- [ ] Verify `crucible stop image-sourcing` works with `"default"` key
- [ ] Verify `crucible run` writes correct arch-keyed `image-sourcing-urls.json`
- [ ] Verify migration converts existing `"x86_64"` key back to `"default"`
- [ ] Verify migration is idempotent (second run is silent)
- [ ] Verify multi-arch configs with explicit non-native arch keys are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Jira: [PERFNFV-310](https://redhat.atlassian.net/browse/PERFNFV-310)