### PR TITLE
fix: add .gitignore to CI filter and expand Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,17 @@
             "Bash(cd * && git log*)",
             "Bash(cd * && git show*)",
             "Bash(cd * && git fetch*)",
-            "Bash(cd * && grep *)"
+            "Bash(cd * && grep *)",
+            "Bash(git status *)",
+            "Bash(git log *)",
+            "Bash(git diff *)",
+            "Bash(git show *)",
+            "Bash(git branch *)",
+            "Bash(git stash list *)",
+            "Bash(git fetch *)",
+            "Bash(python3 -m py_compile *)",
+            "Bash(find *)",
+            "Bash(grep *)"
         ]
     }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
             .github/workflows/fork-check.yaml
+            .gitignore
             .claude/**
             docs/**
             spec/**

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -36,6 +36,7 @@ jobs:
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
             .github/workflows/fork-check.yaml
+            .gitignore
             .claude/**
             docs/**
             spec/**

--- a/.github/workflows/crucible-release-ci.yaml
+++ b/.github/workflows/crucible-release-ci.yaml
@@ -35,6 +35,7 @@ jobs:
             .github/workflows/build-publish-controller.yaml
             .github/workflows/build-publish-controller-worker.yaml
             .github/workflows/fork-check.yaml
+            .gitignore
             .claude/**
             docs/**
             spec/**

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config/instances.json
 config/registries.json
 config/valkey_pass
 bin/_logger_lib/__pycache__/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.gitignore` to the docs-only file filter in all three CI workflows (`crucible-ci.yaml`, `ci.yaml`, `crucible-release-ci.yaml`) so `.gitignore` changes don't trigger full integration test runs
- Add `.claude/settings.local.json` to `.gitignore` (personal settings shouldn't be tracked)
- Expand shared Claude Code permissions with read-only bash commands: bare git commands, `python3 -m py_compile`, `find`, `grep`

## Test plan
- [ ] Verify CI treats this PR as docs-only (faux CI should run, not real CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)