### PR TITLE
docs: update post-processing guides for postprocess/ directory

### DIFF
--- a/docs/implementing-a-new-benchmark.md
+++ b/docs/implementing-a-new-benchmark.md
@@ -546,8 +546,9 @@ use toolbox::metrics;
 ### Output format
 
 The post-process script must write `post-process-data.json` to the
-current directory. This file tells rickshaw where to find the metrics
-and what the primary metric is:
+`postprocess/` subdirectory. The toolbox metrics library automatically
+writes metric-data files there as well. This file tells rickshaw where
+to find the metrics and what the primary metric is:
 
 ```json
 {
@@ -613,7 +614,8 @@ def main():
             'metric-files': [metric_file_name]
         }]
     }
-    with open('post-process-data.json', 'w') as f:
+    os.makedirs('postprocess', exist_ok=True)
+    with open('postprocess/post-process-data.json', 'w') as f:
         json.dump(output, f)
 
 if __name__ == "__main__":
@@ -662,7 +664,7 @@ synchronized by roadblock:
 2. For each iteration/sample/role combination, runs the controller
    `post-script` in that sample's output directory
 3. Post-process script reads raw output, calls `log_sample` /
-   `finish_samples`, writes `post-process-data.json`
+   `finish_samples`, writes `postprocess/post-process-data.json`
 4. Rickshaw indexes the metrics into the result store
 
 ---

--- a/docs/implementing-a-new-tool.md
+++ b/docs/implementing-a-new-tool.md
@@ -346,7 +346,8 @@ use toolbox::metrics;
 ### Output format
 
 The post-process script must write `post-process-data.json` to the
-current directory:
+`postprocess/` subdirectory. The toolbox metrics library automatically
+writes metric-data files there as well:
 
 ```json
 {
@@ -404,7 +405,8 @@ def main():
             'metric-files': [metric_file_name]
         }]
     }
-    with open('post-process-data.json', 'w') as f:
+    os.makedirs('postprocess', exist_ok=True)
+    with open('postprocess/post-process-data.json', 'w') as f:
         json.dump(output, f)
 
 if __name__ == "__main__":
@@ -440,7 +442,7 @@ coordinated by roadblock synchronization:
 2. For each iteration/sample/collector combination, the controller
    runs the tool's `post-script` in that sample's output directory
 3. Post-process script reads compressed raw output, calls
-   `log_sample` / `finish_samples`, writes `post-process-data.json`
+   `log_sample` / `finish_samples`, writes `postprocess/post-process-data.json`
 4. Rickshaw indexes the metrics into the result store
 
 ---


### PR DESCRIPTION
## Summary
- Update benchmark and tool implementation guides to reflect that post-process-data.json and metric-data files are now written to the `postprocess/` subdirectory
- Code examples include `os.makedirs('postprocess', exist_ok=True)` before writing

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Test plan
- [ ] Verify docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)