### PR TITLE
feat: add systemd service for dedicated image sourcing builders

### DIFF
--- a/bin/services/crucible-image-sourcing.service
+++ b/bin/services/crucible-image-sourcing.service
@@ -6,8 +6,8 @@ Wants=network-online.target
 [Service]
 Type=forking
 EnvironmentFile=/etc/sysconfig/crucible
-ExecStart=${CRUCIBLE_HOME}/bin/crucible start image-sourcing
-ExecStop=${CRUCIBLE_HOME}/bin/crucible stop image-sourcing
+ExecStart=__CRUCIBLE_HOME__/bin/crucible start image-sourcing
+ExecStop=__CRUCIBLE_HOME__/bin/crucible stop image-sourcing
 Restart=on-failure
 RestartSec=10
 TimeoutStartSec=120

--- a/bin/services/crucible-image-sourcing.service
+++ b/bin/services/crucible-image-sourcing.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Crucible Image Sourcing Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+EnvironmentFile=/etc/sysconfig/crucible
+ExecStart=${CRUCIBLE_HOME}/bin/crucible start image-sourcing
+ExecStop=${CRUCIBLE_HOME}/bin/crucible stop image-sourcing
+Restart=on-failure
+RestartSec=10
+TimeoutStartSec=120
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/bin/services/setup-image-sourcing-service.sh
+++ b/bin/services/setup-image-sourcing-service.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+
+. /etc/sysconfig/crucible
+
+if [ -z "${CRUCIBLE_HOME}" -o ! -e "${CRUCIBLE_HOME}" ]; then
+    echo "ERROR: Could not find \${CRUCIBLE_HOME} [${CRUCIBLE_HOME}], exiting."
+    exit 1
+fi
+
+UNIT_FILE="${CRUCIBLE_HOME}/bin/services/crucible-image-sourcing.service"
+SYSTEMD_DIR="/etc/systemd/system"
+SERVICE_NAME="crucible-image-sourcing"
+
+if [ ! -f "${UNIT_FILE}" ]; then
+    echo "ERROR: Unit file not found at ${UNIT_FILE}"
+    exit 1
+fi
+
+action="${1:-install}"
+
+case "${action}" in
+    install)
+        echo "Installing ${SERVICE_NAME} systemd service..."
+
+        cp "${UNIT_FILE}" "${SYSTEMD_DIR}/${SERVICE_NAME}.service"
+        systemctl daemon-reload
+        systemctl enable "${SERVICE_NAME}"
+
+        echo ""
+        echo "${SERVICE_NAME} service installed and enabled."
+        echo ""
+        echo "The service will start automatically on boot."
+        echo "To start it now:  systemctl start ${SERVICE_NAME}"
+        echo "To check status:  systemctl status ${SERVICE_NAME}"
+        echo ""
+        echo "Configure the listening port in ${CRUCIBLE_HOME}/config/services.json"
+        echo "under the image-sourcing.services section."
+        ;;
+    uninstall)
+        echo "Uninstalling ${SERVICE_NAME} systemd service..."
+
+        if systemctl is-active "${SERVICE_NAME}" 2>/dev/null | grep -q "^active$"; then
+            systemctl stop "${SERVICE_NAME}"
+        fi
+        systemctl disable "${SERVICE_NAME}" 2>/dev/null
+        rm -f "${SYSTEMD_DIR}/${SERVICE_NAME}.service"
+        systemctl daemon-reload
+
+        echo "${SERVICE_NAME} service uninstalled."
+        ;;
+    *)
+        echo "Usage: $(basename $0) [install|uninstall]"
+        exit 1
+        ;;
+esac

--- a/bin/services/setup-image-sourcing-service.sh
+++ b/bin/services/setup-image-sourcing-service.sh
@@ -24,7 +24,7 @@ case "${action}" in
     install)
         echo "Installing ${SERVICE_NAME} systemd service..."
 
-        cp "${UNIT_FILE}" "${SYSTEMD_DIR}/${SERVICE_NAME}.service"
+        sed "s|__CRUCIBLE_HOME__|${CRUCIBLE_HOME}|g" "${UNIT_FILE}" > "${SYSTEMD_DIR}/${SERVICE_NAME}.service"
         systemctl daemon-reload
         systemctl enable "${SERVICE_NAME}"
 

--- a/bin/services/start-image-sourcing.sh
+++ b/bin/services/start-image-sourcing.sh
@@ -4,5 +4,7 @@
 
 log_base="$1"
 
+mkdir -p ${log_base}/logs
+
 python3 -m source_images_service.main 2>&1 \
     | tee ${log_base}/logs/image-sourcing.log

--- a/bin/update
+++ b/bin/update
@@ -67,12 +67,11 @@ fi
 
 case "${repo}" in
     "all"|"crucible"|"controller-image")
-        restart_image_sourcing_service=0
         if systemctl is-enabled crucible-image-sourcing 2>/dev/null &&
            systemctl is-active crucible-image-sourcing 2>/dev/null; then
             echo "Stopping crucible-image-sourcing systemd service for update..."
             systemctl stop crucible-image-sourcing
-            restart_image_sourcing_service=1
+            touch /tmp/.crucible-restart-image-sourcing
         fi
 
         echo
@@ -232,7 +231,8 @@ ${CRUCIBLE_HOME}/bin/repo info
 echo
 ${CRUCIBLE_HOME}/bin/repo config show
 
-if [ ${restart_image_sourcing_service} -eq 1 ] 2>/dev/null; then
+if [ -f /tmp/.crucible-restart-image-sourcing ]; then
+    rm -f /tmp/.crucible-restart-image-sourcing
     echo "Restarting crucible-image-sourcing systemd service after update..."
     systemctl start crucible-image-sourcing
 fi

--- a/bin/update
+++ b/bin/update
@@ -67,6 +67,11 @@ fi
 
 case "${repo}" in
     "all"|"crucible"|"controller-image")
+        if systemctl is-enabled crucible-image-sourcing 2>/dev/null; then
+            echo "Stopping crucible-image-sourcing systemd service for update..."
+            systemctl stop crucible-image-sourcing
+        fi
+
         echo
         echo "Shutting down existing controller pods:"
         echo
@@ -223,6 +228,11 @@ echo
 ${CRUCIBLE_HOME}/bin/repo info
 echo
 ${CRUCIBLE_HOME}/bin/repo config show
+
+if systemctl is-enabled crucible-image-sourcing 2>/dev/null; then
+    echo "Restarting crucible-image-sourcing systemd service after update..."
+    systemctl start crucible-image-sourcing
+fi
 
 if [ ${RC} != 0 ]; then
     echo

--- a/bin/update
+++ b/bin/update
@@ -67,9 +67,12 @@ fi
 
 case "${repo}" in
     "all"|"crucible"|"controller-image")
-        if systemctl is-enabled crucible-image-sourcing 2>/dev/null; then
+        restart_image_sourcing_service=0
+        if systemctl is-enabled crucible-image-sourcing 2>/dev/null &&
+           systemctl is-active crucible-image-sourcing 2>/dev/null; then
             echo "Stopping crucible-image-sourcing systemd service for update..."
             systemctl stop crucible-image-sourcing
+            restart_image_sourcing_service=1
         fi
 
         echo
@@ -229,7 +232,7 @@ ${CRUCIBLE_HOME}/bin/repo info
 echo
 ${CRUCIBLE_HOME}/bin/repo config show
 
-if systemctl is-enabled crucible-image-sourcing 2>/dev/null; then
+if [ ${restart_image_sourcing_service} -eq 1 ] 2>/dev/null; then
     echo "Restarting crucible-image-sourcing systemd service after update..."
     systemctl start crucible-image-sourcing
 fi


### PR DESCRIPTION
## Summary
- Add a systemd unit file and setup script for running the image sourcing service as a persistent service on dedicated builder hosts (e.g., aarch64 builders)
- The unit calls `crucible start/stop image-sourcing` directly — no wrapper scripts needed
- `crucible update` stops the systemd service before updating and restarts it after, preventing auto-restart conflicts. Both checks are no-ops on installs without the service.

## Setup
```bash
# Install and enable the service
${CRUCIBLE_HOME}/bin/services/setup-image-sourcing-service.sh install

# Start it
systemctl start crucible-image-sourcing

# Uninstall
${CRUCIBLE_HOME}/bin/services/setup-image-sourcing-service.sh uninstall
```

## Test plan
- [ ] Run `setup-image-sourcing-service.sh install` — verify unit file installed and enabled
- [ ] `systemctl start crucible-image-sourcing` — verify container starts and health check passes
- [ ] `curl http://localhost:8888/api/v1/health` — verify service responds
- [ ] `systemctl stop crucible-image-sourcing` — verify clean shutdown
- [ ] `crucible update` — verify service stops before update and restarts after
- [ ] `crucible update` on install without service — verify no errors (no-op)
- [ ] `setup-image-sourcing-service.sh uninstall` — verify clean removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Jira: [PERFNFV-305](https://redhat.atlassian.net/browse/PERFNFV-305)