### PR TITLE
docs: add comprehensive subsystem documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,4 +230,5 @@ Available skills:
 - **Review requests**: When opening PRs, request review from the **Developers** team and self-assign the PR.
 - **Commit messages**: Use conventional commits format (`feat:`, `fix:`, `docs:`, etc.). Be precise and descriptive — prefer nuanced descriptions over broad generalizations.
 - **CLAUDE.md updates**: When making structural changes to a subproject, update that subproject's CLAUDE.md in the same PR. Claude should author CLAUDE.md content, not humans — the human role is review and approval.
+- **Documentation updates**: When making changes to any crucible repo that affect user-facing behavior, configuration, architecture, or workflows, check whether the `docs/` guides need corresponding updates. Consult the documentation index in the Documentation section above to identify which guides cover the affected area. Documentation must stay in sync with the code — treat stale docs as a bug. This applies to all repos in the organization, not just the crucible repo itself.
 - **Branch rulesets**: `.github/rulesets/` files are backups of configured rulesets, not authoritative. Do not read or modify them to determine required status checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,12 +49,33 @@ Defined in `config/repos.json` with categories:
 
 Each entry in `repos.json` has: `name`, `type`, `repository`, `primary-branch`, and `checkout` config.
 
-## Creating New Benchmarks and Tools
+## Documentation
 
-When a user asks to create a new benchmark or tool, consult the implementation guides in `docs/` before writing any code:
+The `docs/` directory contains detailed guides for how each crucible subsystem operates. Consult these when working on, debugging, or analyzing any part of the framework.
 
-- **`docs/implementing-a-new-benchmark.md`** — Complete guide for creating a new benchmark: required files (`rickshaw.json`, `workshop.json`, scripts), rickshaw.json schema, client-server messaging, post-processing with the toolbox metrics API, multiplex.json parameter definitions, CPU partitioning support, and reference implementations by complexity level.
-- **`docs/implementing-a-new-tool.md`** — Complete guide for creating a new tool (passive data collector): required files (`rickshaw.json`, `workshop.json`, start/stop/post-process scripts), collector whitelist/blacklist configuration, tool parameter handling, and reference implementations.
+### Architecture and subsystem guides
+
+- **`docs/crucible-architecture-overview.md`** — High-level overview of all components and how they fit together. Start here.
+- **`docs/how-benchmark-execution-works.md`** — Parameter expansion, engine deployment, synchronized execution, periods, and result generation.
+- **`docs/how-tool-collection-works.md`** — Tool lifecycle, collection models, deployment, and how CDM queries extract tool data by time range.
+- **`docs/how-engines-work.md`** — Bootstrap, execution phases, files-from-controller, CPU partitioning, data archival.
+- **`docs/how-endpoints-work.md`** — Remotehosts, kube, and osp endpoint types, validation, deployment, service discovery.
+- **`docs/how-image-sourcing-works.md`** — The multi-stage image build pipeline, content-based tagging, multi-architecture support.
+- **`docs/how-roadblock-works.md`** — Distributed synchronization, barrier protocol, messaging, wait-for mechanism.
+- **`docs/how-cdm-works.md`** — Document hierarchy, metric model, indexing pipeline, query system, web dashboard.
+- **`docs/how-services-work.md`** — Valkey, OpenSearch, httpd, CDM server, image-sourcing service management.
+- **`docs/how-the-controller-image-works.md`** — What the controller contains, how it's built, the automated build pipeline.
+- **`docs/how-the-repo-system-works.md`** — repos.json, cloning, symlink activation, updating, multi-fork support.
+- **`docs/how-releases-work.md`** — Quarterly releases, follow vs locked mode, set-release.
+- **`docs/how-ci-works.md`** — Workflow hierarchy, capability-based runner matching, release matrix testing.
+- **`docs/how-the-logger-works.md`** — Pipe-based output capture, SQLite storage, log viewing commands.
+
+### Implementation guides
+
+When creating new benchmarks or tools, consult these before writing any code:
+
+- **`docs/implementing-a-new-benchmark.md`** — Required files, rickshaw.json schema, client-server messaging, post-processing, multiplex.json, and reference implementations.
+- **`docs/implementing-a-new-tool.md`** — Required files, collector whitelist/blacklist, tool parameters, and reference implementations.
 
 These guides define the required file structure, naming conventions, JSON schemas, script patterns, and integration points. Follow them rather than inferring structure from existing code alone.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ The `docs/` directory contains detailed guides for how each crucible subsystem o
 ### Architecture and subsystem guides
 
 - **`docs/crucible-architecture-overview.md`** — High-level overview of all components and how they fit together. Start here.
+- **`docs/how-the-installer-works.md`** — Installation, prerequisites, registry configuration, release installs.
+- **`docs/how-run-files-work.md`** — Run file structure: benchmarks, endpoints, parameters, tools, tags.
 - **`docs/how-benchmark-execution-works.md`** — Parameter expansion, engine deployment, synchronized execution, periods, and result generation.
 - **`docs/how-tool-collection-works.md`** — Tool lifecycle, collection models, deployment, and how CDM queries extract tool data by time range.
 - **`docs/how-engines-work.md`** — Bootstrap, execution phases, files-from-controller, CPU partitioning, data archival.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Through the use of containers built at runtime for software distribution (which 
 ### Architecture and subsystem guides
 
 - [Architecture Overview](docs/crucible-architecture-overview.md) — Start here for a high-level understanding of how crucible works
+- [How the Installer Works](docs/how-the-installer-works.md)
+- [How Run Files Work](docs/how-run-files-work.md)
 - [How Benchmark Execution Works](docs/how-benchmark-execution-works.md)
 - [How Tool Collection Works](docs/how-tool-collection-works.md)
 - [How Engines Work](docs/how-engines-work.md)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Through the use of containers built at runtime for software distribution (which 
 
 ## Documentation
 
+### Architecture and subsystem guides
+
+- [Architecture Overview](docs/crucible-architecture-overview.md) — Start here for a high-level understanding of how crucible works
+- [How Benchmark Execution Works](docs/how-benchmark-execution-works.md)
+- [How Tool Collection Works](docs/how-tool-collection-works.md)
+- [How Engines Work](docs/how-engines-work.md)
+- [How Endpoints Work](docs/how-endpoints-work.md)
+- [How Image Sourcing Works](docs/how-image-sourcing-works.md)
+- [How Roadblock Works](docs/how-roadblock-works.md)
+- [How CDM Works](docs/how-cdm-works.md)
+- [How Services Work](docs/how-services-work.md)
+- [How the Controller Image Works](docs/how-the-controller-image-works.md)
+- [How the Repo System Works](docs/how-the-repo-system-works.md)
+- [How Releases Work](docs/how-releases-work.md)
+- [How CI Works](docs/how-ci-works.md)
+- [How the Logger Works](docs/how-the-logger-works.md)
+
+### Implementation guides
+
 - [Implementing a New Benchmark](docs/implementing-a-new-benchmark.md)
 - [Implementing a New Tool](docs/implementing-a-new-tool.md)
 

--- a/docs/crucible-architecture-overview.md
+++ b/docs/crucible-architecture-overview.md
@@ -198,6 +198,8 @@ before they cause runtime failures.
 
 | If you want to understand... | Read... |
 |------------------------------|---------|
+| How to install crucible | [How the installer works](how-the-installer-works.md) |
+| How to write a run file | [How run files work](how-run-files-work.md) |
 | How benchmarks run | [How benchmark execution works](how-benchmark-execution-works.md) |
 | How tools collect data | [How tool collection works](how-tool-collection-works.md) |
 | How engines operate inside | [How engines work](how-engines-work.md) |

--- a/docs/crucible-architecture-overview.md
+++ b/docs/crucible-architecture-overview.md
@@ -1,0 +1,215 @@
+# Crucible Architecture Overview
+
+This document provides a high-level overview of crucible's
+architecture — how the major components fit together and how
+data flows through the system during a benchmark run. It
+serves as a starting point for understanding the framework
+before diving into the detailed subsystem guides.
+
+## What crucible does
+
+Crucible is a container-based performance testing framework
+that orchestrates benchmark execution across distributed
+infrastructure, collects system-level metrics alongside
+workload results, and provides unified storage and analysis
+of the data.
+
+The framework handles everything from building the container
+images that benchmarks run in, to deploying engines across
+Kubernetes clusters or bare metal hosts, to synchronizing
+distributed workloads, to post-processing raw output into
+queryable metrics.
+
+## Major components
+
+### The controller
+
+The controller is the central orchestration point. It runs
+inside a [container image](how-the-controller-image-works.md)
+that contains all the software needed to manage a benchmark
+run. Every `crucible` command executes inside this container.
+
+The controller coordinates:
+- [Image building](how-image-sourcing-works.md) for engine
+  containers
+- [Engine deployment](how-endpoints-work.md) across
+  infrastructure targets
+- [Distributed synchronization](how-roadblock-works.md)
+  during execution
+- [Post-processing](how-benchmark-execution-works.md) of
+  raw results into metrics
+- [Result storage](how-cdm-works.md) in OpenSearch
+
+### Engines
+
+[Engines](how-engines-work.md) are the containers, chroots,
+or VMs where benchmarks and tools actually execute. Each
+engine is bootstrapped from the controller, receives its
+scripts at runtime, and sends collected data back when
+finished. Engines don't know what deployment target they're
+running on — the abstraction is transparent.
+
+### Endpoints
+
+[Endpoints](how-endpoints-work.md) are the deployment targets
+where engines run. Crucible supports three types:
+- **remotehosts** — deploys engines on bare metal or VMs via
+  SSH (podman containers or chroot)
+- **kube** — deploys engines as pods in Kubernetes clusters
+- **osp** — deploys engines as VMs in OpenStack
+
+### Benchmarks and tools
+
+[Benchmarks](how-benchmark-execution-works.md) generate
+workload — they're the thing being measured (fio, uperf,
+cyclictest, trafficgen, etc.).
+
+[Tools](how-tool-collection-works.md) passively collect
+system data alongside benchmarks — CPU utilization, interrupt
+rates, process activity, etc. (sysstat, procstat, forkstat,
+etc.).
+
+Both are independently versioned repositories in the
+[multi-repo ecosystem](how-the-repo-system-works.md).
+
+### Services
+
+Crucible runs several [supporting services](how-services-work.md)
+as containers:
+- **Valkey** — backend for [roadblock](how-roadblock-works.md)
+  synchronization
+- **OpenSearch** — stores indexed results for
+  [CDM](how-cdm-works.md) queries
+- **CDM server** — query API and web dashboard for result
+  analysis
+- **httpd** — web UI for browsing run artifacts
+- **Image-sourcing service** — builds
+  [engine images](how-image-sourcing-works.md)
+
+## Data flow during a run
+
+A benchmark run proceeds through these stages:
+
+### 1. Configuration
+
+The user writes a run file specifying benchmarks, parameters,
+endpoints, and tools. Parameters expand into iterations via
+cartesian product — multiple parameter values produce
+multiple test configurations.
+
+### 2. Image sourcing
+
+The [source-images-service](how-image-sourcing-works.md)
+builds container images for each benchmark and tool. Images
+are built incrementally using a multi-stage approach where
+common layers (toolbox, roadblock, rickshaw engine) are
+cached and only the benchmark-specific layer is rebuilt when
+scripts change. Images are tagged by content hash for
+deterministic caching.
+
+### 3. Engine deployment
+
+[Endpoints](how-endpoints-work.md) create
+[engines](how-engines-work.md) (containers, pods, or VMs) on
+the target infrastructure. Engines persist for the entire
+run — they execute all iterations and samples without being
+recreated.
+
+### 4. Synchronized execution
+
+For each iteration × sample combination, engines execute in
+lockstep via [roadblock](how-roadblock-works.md)
+synchronization:
+
+- Tools start collecting (before any benchmark activity)
+- Servers launch and publish service info
+- Endpoints create network services (K8s Services, etc.)
+- Clients discover servers and execute the workload
+- Clients finish, servers stop, tools stop
+- Data is archived and transferred back to the controller
+
+### 5. Post-processing
+
+Each benchmark's post-processing script converts raw output
+into CDM-format metrics — standardized time-series data with
+descriptors that define what each metric measures. Tool
+post-processors do the same for collected system data. All
+output goes to the `postprocess/` subdirectory within each
+sample's data.
+
+### 6. Document generation and indexing
+
+`rickshaw-gen-docs.py` reads the post-processed metrics and
+generates OpenSearch documents following the
+[CDM](how-cdm-works.md) hierarchy: run → iteration → sample
+→ period → metrics. These documents are bulk-indexed into
+OpenSearch.
+
+### 7. Analysis
+
+Results are available through:
+- The **CDM web dashboard** for interactive exploration
+  (search, compare, deep-dive views)
+- The **CLI** (`crucible get result`, `crucible get metric`)
+  for command-line queries
+- The **CDM REST API** for programmatic access
+
+## The multi-repo ecosystem
+
+Crucible is composed of 40+ independently versioned
+repositories managed through the
+[repo/subproject system](how-the-repo-system-works.md).
+Repos are cloned to `repos/` and activated via symlinks in
+`subprojects/`. This enables:
+
+- Independent versioning and release cycles per component
+- Multiple forks coexisting on the same system
+- Switching between sources without re-cloning
+
+Quarterly [releases](how-releases-work.md) create
+coordinated snapshots across all repos for stable,
+reproducible installations.
+
+## Supporting infrastructure
+
+### CI
+
+The [CI system](how-ci-works.md) validates changes across the
+multi-repo ecosystem. It uses capability-based runner matching
+to route test scenarios to appropriate infrastructure, with
+docs-only filtering to skip full tests for documentation
+changes.
+
+### Logging
+
+The [logger](how-the-logger-works.md) captures all crucible
+command output to a SQLite database, enabling review of past
+commands without manual log file management.
+
+### Schema validation
+
+JSON schemas enforce configuration validity at system
+boundaries. Configuration files (repos.json, services.json,
+run files, rickshaw.json, workshop.json, etc.) are validated
+against their schemas before use, catching errors early
+before they cause runtime failures.
+
+## Guide to the documentation
+
+| If you want to understand... | Read... |
+|------------------------------|---------|
+| How benchmarks run | [How benchmark execution works](how-benchmark-execution-works.md) |
+| How tools collect data | [How tool collection works](how-tool-collection-works.md) |
+| How engines operate inside | [How engines work](how-engines-work.md) |
+| Where engines are deployed | [How endpoints work](how-endpoints-work.md) |
+| How engine images are built | [How image sourcing works](how-image-sourcing-works.md) |
+| How engines are synchronized | [How roadblock works](how-roadblock-works.md) |
+| How results are stored and queried | [How CDM works](how-cdm-works.md) |
+| How supporting services run | [How services work](how-services-work.md) |
+| What the controller container is | [How the controller image works](how-the-controller-image-works.md) |
+| How repos are managed | [How the repo system works](how-the-repo-system-works.md) |
+| How releases work | [How releases work](how-releases-work.md) |
+| How CI validates changes | [How CI works](how-ci-works.md) |
+| How command output is captured | [How the logger works](how-the-logger-works.md) |
+| How to write a new benchmark | [Implementing a new benchmark](implementing-a-new-benchmark.md) |
+| How to write a new tool | [Implementing a new tool](implementing-a-new-tool.md) |

--- a/docs/how-benchmark-execution-works.md
+++ b/docs/how-benchmark-execution-works.md
@@ -10,6 +10,8 @@ For instructions on creating a new benchmark, see
 [implementing-a-new-benchmark.md](implementing-a-new-benchmark.md).
 For how tool collection works alongside benchmarks, see
 [how-tool-collection-works.md](how-tool-collection-works.md).
+For how results are stored and queried, see
+[how-cdm-works.md](how-cdm-works.md).
 
 ## Overview
 

--- a/docs/how-benchmark-execution-works.md
+++ b/docs/how-benchmark-execution-works.md
@@ -1,0 +1,606 @@
+# How Benchmark Execution Works
+
+This document explains how crucible orchestrates benchmark execution
+— from parameter configuration through engine deployment,
+synchronized workload execution, data collection, and result
+generation. It covers the conceptual model and data flow rather
+than how to write a benchmark.
+
+For instructions on creating a new benchmark, see
+[implementing-a-new-benchmark.md](implementing-a-new-benchmark.md).
+For how tool collection works alongside benchmarks, see
+[how-tool-collection-works.md](how-tool-collection-works.md).
+
+## Overview
+
+Benchmarks are the workload generators in crucible. A run consists
+of one or more benchmarks, each with parameters that expand into
+**iterations**. Each iteration runs one or more **samples**
+(repeated executions of the same parameter set). The orchestration
+framework handles image building, engine deployment, distributed
+synchronization across client and server processes, data collection,
+post-processing, and result generation.
+
+The key abstractions:
+
+- **Iteration**: A unique combination of benchmark parameters
+  (e.g., 64-byte frame size with TCP protocol)
+- **Sample**: A single execution of an iteration's parameters.
+  Multiple samples of the same iteration provide statistical
+  confidence.
+- **Period**: A named time window within a sample
+  (e.g., "measurement"). Most benchmarks have a single measurement
+  period, but some define warm-up or cool-down phases.
+- **Primary metric**: The headline result for the benchmark
+  (e.g., "ops-sec" for uperf, "latency-usec" for cyclictest)
+
+## From run file to iterations
+
+### Parameter specification
+
+The run file specifies benchmark parameters using the multiplex
+system. Parameters are organized into two sections:
+**global-options** (reusable named groups) and **sets** (the
+actual test configurations that reference global-options and add
+set-specific parameters).
+
+```json
+{
+    "benchmarks": [{
+        "name": "uperf",
+        "mv-params": {
+            "global-options": [
+                {
+                    "name": "common",
+                    "params": [
+                        { "arg": "duration", "vals": ["60"] },
+                        { "arg": "nthreads", "vals": ["1"] }
+                    ]
+                }
+            ],
+            "sets": [
+                {
+                    "include": "common",
+                    "params": [
+                        { "arg": "protocol", "vals": ["tcp"] },
+                        { "arg": "wsize", "vals": ["64", "1024"] }
+                    ]
+                },
+                {
+                    "include": "common",
+                    "params": [
+                        { "arg": "protocol", "vals": ["udp"] },
+                        { "arg": "wsize", "vals": ["256"] }
+                    ]
+                }
+            ]
+        }
+    }]
+}
+```
+
+### Structure and fields
+
+**global-options** (required): An array of named parameter groups.
+Each group has:
+
+- `name` (required): A label used by sets to reference this group
+- `params` (required): Array of parameter objects
+
+**sets** (required): An array of test configurations. Each set
+has:
+
+- `include` (optional): Name of a global-options group to inherit
+  parameters from
+- `params` (required): Array of parameter objects specific to this
+  set
+- `enabled` (optional): `"yes"` or `"no"` — disabled sets are
+  skipped entirely, useful for temporarily excluding a
+  configuration without deleting it
+
+**Parameter objects** have these fields:
+
+- `arg` (required): The parameter name passed to the benchmark
+  script as `--arg`
+- `vals` (required): Array of values. Multiple values cause
+  cartesian expansion.
+- `role` (optional): Restricts this parameter to a specific
+  engine role (`"client"` or `"server"`). Parameters without a
+  role apply to all engines.
+- `enabled` (optional): `"yes"` or `"no"` — disabled parameters
+  are excluded
+
+### Cartesian expansion
+
+Each set independently expands its parameters (inherited from
+global-options plus its own) via cartesian product. In the example
+above:
+
+**Set 1** (TCP): `protocol` has 1 value, `wsize` has 2 values →
+2 iterations:
+
+| Iteration | protocol | wsize | duration | nthreads |
+|-----------|----------|-------|----------|----------|
+| 1 | tcp | 64 | 60 | 1 |
+| 2 | tcp | 1024 | 60 | 1 |
+
+**Set 2** (UDP): `protocol` has 1 value, `wsize` has 1 value →
+1 iteration:
+
+| Iteration | protocol | wsize | duration | nthreads |
+|-----------|----------|-------|----------|----------|
+| 3 | udp | 256 | 60 | 1 |
+
+The total run has 3 iterations. Parameters inherited from the
+`common` global-options group (`duration`, `nthreads`) apply to
+all iterations from both sets.
+
+### Role-specific parameters
+
+For client-server benchmarks, some parameters only apply to one
+role. The `role` field controls this:
+
+```json
+{ "arg": "trex-devices", "vals": ["0000:2d:00.0,0000:2d:00.1"], "role": "client" }
+{ "arg": "ifname", "vals": ["default-route"], "role": "server" }
+```
+
+Parameters with `"role": "client"` are only passed to client
+engines; `"role": "server"` only to server engines. Parameters
+without a role field are passed to all engines.
+
+### Samples and test order
+
+Each iteration executes `num-samples` times (default 1). The
+`test-order` setting controls the execution sequence:
+
+- **`sample`** (default): All samples of iteration 1, then all
+  samples of iteration 2, etc.
+- **`iteration`**: Sample 1 of all iterations, then sample 2 of
+  all iterations, etc.
+- **`random`**: Randomized execution order
+
+Random test order is useful for reducing systematic bias from
+thermal effects, caching, or other time-dependent factors.
+
+## Engine images and deployment
+
+### Container image building
+
+Before any benchmark can run, crucible builds container images
+containing the benchmark software and its dependencies. Each
+benchmark has a `workshop.json` file declaring what needs to be
+installed (packages, source builds, pip modules, etc.).
+
+The source-images-service builds these images incrementally using
+a multi-stage approach. Each stage adds one layer of requirements,
+and stages are cached independently. If only the benchmark-specific
+requirements change, earlier stages (toolbox, roadblock, rickshaw
+engine) are reused from cache.
+
+### Split workshop files
+
+Benchmarks with fundamentally different client and server
+requirements (like trafficgen) can use separate
+`client-workshop.json` and `server-workshop.json` files instead
+of a single `workshop.json`. This produces different container
+images for each role, reducing image size and allowing different
+base images (userenvs) per role. The `--image` format includes
+a role field (`bench::role::userenv::arch::image`) so each engine
+gets the correct image for its role.
+
+### Userenvs
+
+A userenv (user environment) defines the base container image for
+the engine. Userenvs are JSON files that specify the OS
+distribution and version (e.g., `rhubi9`, `fedora-latest`,
+`alma8`). Each benchmark's workshop requirements are layered on
+top of the userenv base image.
+
+### Engine deployment
+
+Engines are the containers that run benchmark workloads. Depending
+on the endpoint type:
+
+- **Kubernetes**: Each engine becomes a pod, created via the K8s
+  API. Client and server pods may run on different nodes, with
+  optional node selectors for architecture or topology control.
+- **Remotehosts**: Each engine becomes a podman container on a
+  remote host, started via SSH.
+- **OSP (OpenStack)**: Each engine becomes a VM instance in an
+  OpenStack cluster.
+
+Engines persist for the entire run — they are created once and
+execute all iterations and samples sequentially. This avoids the
+overhead of container creation per sample.
+
+## Per-sample execution flow
+
+Each sample follows a precisely synchronized sequence coordinated
+by roadblock, a distributed barrier synchronization system backed
+by valkey. Every phase has a begin and end barrier that all
+participating engines must reach before execution proceeds.
+
+### Execution sequence
+
+For each sample, the following phases execute in order:
+
+1. **infra-start** — Optional infrastructure setup. Used by
+   benchmarks that need supporting services before the main
+   workload starts (e.g., trafficgen starts a TRex traffic
+   generation service).
+
+2. **server-start** — Server engines launch their server
+   processes (e.g., iperf3 in server mode, uperf master). Servers
+   publish service information (IP address, ports) via the
+   messaging system for clients to discover.
+
+3. **endpoint-start** — Endpoint-specific service setup. On
+   Kubernetes, this may create Service resources (ClusterIP,
+   NodePort, or LoadBalancer) to expose server pods. The endpoint
+   can transform the server's service information (e.g., replacing
+   a pod IP with a LoadBalancer VIP).
+
+4. **client-start** — The main benchmark execution phase:
+   - Client engine 1 runs the `get-runtime` script to discover
+     the expected workload duration
+   - The runtime value adjusts the roadblock timeout for this
+     phase (with padding for startup/teardown overhead)
+   - All client engines execute the benchmark workload
+   - Clients run until completion or timeout
+
+5. **client-stop** — Clients have finished. Data is preserved.
+
+6. **endpoint-stop** — Endpoint-specific cleanup (e.g., deleting
+   Kubernetes Services).
+
+7. **server-stop** — Server processes are shut down cleanly.
+
+8. **infra-stop** — Infrastructure teardown.
+
+Each phase's begin/end barriers ensure tight synchronization
+across all engines, even when distributed across multiple hosts
+or clusters.
+
+## Client-server communication
+
+Client-server benchmarks need clients to discover where servers
+are running. Crucible provides a message-passing system built on
+roadblock synchronization.
+
+### How it works
+
+1. During **server-start**, the server script writes a JSON
+   message to `msgs/tx/svc` containing its IP and port(s):
+   ```json
+   {
+       "recipient": {"type": "all", "id": "all"},
+       "user-object": {
+           "svc": {"ip": "10.244.1.5", "ports": [30000]}
+       }
+   }
+   ```
+
+2. During the roadblock synchronization between server-start-end
+   and client-start-begin, messages are collected and delivered
+   to all participants.
+
+3. **Endpoints may modify the service information.** On
+   Kubernetes, the endpoint creates a Service resource and
+   replaces the pod IP with the Service ClusterIP, NodePort
+   address, or LoadBalancer VIP. This is written as an
+   `endpoint-start-end` message.
+
+4. During **client-start**, the client reads service information
+   from `msgs/rx/`, preferring `endpoint-start-end` messages
+   (which have endpoint-transformed addresses) over
+   `server-start-end` messages (which have raw pod IPs).
+
+This indirection allows the same benchmark code to work across
+different endpoint types without modification — the client always
+reads from `msgs/rx/` and gets the appropriate address for its
+deployment context.
+
+## Controller scripts
+
+### Pre-script
+
+The controller pre-script runs once before any iteration begins.
+It executes on the controller host (not inside engine containers)
+and is used to generate shared configuration that all iterations
+need.
+
+**Example**: fio's pre-script generates job files from the run
+parameters. These files are then copied to client engines via the
+`files-from-controller` mechanism.
+
+### Post-script (post-processing)
+
+The controller post-script runs after all iterations and samples
+have completed and the data has been transferred back from engines.
+It executes once per iteration/sample/role combination, in the
+directory containing that engine's raw output for that sample.
+
+The post-script's job is to:
+1. Read raw benchmark output (text files, JSON, etc.)
+2. Parse the results into time-series metric data
+3. Log each data point via the toolbox metrics API
+   (`log_sample()` / `finish_samples()`)
+4. Write `postprocess/post-process-data.json` declaring the
+   metrics, periods, and primary metric
+
+### Runtime script delivery
+
+Benchmark scripts run inside engine containers but are not baked
+into the container image. Instead, they are copied from the
+controller to each engine at runtime via the
+`files-from-controller` mechanism defined in `rickshaw.json`.
+This means scripts can be modified on the controller between runs
+without rebuilding images — a core design property that enables
+rapid iteration during development, debugging, and deep-dive
+investigations that often require modifying script behavior to
+capture additional data or alter execution parameters.
+
+## Data flow and result structure
+
+### On the engine
+
+During execution, each engine writes benchmark output to
+per-iteration, per-sample directories:
+
+```
+iteration-1/sample-1/
+├── benchmark-stderrout.txt
+├── benchmark-result.json
+└── msgs/
+    ├── tx/svc          # outgoing messages
+    └── rx/             # received messages
+```
+
+### Transfer to controller
+
+After all iterations complete, the engine archives its entire
+working directory into a compressed tarball and transfers it to
+the controller via SSH. The controller extracts and reorganizes
+the data:
+
+```
+run/iterations/
+├── iteration-1/
+│   └── sample-1/
+│       ├── client/
+│       │   ├── 1/              # client engine 1's output
+│       │   │   ├── benchmark-stderrout.txt
+│       │   │   └── postprocess/
+│       │   │       ├── metric-data-0.csv.xz
+│       │   │       ├── metric-data-0.json.xz
+│       │   │       └── post-process-data.json
+│       │   └── 2/              # client engine 2's output
+│       └── server/
+│           └── 1/              # server engine 1's output
+└── iteration-2/
+    └── sample-1/
+        └── ...
+```
+
+### Post-processing
+
+The `rickshaw-post-process-bench.py` script iterates over each
+iteration/sample/role/engine-id combination. For each, it creates
+the `postprocess/` subdirectory, then executes the benchmark's
+post-script in that directory. On re-processing, the orchestrator
+deletes and recreates `postprocess/`, providing clean artifact
+isolation.
+
+## Periods and the primary metric
+
+### Period definition
+
+Each sample's post-processing output declares one or more
+**periods** — named time windows within the sample. The most
+common pattern is a single "measurement" period covering the
+benchmark's steady-state execution.
+
+```json
+{
+    "primary-period": "measurement",
+    "primary-metric": "ops-sec",
+    "periods": [{
+        "name": "measurement",
+        "metric-files": ["metric-data-0"]
+    }]
+}
+```
+
+Some benchmarks define additional periods like "warm-up" or
+"ramp-up" to distinguish transient startup behavior from
+steady-state measurement.
+
+### Period timestamps
+
+Period begin and end timestamps are derived from the actual
+metric data — the earliest `begin` and latest `end` across all
+data points in that period's metric files. When multiple client
+or server engines contribute to the same period, rickshaw
+consolidates the timestamps to cover the full participation
+window.
+
+### Primary metric and result summary
+
+The `primary-metric` field identifies the headline metric for
+the benchmark (e.g., "Gbps" for iperf, "ops-sec" for uperf,
+"wakeup-latency-usec" for cyclictest). Combined with
+`primary-period`, this tells the result system which metric
+value to extract as the official result for each iteration.
+
+Crucible generates a result summary showing the primary metric
+value for each iteration, providing a quick overview of
+benchmark performance across parameter combinations.
+
+## Sample pass/fail and retry
+
+### Failure detection
+
+A sample can fail for several reasons:
+
+- **Roadblock timeout**: An engine didn't reach a synchronization
+  barrier within the allowed time (the benchmark hung or crashed)
+- **Script failure**: The benchmark start script returned a
+  non-zero exit code
+- **Abort signal**: An engine sent a `follower-ready-abort`
+  message during a roadblock (typically because the benchmark
+  detected an error condition)
+
+### Retry behavior
+
+The `max-sample-failures` setting (default 1) controls how many
+failed attempts are allowed before the sample is considered
+permanently failed. With the default of 1, a failed sample gets
+no retries. Setting it to 2 allows one retry, and so on.
+
+Failed samples are preserved with a modified directory name:
+`sample-1-fail-1`, `sample-1-fail-2`, etc. Only a sample with
+no failures is considered passing.
+
+An iteration is considered failed if it doesn't have enough
+passing samples to meet the `num-samples` requirement.
+
+## Re-processing
+
+### crucible postprocess
+
+Re-runs the post-processing scripts on existing run data without
+re-executing the benchmarks. This is useful when:
+
+- A post-processor bug was fixed
+- The metrics extraction logic was improved
+- You want to re-generate metrics with updated toolbox code
+
+The orchestrator cleans the `postprocess/` directory and any
+stale root-level artifacts before re-running, ensuring a clean
+slate.
+
+### crucible index
+
+Re-indexes the post-processed results into OpenSearch. This reads
+`postprocess/post-process-data.json` and the associated metric
+files, generates CDM documents, and pushes them to the configured
+OpenSearch instance. Useful after re-processing or when switching
+to a different OpenSearch instance.
+
+## Multi-benchmark runs
+
+Crucible supports running multiple benchmarks in a single run.
+Each benchmark occupies its own set of engine IDs, and the
+orchestration framework manages them together.
+
+### Configuration
+
+Multiple benchmarks are listed as separate entries in the run
+file's `benchmarks` array. Each benchmark specifies its own
+`ids` field to assign engine IDs, and its own `mv-params` for
+parameter configuration:
+
+```json
+{
+    "benchmarks": [
+        {
+            "name": "iperf",
+            "ids": "1",
+            "mv-params": {
+                "global-options": [{ "name": "common", "params": [...] }],
+                "sets": [{ "include": "common", "params": [...] }]
+            }
+        },
+        {
+            "name": "uperf",
+            "ids": "2",
+            "mv-params": {
+                "global-options": [{ "name": "common", "params": [...] }],
+                "sets": [{ "include": "common", "params": [...] }]
+            }
+        }
+    ]
+}
+```
+
+The `ids` field assigns engine IDs to each benchmark — engine 1
+runs iperf and engine 2 runs uperf. The endpoint configuration
+references these same IDs to determine which engines run on which
+hosts and with what settings.
+
+### Shared execution
+
+All benchmarks share the same iteration/sample execution loop,
+roadblock synchronization, and tool collection. Benchmark-specific
+parameters are filtered per-engine so each engine only receives
+parameters for its assigned benchmark. Tools collect data
+continuously across all benchmarks, providing a unified system
+view.
+
+This enables comparative testing — running two different
+benchmarks under identical conditions (same system, same tools,
+same time window) to compare their behavior.
+
+### Aligning workloads
+
+One complexity of multi-benchmark runs is ensuring the workloads
+are aligned with each other. Because all benchmarks in a run
+share the same roadblock synchronization, a sample doesn't
+complete until all clients finish. If one benchmark runs for 60
+seconds and another for 300 seconds, the shorter benchmark's
+engines sit idle waiting for the longer one to finish. This means
+their tool data windows and measurement periods won't align
+cleanly.
+
+For meaningful comparative testing, configure all benchmarks to
+use the same duration or runtime so their measurement periods
+overlap. This ensures tool data captured during the sample
+reflects all workloads running simultaneously rather than one
+workload running while the other has already stopped.
+
+## Result directory structure
+
+The complete result directory for a benchmark run:
+
+```
+<run-dir>/
+├── config/
+│   ├── rickshaw-run.json          # full run configuration
+│   ├── run-file.json              # original user run file
+│   ├── bench-params/              # expanded parameter sets
+│   ├── engine/
+│   │   └── bench-cmds/            # per-engine benchmark commands
+│   │       ├── client/1/start     # client 1 start commands
+│   │       ├── client/1/runtime   # client 1 runtime script
+│   │       ├── server/1/start     # server 1 start commands
+│   │       └── server/1/stop      # server 1 stop commands
+│   └── image-source-*.json.xz     # image sourcing records
+├── run/
+│   ├── iterations/
+│   │   ├── iteration-1/
+│   │   │   ├── sample-1/
+│   │   │   │   ├── client/
+│   │   │   │   │   └── 1/
+│   │   │   │   │       ├── uperf-stderrout.txt    # raw output
+│   │   │   │   │       └── postprocess/           # CDM metrics
+│   │   │   │   │           ├── metric-data-0.csv.xz
+│   │   │   │   │           ├── metric-data-0.json.xz
+│   │   │   │   │           └── post-process-data.json
+│   │   │   │   └── server/
+│   │   │   │       └── 1/
+│   │   │   └── sample-1-fail-1/   # failed attempt (if any)
+│   │   └── iteration-2/
+│   │       └── ...
+│   ├── tool-data/                  # tool collection output
+│   ├── sysinfo/                    # system information
+│   └── opensearch/                 # indexed CDM documents
+│       └── *-docs.ndjson
+└── crucible.log.xz                 # run log
+```
+
+Each engine's output for each iteration/sample combination lives
+in its own directory. The `postprocess/` subdirectory contains
+the CDM-format metrics produced by the benchmark's post-processor.
+Failed sample attempts are preserved alongside successful ones
+for debugging.

--- a/docs/how-benchmark-execution-works.md
+++ b/docs/how-benchmark-execution-works.md
@@ -79,6 +79,12 @@ set-specific parameters).
 }
 ```
 
+Run files are validated against `rickshaw/schema/run-file.json`
+before execution begins. Each benchmark's `rickshaw.json` is
+validated against `rickshaw/schema/benchmark.json`. These
+schemas enforce valid parameter structures, endpoint
+configurations, and benchmark integration fields.
+
 ### Structure and fields
 
 **global-options** (required): An array of named parameter groups.

--- a/docs/how-cdm-works.md
+++ b/docs/how-cdm-works.md
@@ -1,0 +1,325 @@
+# How CDM Works
+
+This document explains how crucible's Common Data Model (CDM)
+stores, indexes, and queries benchmark and tool results. CDM
+provides the data model, OpenSearch integration, query API,
+and web dashboard for result analysis.
+
+For how benchmark metrics are generated, see
+[how-benchmark-execution-works.md](how-benchmark-execution-works.md).
+For how tool metrics relate to benchmark periods, see
+[how-tool-collection-works.md](how-tool-collection-works.md).
+
+## Overview
+
+CDM solves a fundamental problem: different benchmarks produce
+results in different formats with different metric names,
+units, and structures. CDM defines a standardized schema that
+all benchmarks and tools conform to, enabling unified storage,
+querying, and comparison across workloads.
+
+All result data is stored in OpenSearch using a hierarchical
+document model. The CDM server provides a REST API for
+querying, and a web dashboard for interactive analysis.
+
+## The document hierarchy
+
+Result data is organized hierarchically:
+
+```
+run
+├── tag (metadata key-value pairs)
+├── iteration
+│   ├── param (benchmark parameters for this iteration)
+│   ├── sample
+│   │   ├── period (named time window: measurement, warm-up, etc.)
+│   │   │   ├── metric_desc (what the metric is)
+│   │   │   └── metric_data (time-series values)
+```
+
+### Document types
+
+| Type | Purpose | Key fields |
+|------|---------|-----------|
+| **run** | A single benchmark execution | run UUID, begin/end times, benchmark name, user, host |
+| **iteration** | One parameter combination | iteration UUID, primary metric, primary period, status |
+| **sample** | One execution of an iteration | sample UUID, status (pass/fail) |
+| **period** | A time window within a sample | period UUID, name, begin/end timestamps |
+| **param** | A benchmark parameter | arg name, value, role (client/server) |
+| **tag** | Run metadata | name, value (e.g., kernel version, test purpose) |
+| **metric_desc** | What a metric IS | source, type, class, breakout dimensions |
+| **metric_data** | Actual values | begin, end, value, duration |
+
+Each level adds context. A metric_data document inherits its
+run, iteration, sample, and period context through the
+document hierarchy, so queries can filter at any level.
+
+## Metric descriptors and metric data
+
+The core of CDM is the separation between metric definitions
+(what) and metric values (data).
+
+### metric_desc (descriptor)
+
+Defines what a metric measures:
+
+- **source**: Which benchmark or tool produced it (e.g.,
+  `uperf`, `mpstat`, `procstat`)
+- **type**: The specific metric name (e.g., `Gbps`,
+  `Busy-CPU`, `interrupts-sec`)
+- **class**: The metric category — `throughput` (rate-based)
+  or `count` (accumulative)
+- **names**: Breakout dimensions that identify specific
+  instances of this metric (e.g., `hostname=worker-01`,
+  `cpu=3`, `device=sda`, `direction=rx`)
+
+The names/dimensions enable drill-down analysis. A single
+metric type like `Busy-CPU` may have hundreds of metric_desc
+documents — one per CPU per host.
+
+### metric_data (values)
+
+Contains the actual time-series data:
+
+- **begin**: Start timestamp (milliseconds since epoch)
+- **end**: End timestamp (milliseconds since epoch)
+- **value**: The metric value for this time window
+- **duration**: `end - begin + 1`
+
+Each metric_data document is linked to a metric_desc via
+UUID. The toolbox metrics library consolidates adjacent
+samples with the same value to reduce data volume.
+
+### Benchmark metrics vs tool metrics
+
+- **Benchmark metrics** are attributed to a specific period
+  (e.g., "measurement"). They exist only within the time
+  window of that period.
+- **Tool metrics** have no period attribution. They are
+  collected continuously and exist as a flat time series.
+  When querying tool metrics for a specific period, CDM
+  uses the period's begin/end timestamps as a time range
+  filter rather than a document relationship.
+
+## How results get into OpenSearch
+
+### The indexing pipeline
+
+```
+Post-processing
+  ↓ (creates metric-data files + post-process-data.json)
+rickshaw-gen-docs.py
+  ↓ (generates NDJSON documents)
+add-run.sh
+  ↓ (bulk-indexes into OpenSearch)
+OpenSearch indices
+```
+
+### Document generation
+
+`rickshaw-gen-docs.py` reads the post-processing output and
+generates OpenSearch documents:
+
+1. Creates **run**, **tag**, and **param** documents from
+   the run configuration
+2. Processes **tool metrics** in parallel — reads
+   metric-data files from each tool's postprocess/ directory
+3. Processes **benchmark metrics** sequentially — for each
+   iteration/sample/period, reads post-process-data.json
+   and the associated metric files
+4. Creates **period**, **sample**, and **iteration**
+   documents with consolidated timestamps
+
+Output is NDJSON (newline-delimited JSON) — pairs of index
+commands and document bodies, written to the
+`run/opensearch/` directory.
+
+### UUID persistence
+
+Document UUIDs are generated once and stored in persistent
+ID files within the result directory. This means re-indexing
+the same run produces the same UUIDs, making re-indexing
+idempotent rather than creating duplicate documents. It also
+means that any saved queries, dashboard URLs, or scripts
+that reference specific UUIDs (run, iteration, period, etc.)
+continue to work after re-indexing — users don't have to
+update their queries when results are re-processed and
+re-indexed.
+
+## How results are queried
+
+### The CDM server
+
+The CDM server is a Node.js/Express application that
+provides a REST API for querying results in OpenSearch.
+It runs as a crucible service on a configurable port
+(default 3000).
+
+### Key query patterns
+
+**Run discovery**: Search for runs by benchmark name,
+user, tags, date range:
+
+```
+GET /api/v1/runs?benchmark=uperf&name=John
+```
+
+**Result summary**: Get the primary metric value for each
+iteration in a run, providing a quick overview of
+performance:
+
+```
+crucible get result --run <run-id>
+```
+
+**Metric data retrieval**: Get specific metric values
+with optional breakouts and time filtering:
+
+```
+POST /api/v1/metric-data
+{
+    "run": "<run-uuid>",
+    "period": "<period-uuid>",
+    "source": "mpstat",
+    "type": "Busy-CPU",
+    "breakouts": ["hostname", "cpu"]
+}
+```
+
+### Period-based time filtering
+
+When you query for metrics within a specific period, CDM:
+
+1. Looks up the period document to get its begin and end
+   timestamps
+2. **Removes the period ID from the query** — because
+   tool metrics don't have period attribution
+3. Uses the timestamps as a range filter on metric_data
+
+This approach works uniformly for both benchmark metrics
+(which have period attribution) and tool metrics (which
+don't). The result is the same: you get metric data from
+within that time window.
+
+### Breakout dimensions
+
+Metrics can be broken down by their dimension values. For
+example, `Busy-CPU` from mpstat has dimensions like
+`hostname` and `cpu`. Querying with `breakouts: ["hostname"]`
+returns separate time series per host. Adding `"cpu"` splits
+further by individual CPU.
+
+The query API supports:
+
+- **Expanding**: Add a breakout dimension to see more detail
+- **Filtering**: Limit to specific dimension values (exact
+  match, regex, or multiple values)
+- **Collapsing**: Remove a breakout to aggregate across that
+  dimension
+
+## The web dashboard
+
+CDM includes a React-based web dashboard for interactive
+result analysis, served by the CDM server.
+
+### Search view
+
+Filter and select iterations for comparison:
+
+- Filter by benchmark, tags, parameters, user, date range
+- Select multiple iterations across different runs
+- Persistent selection state — selections survive navigation
+
+### Compare view
+
+Side-by-side comparison of selected iterations:
+
+- Bar charts showing primary metric values
+- Error bars from multiple samples (min/max/standard
+  deviation)
+- Group iterations by parameter value, run, or tag
+- Overlay supplemental metrics (tool metrics like CPU
+  utilization alongside benchmark throughput)
+
+### Deep-dive view
+
+Time-series analysis of individual metrics:
+
+- Line charts with time on the X-axis
+- Configurable resolution (single aggregate value or N
+  time-series points)
+- Overlay multiple iterations aligned by relative time
+- Per-sample or averaged across samples
+- Interactive breakout exploration:
+  - Right-click to add/remove/filter dimensions
+  - Isolate individual lines
+  - Zoom and pan
+- Legend toggle for showing/hiding specific series
+
+### Shareable URLs
+
+Dashboard state (filters, selections, view, breakouts) is
+encoded in the URL hash. Sharing the URL reproduces the
+exact same view, enabling collaboration and issue tracking
+with direct links to specific analyses.
+
+## Crucible commands for CDM
+
+### Indexing results
+
+```bash
+crucible index <run-dir>
+```
+
+Generates CDM documents and indexes them into OpenSearch.
+This runs automatically after a benchmark completes, but
+can be run manually to re-index or index imported results.
+
+### Viewing results
+
+```bash
+crucible get result --run <run-id>
+crucible get metric --run <run-id> --source mpstat --type Busy-CPU
+```
+
+Query results from the command line. `get result` shows
+the primary metric summary; `get metric` retrieves specific
+metric data.
+
+### Managing results
+
+```bash
+crucible ls                    # list all runs
+crucible ls --type tags        # list runs with tag info
+crucible rm --run <run-id>     # remove a run from OpenSearch
+```
+
+### Re-processing
+
+```bash
+crucible postprocess <run-dir>
+```
+
+Re-runs post-processing on existing run data without
+re-executing benchmarks. Useful when post-processor logic
+has been updated. Follow with `crucible index` to update
+OpenSearch.
+
+## Versioning
+
+CDM has evolved through several versions:
+
+| Version | Key changes |
+|---------|------------|
+| v7dev | Original version, generic `id` fields |
+| v8dev | Document-specific UUID fields (`iteration-uuid`, `period-uuid`, etc.) |
+| v9dev | Per-month index naming (`cdm-v9dev-metric_data@2026.06`), additional document types |
+
+Multiple CDM versions can coexist in the same OpenSearch
+instance. The `services.json` OpenSearch configuration
+specifies which CDM version each instance uses, and the
+`index-to` / `query-from` settings control where new results
+go and which versions are searchable.
+
+This enables gradual migration — new results can be indexed
+in v9dev while older v8dev results remain queryable.

--- a/docs/how-cdm-works.md
+++ b/docs/how-cdm-works.md
@@ -117,8 +117,9 @@ OpenSearch indices
 
 ### Document generation
 
-`rickshaw-gen-docs.py` reads the post-processing output and
-generates OpenSearch documents:
+`rickshaw-gen-docs.py` reads the post-processing output
+(validated against `rickshaw/schema/bench-metric.json`)
+and generates OpenSearch documents:
 
 1. Creates **run**, **tag**, and **param** documents from
    the run configuration

--- a/docs/how-ci-works.md
+++ b/docs/how-ci-works.md
@@ -153,8 +153,8 @@ capabilities rather than hardcoded runner types.
 
 ### Configuration
 
-The `crucible-ci.json` file (in rickshaw's `util/` directory)
-defines:
+The `crucible-ci.json` file (in rickshaw's `util/` directory,
+validated against `rickshaw/schema/crucible-ci.json`) defines:
 
 - **Capabilities**: A dictionary of valid capability names
   with descriptions (e.g., `k8s-cluster`,

--- a/docs/how-ci-works.md
+++ b/docs/how-ci-works.md
@@ -1,0 +1,386 @@
+# How CI Works
+
+This document explains how crucible's continuous integration
+system operates — the workflow hierarchy, runner matching,
+docs-only filtering, release matrix testing, and post-merge
+validation.
+
+For how the capability-based runner matching was designed, see
+the `crucible-ci.json` configuration in the rickshaw repo.
+For how releases interact with CI, see
+[how-releases-work.md](how-releases-work.md).
+
+## Overview
+
+Crucible validates changes across its multi-repo ecosystem
+using GitHub Actions. Each repo has a trigger workflow that
+calls reusable workflows in the `crucible-ci` repo. This
+layered approach means CI logic is centralized — individual
+repos only need a thin trigger workflow, while the test
+orchestration, runner matching, and integration test execution
+are shared.
+
+Key CI capabilities:
+
+- **Docs-only filtering**: PRs that only change documentation
+  skip full integration tests
+- **Capability-based runner matching**: Scenarios declare
+  requirements, runner pools declare capabilities, and the
+  system matches them
+- **Release matrix testing**: Core repo changes are tested
+  across multiple crucible releases
+- **Post-merge validation**: Merged changes are re-tested
+  against production registries
+
+## Workflow hierarchy
+
+CI uses a multi-level calling structure:
+
+```
+Repo trigger workflow (e.g., crucible-ci.yaml)
+  └── crucible-ci reusable workflow
+        (e.g., core-release-crucible-ci.yaml)
+      └── Per-release workflow
+            (e.g., core-crucible-ci.yaml)
+          └── Per-endpoint workflow
+                (e.g., endpoint-crucible-ci.yaml)
+              └── Integration test action
+                    (integration-tests/)
+```
+
+### Level 1: Repo trigger
+
+Each repo has a `crucible-ci.yaml` in `.github/workflows/`
+that fires on pull requests. It performs the docs-only check
+and calls the appropriate crucible-ci reusable workflow.
+
+### Level 2: Reusable workflows
+
+The `crucible-ci` repo provides reusable workflows for each
+repo type:
+
+- **`core-release-crucible-ci.yaml`**: For core repos
+  (crucible, rickshaw, toolbox, etc.). Includes release
+  matrix and controller build checks.
+- **`benchmark-crucible-ci.yaml`**: For benchmark repos.
+  Simpler — no release matrix.
+- **`tool-crucible-ci.yaml`**: For tool repos. Similar to
+  benchmark CI.
+
+### Level 3: Endpoint workflows
+
+The endpoint workflow generates the test job matrix using
+`generate-ci-jobs.py` and `crucible-ci.json`, then runs
+integration tests for each job in the matrix.
+
+### Level 4: Integration tests
+
+The `integration-tests` action performs the actual test:
+installs crucible, configures endpoints, runs benchmarks,
+and collects results.
+
+## Core vs benchmark vs tool CI
+
+### Core CI
+
+Core repos (crucible, rickshaw, toolbox, workshop, etc.)
+get the most thorough testing:
+
+- **Release matrix**: Tests across upstream + all supported
+  releases (when controller build is triggered)
+- **Controller build check**: Detects if the controller
+  image needs rebuilding
+- **All benchmarks**: Tests all enabled benchmarks in
+  `crucible-ci.json`
+- **Both endpoint types**: kube and remotehosts
+
+This produces the largest job count — potentially 200+ jobs
+per release, multiplied by the number of releases.
+
+### Benchmark CI
+
+Benchmark repos get simpler testing:
+
+- **Single release**: Tests against upstream only (no release
+  matrix)
+- **Single benchmark**: Tests only the changed benchmark
+- **Both endpoint types**: kube and remotehosts
+- **All userenvs**: Tests across all supported base images
+
+### Tool CI
+
+Tool repos are similar to benchmark CI:
+
+- **Single release**: upstream only
+- **Test workload**: Uses fio as the benchmark to exercise
+  the tool
+- **Both endpoint types**: kube and remotehosts
+
+## Docs-only filtering
+
+PRs that only change documentation files skip the full
+integration test suite. This saves significant CI runner
+time and cost.
+
+### How it works
+
+Each repo's trigger workflow uses `tj-actions/changed-files`
+to check if all modified files match the docs-only list:
+
+- `LICENSE`, `*.md`, `**/*.md`
+- `.github/rulesets/**`
+- Most workflow files (CI, release, tracking, fork-check)
+- `.gitignore`
+- `.claude/**`
+- `docs/**`, `spec/**`
+
+### Faux workflows
+
+When only docs changed, a **faux workflow** runs instead of
+the real CI. Faux workflows simply echo a success message
+without running any tests. This satisfies branch protection
+rules (which require CI checks to pass) without wasting
+runner resources.
+
+When non-docs files changed (or on manual `workflow_dispatch`
+triggers), the **real workflow** runs with full integration
+testing.
+
+## Capability-based runner matching
+
+The CI system matches test scenarios to runners based on
+capabilities rather than hardcoded runner types.
+
+### Configuration
+
+The `crucible-ci.json` file (in rickshaw's `util/` directory)
+defines:
+
+- **Capabilities**: A dictionary of valid capability names
+  with descriptions (e.g., `k8s-cluster`,
+  `remotehosts-access`, `cpu-partitioning`)
+- **Endpoints**: Baseline requirements for each endpoint type
+  (e.g., kube needs `k8s-cluster`)
+- **Runner pools**: What each pool provides and its GitHub
+  Actions labels (e.g., `aws-cloud-1` provides
+  `k8s-cluster`, `remotehosts-access`, `cpu-partitioning`)
+- **Benchmarks**: Scenarios with per-endpoint requirements
+  (e.g., cyclictest on remotehosts needs
+  `cpu-partitioning`)
+
+### How matching works
+
+For each scenario, the effective requirements are computed:
+
+```
+effective = scenario requirements ∪ endpoint requirements
+```
+
+A runner pool matches if it provides all effective
+requirements. The pool's GitHub Actions labels become the
+`runs-on` value for the job.
+
+### Runner types
+
+CI uses both GitHub-provided runners and self-hosted runners:
+
+- **GitHub-provided runners** (`ubuntu-latest`): Used for
+  lightweight jobs that don't need special infrastructure —
+  parameter generation, docs-only checks, display jobs,
+  controller build checks, and other orchestration tasks.
+- **Self-hosted runners** (e.g., `aws-cloud-1`): Used for
+  integration test jobs that require specific capabilities
+  — installed dependencies, system configurations like CPU
+  partitioning, Kubernetes cluster access, and SSH access
+  to remotehosts test systems.
+
+The capability matching system determines which integration
+test jobs land on self-hosted runners and with what labels.
+
+## Job generation and multiplication
+
+### The job matrix
+
+The `generate-ci-jobs.py` script processes `crucible-ci.json`
+to generate a job matrix. The matrix is the cartesian product
+of:
+
+- **Benchmarks**: Which benchmarks to test (filtered by
+  `--benchmark` parameter)
+- **Endpoints**: Which endpoints to test (kube, remotehosts)
+- **Userenvs**: Which base images to test against
+
+### Userenv filtering
+
+The `--userenv-filter` parameter controls how many userenvs
+are included:
+
+- **`all`**: Default, default + all unique userenvs +
+  external. Produces the largest matrix.
+- **`unique`**: Used for post-merge CI. Tests all unique
+  userenvs but no external.
+- **`minimal`**: Only the default userenv. Smallest matrix.
+
+### Smart rickshaw PR detection
+
+When a rickshaw PR only modifies userenv files (and no other
+code), the CI system detects this and only tests the modified
+userenvs instead of all of them. This dramatically reduces
+the job count for userenv-only changes.
+
+## Release matrix testing
+
+Core repo PRs can trigger testing across multiple crucible
+releases.
+
+### Why controller changes trigger multi-release testing
+
+The controller image is **shared across all releases**. There
+is one controller image that all crucible installations use,
+regardless of which release they're running. This means a
+change to the controller image could break any release, not
+just upstream. Therefore, when the controller needs
+rebuilding, CI tests the new image against every supported
+release to ensure backward compatibility.
+
+### When multi-release testing happens
+
+The `get-releases` action determines which releases to test:
+
+- **No controller rebuild needed**: Tests only `upstream`
+  (~200 jobs)
+- **Controller rebuild needed**: Tests `upstream` + all
+  supported releases (~200 × N jobs, where N is the number
+  of supported releases)
+- **Installer changed**: Also triggers multi-release testing
+
+### Controller build check
+
+The `check-controller-build` action examines the PR's changed
+files to determine if the controller image needs rebuilding.
+Rebuilds are triggered when:
+
+- Files in `crucible/workshop/` changed (base image specs)
+- `workshop/workshop.py` changed (builder logic)
+- `workshop/schema.json` changed (validation rules)
+
+When a rebuild is needed, the job count can grow
+significantly because each release gets its own complete
+test matrix.
+
+## Integration tests
+
+The `integration-tests` action is where benchmarks actually
+run. For each job in the matrix:
+
+### Setup
+
+1. Clean the runner environment (remove leftover containers,
+   networks, images from previous jobs)
+2. Install crucible (with the PR's changes for the target
+   repo)
+3. Configure the test endpoint (kube or remotehosts)
+4. Import registry authentication secrets
+
+### Execution
+
+1. Run the benchmark with the specified userenv and endpoint
+2. Collect results and artifacts
+3. Upload artifacts to GitHub Actions (5-day retention)
+
+### Pass/fail
+
+A job passes if the benchmark completes without errors.
+Failures can come from:
+
+- Benchmark execution errors
+- Container image build failures
+- Endpoint connectivity issues
+- Timeout exceeded
+
+## Post-merge CI
+
+The `crucible-merged.yaml` workflow runs after a PR is
+merged, providing production-level validation.
+
+### What triggers it
+
+Post-merge CI fires on `pull_request_target` (closed +
+merged) when specific paths change:
+
+- Workshop files (`workshop.json`, `client-workshop.json`,
+  `server-workshop.json`)
+- Source scripts (benchmark scripts, tool scripts)
+- Userenv definitions
+
+Documentation-only changes do not trigger post-merge CI.
+
+### How it differs from PR CI
+
+- Uses **production registry** credentials instead of CI
+  registry
+- Tests the **merged code** on the default branch
+- Uses **`userenv_filter: "unique"`** to test all unique
+  userenvs
+- Provides confidence that the merged change works in the
+  production context
+
+### Pre-seeding the image cache
+
+An important side effect of post-merge CI is that it
+**pre-seeds the image cache** in the production registry.
+When a merged change affects workshop requirements (new
+packages, updated source builds, etc.), the post-merge CI
+run builds the new engine images and pushes them to the
+production registry. This means the next user who runs that
+benchmark will find the images already cached in the
+registry rather than having to build them from scratch.
+
+Without post-merge CI, the first user to run after a
+workshop change would pay the full image build cost. With
+it, the images are ready and waiting.
+
+## Fork protection
+
+Every repo has a `fork-check.yaml` workflow that
+automatically closes PRs opened from forks. Fork PRs cannot
+access the organization's secrets and variables needed for
+CI workflows (registry tokens, runner access, etc.), so they
+would fail with misleading errors.
+
+The workflow comments on the PR explaining that PRs must be
+opened from branches on the upstream repository, then closes
+it.
+
+## Controller image builds
+
+The controller image contains the orchestration software
+(rickshaw, toolbox, roadblock, CDM, etc.) that runs inside
+the controller container. When a PR changes files that affect
+this image, CI rebuilds it.
+
+### Build trigger
+
+The `check-controller-build` action checks if the PR touches
+files in:
+
+- `crucible/workshop/` (image specifications)
+- `workshop/workshop.py` (the build script itself)
+- `workshop/schema.json` (validation schema)
+
+If any of these changed, `build_controller` is set to `yes`
+and the controller image is rebuilt as part of CI.
+
+### Impact on test scope
+
+A controller rebuild triggers multi-release testing because
+the image affects all releases. This means a workshop change
+to a core repo can produce 400+ CI jobs (200 per release ×
+2+ releases), compared to ~200 jobs for a non-workshop
+change.
+
+The rebuilt image is tagged with a CI-specific tag
+(`{repo}_{target}_{run_number}`) and used for all test jobs
+in that CI run. It's not pushed to the production registry
+— that happens separately through the controller build
+workflow after merge.

--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -155,9 +155,9 @@ benchmark::role::userenv::arch::image_url[::auth_file]
 
 Examples:
 ```
-uperf::all::rhubi9::x86_64::quay.io/crucible/engines:abc123_x86_64
-trafficgen::client::alma8::x86_64::quay.io/crucible/engines:def456_x86_64
-sysstat::all::fedora-latest::x86_64::quay.io/crucible/engines:ghi789_x86_64
+uperf::all::rhubi9::x86_64::<registry>/<repo>:abc123_x86_64
+trafficgen::client::alma8::x86_64::<registry>/<repo>:def456_x86_64
+sysstat::all::fedora-latest::x86_64::<registry>/<repo>:ghi789_x86_64
 ```
 
 The `role` field is `all` for standard benchmarks or

--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -250,6 +250,12 @@ modification.
 }
 ```
 
+Endpoint configurations in run files are validated against
+endpoint-specific schemas (`rickshaw/schema/remotehosts.json`,
+`rickshaw/schema/kube.json`, `rickshaw/schema/osp.json`).
+The overall run file structure is validated against
+`rickshaw/schema/run-file.json`.
+
 Key settings:
 - `osruntime`: `"podman"` (default) or `"chroot"`
 - `cpu-partitioning`: Enable CPU isolation for latency-sensitive

--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -1,0 +1,328 @@
+# How Endpoints Work
+
+This document explains how crucible's endpoint system operates —
+the abstraction layer that deploys benchmark and tool engines
+across different infrastructure targets. Endpoints handle
+validation, engine deployment, image management, service
+discovery, and cleanup so that benchmarks and tools don't need
+to know where they're running.
+
+For the benchmark execution flow that uses endpoints, see
+[how-benchmark-execution-works.md](how-benchmark-execution-works.md).
+For tool collection across endpoints, see
+[how-tool-collection-works.md](how-tool-collection-works.md).
+
+## Overview
+
+An endpoint represents a deployment target — a set of machines
+or a cluster where benchmark engines will run. Crucible supports
+three endpoint types:
+
+- **remotehosts**: Deploys engines on remote Linux hosts via SSH,
+  supporting two runtime modes: podman containers (default) or
+  chroot environments (for lower overhead and direct hardware
+  access)
+- **kube**: Deploys engines as pods in a Kubernetes cluster
+- **osp**: Deploys engines as VMs in an OpenStack environment
+
+The endpoint abstraction means the same benchmark (e.g., uperf)
+runs identically whether deployed as a podman container on a bare
+metal host, a pod in Kubernetes, or a VM in OpenStack. The
+endpoint handles all deployment-specific concerns.
+
+A single run can use multiple endpoints — for example, running
+clients on bare metal via remotehosts while running servers in
+Kubernetes via kube.
+
+## Endpoint lifecycle
+
+Each endpoint goes through these phases during a run:
+
+1. **Validation** — verify connectivity, detect capabilities
+2. **Deployment** — create engines (containers, pods, or VMs)
+3. **Execution** — engines run benchmarks and tools, synchronized
+   via roadblock
+4. **Cleanup** — tear down engines and associated resources
+
+## Validation phase
+
+Before deploying any engines, rickshaw validates each endpoint
+to verify connectivity and discover its capabilities. The
+endpoint runs in validate mode and reports structured output
+that rickshaw parses.
+
+### What validation reports
+
+Endpoints output specific keywords that rickshaw-run.py parses:
+
+- **`arch`** — CPU architectures available (e.g., `x86_64`,
+  `aarch64`). Used to determine which container images to build.
+- **`userenv`** — user environments (base images) available.
+  Repeated for each userenv.
+- **`client`** / **`server`** — engine IDs for each role
+- **`engine-types`** — what roles this endpoint supports
+  (client, server, profiler, worker, master)
+
+### Architecture detection
+
+Each endpoint type detects architecture differently:
+
+- **remotehosts**: Runs `uname -m` on each remote host via SSH.
+  Reports native Linux architecture names directly.
+- **kube**: Queries the Kubernetes API
+  (`kubectl get nodes --output json`) and reads
+  `node.status.nodeInfo.architecture`. Normalizes K8s names to
+  Linux names: `amd64` → `x86_64`, `arm64` → `aarch64`.
+- **osp**: Uses VM metadata.
+
+Multi-architecture clusters (e.g., a K8s cluster with both
+x86_64 and aarch64 nodes) report all detected architectures.
+Rickshaw then sources separate container images for each
+architecture.
+
+## Engine deployment
+
+### Remotehosts
+
+The remotehosts endpoint deploys engines on remote Linux hosts
+via SSH. It supports two runtime modes:
+
+**Podman mode** (default, `"osruntime": "podman"`):
+1. SSH to the remote host
+2. Pull the container image (`podman pull`)
+3. Start the engine container (`podman run`) with the bootstrap
+   script mounted
+4. The engine script runs inside the container
+
+**Chroot mode** (`"osruntime": "chroot"`):
+1. SSH to the remote host
+2. Pull the container image (`podman pull`)
+3. Create a container without starting it (`podman create`) to
+   extract the filesystem
+4. Mount the container filesystem
+5. Execute the engine bootstrap inside a `chroot` of that
+   filesystem
+
+Chroot mode provides lower overhead and direct hardware access
+compared to running inside a container. This is important for
+latency-sensitive benchmarks (cyclictest, oslat) that need
+direct access to CPUs, DPDK devices, or kernel tracing
+infrastructure without container isolation layers.
+
+**Host mounts**: The `host-mounts` setting allows mounting host
+directories into the engine's environment. This is commonly
+used to expose device files, `/proc`, `/sys`, or application
+sockets to the engine.
+
+### Kubernetes
+
+The kube endpoint deploys engines as pods:
+
+1. **Namespace creation**: Creates a dedicated namespace for the
+   run (with labels tracking ownership and run ID). If a
+   namespace from a previous run exists, it's cleaned up first.
+2. **Pod creation**: Each engine becomes a pod. Pod specs include
+   the container image, resource requests, node selectors, and
+   volume mounts.
+3. **Architecture targeting**: If the cluster has multiple
+   architectures, the endpoint adds a
+   `kubernetes.io/arch` node selector to ensure pods land on
+   nodes with the correct architecture.
+
+### OpenStack (OSP)
+
+The osp endpoint deploys engines as VM instances in an OpenStack
+cluster. Each engine becomes a VM with the benchmark environment
+installed.
+
+### Engine persistence
+
+Engines persist for the entire run — they are created once during
+the deployment phase and execute all iterations and samples
+sequentially. This avoids the overhead of creating and destroying
+containers or pods for each sample.
+
+## Image management
+
+### The image format
+
+Container images are passed to endpoints using a structured
+format:
+
+```
+benchmark::role::userenv::arch::image_url[::auth_file]
+```
+
+Examples:
+```
+uperf::all::rhubi9::x86_64::quay.io/crucible/engines:abc123_x86_64
+trafficgen::client::alma8::x86_64::quay.io/crucible/engines:def456_x86_64
+sysstat::all::fedora-latest::x86_64::quay.io/crucible/engines:ghi789_x86_64
+```
+
+The `role` field is `all` for standard benchmarks or
+`client`/`server` for benchmarks with split workshop files.
+
+### Image pulling
+
+Endpoints pull images in parallel across hosts or nodes.
+For remotehosts, a thread pool handles concurrent pulls across
+remote hosts. For kube, the Kubernetes runtime handles pulls
+when pods are created.
+
+### Private registry authentication
+
+When an image requires authentication:
+
+1. The auth file is included in the image string as a 6th field
+2. The endpoint copies the auth file to the remote host or
+   creates a Kubernetes image pull secret
+3. The image pull uses the auth credentials
+4. The auth file is cleaned up after pulling
+
+### Image caching
+
+Endpoints track which images have been pulled to avoid redundant
+pulls. The remotehosts endpoint maintains an image census file
+on each remote host that records which images are present and
+when they were last used. Old images can be pruned based on a
+configurable cache size.
+
+## Client-server service discovery
+
+Client-server benchmarks need clients to discover where servers
+are running. The mechanism differs by endpoint type.
+
+### Remotehosts
+
+Clients connect directly to server IPs. Since both client and
+server containers run on known hosts with known IPs, the server
+publishes its host IP and ports via the roadblock messaging
+system. The client reads the message and connects directly.
+
+### Kubernetes
+
+Kubernetes networking requires additional abstraction because
+pod IPs are internal to the cluster:
+
+1. During **server-start**, the server pod publishes its pod IP
+   and ports via `msgs/tx/svc`
+2. During **endpoint-start**, the kube endpoint creates a
+   Kubernetes Service (ClusterIP, NodePort, or LoadBalancer)
+   that routes to the server pod
+3. The endpoint writes an **endpoint-start-end** message with
+   the Service IP, replacing the raw pod IP
+4. During **client-start**, the client reads from `msgs/rx/`,
+   preferring `endpoint-start-end` messages (Service IP) over
+   `server-start-end` messages (pod IP)
+
+This allows the same benchmark client code to work on both
+remotehosts (direct IP) and kube (Service IP) without
+modification.
+
+## Run file configuration
+
+### Remotehosts example
+
+```json
+{
+    "endpoints": [{
+        "type": "remotehosts",
+        "settings": {
+            "user": "root"
+        },
+        "remotes": [{
+            "engines": [
+                { "role": "client", "ids": [1] },
+                { "role": "server", "ids": [2] }
+            ],
+            "config": {
+                "host": "testhost.example.com",
+                "settings": {
+                    "userenv": "rhubi9",
+                    "osruntime": "podman",
+                    "cpu-partitioning": false,
+                    "host-mounts": []
+                }
+            }
+        }]
+    }]
+}
+```
+
+Key settings:
+- `osruntime`: `"podman"` (default) or `"chroot"`
+- `cpu-partitioning`: Enable CPU isolation for latency-sensitive
+  workloads
+- `host-mounts`: Directories from the host to mount into the
+  engine
+- `userenv`: Base container image to use
+
+### Kubernetes example
+
+```json
+{
+    "endpoints": [{
+        "type": "kube",
+        "settings": {
+            "user": "root"
+        },
+        "remotes": [{
+            "engines": [
+                { "role": "client", "ids": [1, 2] },
+                { "role": "server", "ids": [3, 4] }
+            ],
+            "config": {
+                "host": "k8s-controller.example.com",
+                "settings": {
+                    "userenv": "rhubi9",
+                    "controller-ip-address": "10.0.0.1"
+                }
+            }
+        }]
+    }]
+}
+```
+
+### Per-engine configuration
+
+Both endpoint types support per-engine configuration through a
+`config` array with `targets`. This allows different settings
+for different engines — for example, different userenvs for
+client vs server, or node selection for specific engine IDs.
+
+## Cleanup
+
+After a run completes (or fails), endpoints clean up their
+resources:
+
+### Remotehosts
+- Stop and remove engine containers (or unmount chroot
+  filesystems)
+- Remove bootstrap scripts and temporary files from remote hosts
+- Auth files cleaned up after image pulls
+
+### Kubernetes
+- Delete all engine pods
+- Delete Services created for client-server communication
+- Delete image pull secrets
+- Clean up namespace labels (or delete the namespace entirely)
+
+### OSP
+- Terminate VM instances
+- Release floating IPs and network resources
+
+## Comparison
+
+| Aspect | Remotehosts | Kube | OSP |
+|--------|-------------|------|-----|
+| **Engine type** | Podman container or chroot | K8s pod | OpenStack VM |
+| **Connectivity** | SSH | SSH + kubectl | SSH + OpenStack API |
+| **Arch detection** | `uname -m` | K8s node API | VM metadata |
+| **Service discovery** | Direct IP | K8s Service (ClusterIP/NodePort/LB) | Direct IP |
+| **Image pull** | `podman pull` via SSH | K8s runtime | Hypervisor |
+| **Auth support** | Docker auth JSON file | K8s ImagePullSecret | VM-specific |
+| **CPU isolation** | cpu-partitioning setting | Pod resource limits | VM pinning |
+| **Hardware access** | Full (especially chroot mode) | Limited by pod security | Full (VM) |
+| **Overhead** | Low (chroot) to medium (podman) | Medium | High (full VM) |
+| **Best for** | Bare metal testing, DPDK, RT | Cloud-native workloads | OpenStack validation |

--- a/docs/how-engines-work.md
+++ b/docs/how-engines-work.md
@@ -1,0 +1,451 @@
+# How Engines Work
+
+This document explains how crucible's engines operate — the
+runtime environments where benchmark and tool scripts actually
+execute. It covers the bootstrap process, execution phases,
+script delivery, CPU partitioning, and data archival.
+
+For how endpoints deploy engines, see
+[how-endpoints-work.md](how-endpoints-work.md).
+For the benchmark execution flow within engines, see
+[how-benchmark-execution-works.md](how-benchmark-execution-works.md).
+For tool collection within engines, see
+[how-tool-collection-works.md](how-tool-collection-works.md).
+
+## Overview
+
+An engine is a container, chroot, or VM where benchmark and
+tool scripts run. Engines are deployed by endpoints, bootstrapped
+from the controller, synchronized via roadblock, and persist
+for the entire run (all iterations and samples).
+
+A key design property: **engines don't know what endpoint type
+deployed them.** Whether running inside a podman container, a
+Kubernetes pod, or an OpenStack VM, the engine sees the same
+environment and follows the same execution flow. This
+abstraction is what allows the same benchmark to run identically
+across different deployment targets.
+
+Each engine has an identity defined by its **cs-label** — a
+string like `client-1`, `server-2`, or
+`profiler-kube-1-sysstat-1` that identifies its role and ID
+within the run.
+
+## Bootstrap
+
+When an engine starts, the first thing it runs is the bootstrap
+script. Bootstrap is **the one script that is baked into the
+engine container image** — it has to be, because nothing else
+is available yet. The engine has no connection to the controller
+and no other scripts at this point. Bootstrap's sole purpose is
+to establish that connection and fetch everything else.
+
+This is a deliberate minimal footprint: only the bootstrap
+logic is embedded in the image, keeping the image stable and
+cacheable. All other scripts (engine-script, benchmark scripts,
+tool scripts, roadblock client) are fetched from the controller
+at runtime, enabling modification without image rebuilds.
+
+### What bootstrap does
+
+1. **Receives identity**: The engine's cs-label, role, and ID
+   are passed as arguments by the endpoint that created it.
+
+2. **Sets up SSH keys**: Creates an SSH private key from an
+   injected environment variable. This key enables secure file
+   transfer from the controller throughout the run.
+
+3. **Fetches engine scripts**: Uses SCP to retrieve the main
+   execution scripts from the controller:
+   - `engine-script` — the main execution driver
+   - `engine-script-library` — shared functions
+   - `roadblocker.py` — the roadblock synchronization client
+   - `rickshaw-settings.json.xz` — run configuration
+
+4. **CPU partitioning discovery**: If cpu-partitioning is
+   enabled, runs `discover-cpu-partitioning.py` to detect which
+   CPUs are isolated for workload use and which are available
+   for housekeeping (see [CPU partitioning](#cpu-partitioning)
+   below).
+
+5. **Hands off to engine-script**: Once initialization is
+   complete, bootstrap executes `engine-script` which drives
+   the rest of the engine's lifecycle.
+
+## Execution phases
+
+After bootstrap, the engine proceeds through a series of
+roadblock-synchronized phases. Each phase has begin and end
+barriers that all engines in the run must reach before
+execution continues. This ensures tight coordination across
+distributed engines.
+
+### Phase sequence
+
+1. **engine-init** — The engine signals readiness and receives
+   any environment variables injected by the controller. The
+   full environment is captured to `engine-env.txt` for later
+   use during post-processing.
+
+2. **get-data** — The engine fetches everything it needs to
+   execute:
+   - Benchmark and tool scripts via the files-from-controller
+     mechanism
+   - Benchmark command files (start, stop, runtime, infra)
+   - Tool command files (start and stop JSON)
+
+3. **collect-sysinfo** — System profiling via packrat. Captures
+   hardware and software inventory (CPU topology, memory,
+   kernel version, installed packages, etc.) to the `sysinfo/`
+   directory.
+
+4. **start-tools** — Tool collectors launch in the background
+   (see [Tool command execution](#tool-command-execution)
+   below). Tools start before any benchmark activity.
+
+5. **process_bench_roadblocks** — The main benchmark execution
+   loop. For each iteration and sample, the engine participates
+   in the synchronized sequence: infra-start, server-start,
+   endpoint-start, client-start, client-stop, endpoint-stop,
+   server-stop, infra-stop. This is where the actual workload
+   runs.
+
+6. **stop-tools** — Tool collectors are shut down after all
+   benchmark iterations complete.
+
+7. **send-data** — The engine archives its entire working
+   directory and transfers it back to the controller via SSH.
+
+## Files-from-controller
+
+Benchmark and tool scripts are **not baked into the container
+image**. Instead, they are copied from the controller to each
+engine at runtime during the get-data phase. This is the
+files-from-controller mechanism defined in each benchmark and
+tool's `rickshaw.json`.
+
+### How it works
+
+Each benchmark's `rickshaw.json` declares which files to copy:
+
+```json
+"files-from-controller": [
+    { "src": "%bench-dir%/mybench-client", "dest": "/usr/bin/" },
+    { "src": "%bench-dir%/mybench-base", "dest": "/usr/bin/" },
+    { "src": "%run-dir%/config.yaml", "dest": "." }
+]
+```
+
+The `%bench-dir%`, `%run-dir%`, and `%tool-dir%` placeholders
+are resolved by rickshaw to actual paths on the controller.
+During get-data, the engine fetches each file via SCP.
+
+### Why this matters
+
+This design enables rapid iteration without rebuilding container
+images. You can modify a benchmark script on the controller,
+re-run, and the engines pick up the changes immediately. This
+is invaluable for development, debugging, and deep-dive
+investigations that require modifying script behavior to capture
+additional data or alter execution parameters.
+
+## Working directory structure
+
+Each engine operates in a temporary working directory (`cs_dir`)
+that accumulates all data during the run:
+
+```
+cs_dir/
+├── engine-env.txt              # environment snapshot
+├── tool-start.json.xz          # tool start commands
+├── tool-stop.json.xz           # tool stop commands
+├── roadblock-msgs/             # roadblock sync logs
+│   ├── engine-init-begin.json
+│   ├── engine-init-end.json
+│   └── ...
+├── sysinfo/                    # packrat system info
+├── tool-data/                  # tool collection output
+│   ├── sysstat/
+│   │   ├── mpstat.json.xz
+│   │   ├── sar-stdout.txt.xz
+│   │   └── engine-env.txt      # copy for post-processing
+│   └── procstat/
+│       └── ...
+├── iteration-1/
+│   ├── sample-1/
+│   │   ├── mybench-stderrout.txt
+│   │   ├── mybench-result.json
+│   │   └── msgs/
+│   │       ├── tx/             # outgoing messages
+│   │       └── rx/             # received messages
+│   └── sample-2/
+│       └── ...
+└── iteration-2/
+    └── ...
+```
+
+Benchmark output goes into per-iteration/per-sample
+directories. Tool data goes into `tool-data/` with per-tool
+subdirectories. The messaging directories (`msgs/tx/` and
+`msgs/rx/`) are used for client-server service discovery and
+runtime timeout communication.
+
+## Benchmark command execution
+
+### Command format
+
+Benchmark commands are generated by rickshaw-run.py and stored
+in command files that the engine fetches during get-data. Each
+command includes the iteration and sample context plus the
+benchmark script with its parameters.
+
+Parameters are passed using a Bash array mechanism:
+
+```bash
+declare -a ARGS=(
+    '--duration' '60'
+    '--protocol' 'tcp'
+    '--nthreads' '4'
+) && mybench-client "${ARGS[@]}"
+```
+
+The array preserves quoting and handles values with spaces
+correctly. The engine executes the command via `eval`, which
+processes the array declaration and runs the benchmark script.
+
+### Runtime discovery
+
+Before the client benchmark runs, client engine 1 executes the
+benchmark's `get-runtime` script to discover how long the
+workload will take. This value is communicated via roadblock
+messaging to adjust the timeout for the client-start phase.
+Benchmarks that run for an indeterminate duration return `-1` to
+signal unbounded execution.
+
+### Output capture
+
+Benchmark scripts redirect their stdout and stderr to a
+`-stderrout.txt` file in the sample directory. This provides a
+complete log of the benchmark's execution for debugging.
+
+## Tool command execution
+
+### Start/stop JSON format
+
+Tool commands are stored as compressed JSON files:
+
+```json
+{
+    "tools": [
+        {
+            "name": "sysstat",
+            "command": "declare -a ARGS=('--interval' '3') && sysstat-start \"${ARGS[@]}\""
+        }
+    ]
+}
+```
+
+### Execution
+
+For each tool in the JSON:
+
+1. The engine creates a `tool-data/<tool-name>/` subdirectory
+2. Changes into that directory
+3. Executes the command via `eval`
+4. The tool's start script launches background processes and
+   records PIDs
+
+At stop time, the engine reads the stop JSON and executes each
+tool's stop command in the same tool directory. After stopping,
+it copies `engine-env.txt` into each tool's directory so the
+post-processor has access to the engine's environment context.
+
+### Profiler engines
+
+For profiler engines (dedicated tool collection nodes), each
+engine runs exactly one tool. The engine's cs-label encodes
+which tool it runs (e.g., `profiler-kube-1-sysstat-1`), and
+the start logic only executes the matching tool.
+
+## CPU partitioning
+
+CPU partitioning isolates specific CPUs for the benchmark
+workload, keeping system housekeeping activity on separate
+CPUs. This reduces measurement noise and timing jitter for
+latency-sensitive workloads.
+
+### How isolation is detected
+
+The `discover-cpu-partitioning.py` script operates in two modes
+depending on the runtime environment:
+
+**Process mode** (used with chroot runtime):
+
+The engine runs directly on the host, so it has visibility into
+the kernel command line. The script reads `/proc/cmdline` and
+looks for CPU isolation parameters in priority order:
+
+1. `isolcpus=` — highest priority, explicitly isolates CPUs
+   from the scheduler
+2. `nohz_full=` — disables timer ticks on specified CPUs
+3. `rcu_nocbs=` — moves RCU callbacks off specified CPUs
+
+The isolated CPUs become workload CPUs; all remaining online
+CPUs become housekeeping CPUs. This mode gives the most
+accurate picture of the host's isolation configuration.
+
+**Container mode** (used with podman and Kubernetes):
+
+Inside a container, the kernel command line reflects the host
+but the container may only have access to a subset of CPUs
+(via cgroup cpuset). The script reads
+`/proc/self/status` → `Cpus_allowed_list` to discover which
+CPUs the container is permitted to use. It then designates the
+first allowed CPU (and its SMT siblings) as housekeeping and
+all remaining allowed CPUs as isolated workload CPUs.
+
+This approach works regardless of the host's actual isolation
+configuration — the container's cpuset is the authoritative
+source of which CPUs are available to this engine.
+
+### Multi-engine partitioning
+
+When multiple engines share the same host, `partition-cpus.py`
+divides the isolated CPUs among them. It groups CPUs into
+physical cores (accounting for SMT/hyperthreading siblings) and
+assigns each engine a proportional partition. Each engine
+receives its partition index, ensuring no two engines compete
+for the same CPUs.
+
+### Environment variables
+
+Two environment variables are exported for use by benchmark
+scripts:
+
+- **`HK_CPUS`**: Comma-separated list of housekeeping CPUs.
+  Management threads and system activity should be pinned here.
+- **`WORKLOAD_CPUS`**: Comma-separated list of workload CPUs.
+  Benchmark measurement threads should be pinned here.
+
+Benchmarks that support cpu-partitioning (cyclictest, oslat,
+trafficgen) use these variables with `taskset` or tool-specific
+affinity options to pin threads to the appropriate CPU sets.
+
+## Data archival and transfer
+
+After all phases complete, the engine archives its entire
+working directory and transfers it to the controller.
+
+### Archive process
+
+1. The entire `cs_dir` is packaged into a compressed tarball
+2. The tar stream is piped through SSH directly to the
+   controller (no intermediate file on the engine)
+3. The controller writes it to
+   `run/engine/archives/<cs_label>-data.tgz`
+4. Transfer retries up to 10 times with backoff on failure
+
+### What gets archived
+
+Everything in the engine's working directory:
+
+- Benchmark output (per-iteration/sample directories)
+- Tool collection data (tool-data/ subdirectories)
+- System information (sysinfo/)
+- Roadblock message logs
+- Environment snapshot (engine-env.txt)
+
+The controller later extracts and reorganizes this data into
+the final result directory structure.
+
+## Engine environment
+
+Engines receive configuration through three different
+mechanisms, each suited to a different purpose:
+
+**Bootstrap parameters** provide the engine's identity and
+controller connection info — the minimum needed to get started.
+How these are delivered depends on the runtime environment:
+
+- **Chroot mode** (remotehosts): Parameters are passed as
+  command-line arguments directly to the bootstrap script
+  (e.g., `bootstrap --cs-label=client-1 --rickshaw-host=...`).
+  A chroot doesn't have a container environment, so CLI is the
+  only option.
+- **Podman mode** (remotehosts): Parameters are written to an
+  env file that podman loads as container environment variables.
+  Bootstrap reads them from its environment instead of CLI
+  arguments.
+- **Kubernetes**: Parameters are set as environment variables in
+  the pod spec. The kubelet injects them when the container
+  starts.
+
+Bootstrap handles both delivery methods transparently — it
+checks for CLI arguments first, then falls back to environment
+variables.
+
+**Roadblock environment injection** happens during the
+engine-init phase, after the engine is running and connected.
+The endpoint sends additional environment variables via
+roadblock messages — things like `endpoint_label`,
+`hosted_by` (which node the engine landed on), `userenv`, and
+`osruntime`. These are deployment context that the endpoint
+only knows after the engine is created (e.g., which Kubernetes
+node the pod was scheduled to) and that scripts need during
+execution or post-processing.
+
+**Command files** (the ARGS array mechanism) deliver
+benchmark and tool parameters. These are fetched from the
+controller during the get-data phase and contain the actual
+workload configuration — what to run, with what parameters,
+for each iteration and sample.
+
+This separation keeps each mechanism focused: bootstrap
+parameters for identity and connectivity, roadblock injection
+for deployment context, command files for workload parameters.
+
+### Key environment variables
+
+Scripts running inside engines have access to these key
+environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `RS_CS_LABEL` | Engine identity (e.g., `client-1`, `server-2`) |
+| `TOOLBOX_HOME` | Path to the toolbox shared library |
+| `RICKSHAW_HOME` | Path to rickshaw scripts |
+| `CRUCIBLE_HOME` | Path to the crucible installation |
+| `HK_CPUS` | Housekeeping CPUs (when cpu-partitioning enabled) |
+| `WORKLOAD_CPUS` | Workload CPUs (when cpu-partitioning enabled) |
+
+The `engine-env.txt` file captures the full environment after
+initialization. This file is included in each tool's data
+directory and in the archive, ensuring post-processors have
+access to the engine's runtime context even though they run on
+the controller after the engine is gone.
+
+## Error handling
+
+### Roadblock abort
+
+When an engine detects a fatal error (benchmark script returns
+non-zero, prerequisite check fails), it sends an abort signal
+through roadblock. All engines in the run receive the abort,
+the current sample is marked as failed, and the run proceeds to
+the next sample or iteration.
+
+### Roadblock timeout
+
+If an engine doesn't reach a roadblock barrier within the
+allowed time, the roadblock times out. This is treated as a
+more severe failure — the entire run is terminated because an
+unresponsive engine indicates a fundamental problem.
+
+### Sample retry
+
+Failed samples increment a failure counter. If the counter
+reaches `max-sample-failures`, the sample is permanently
+failed. Failed sample directories are renamed to
+`sample-N-fail-M` (where M is the attempt number) and preserved
+in the result for debugging. Only samples that complete without
+failures contribute to the benchmark results.

--- a/docs/how-image-sourcing-works.md
+++ b/docs/how-image-sourcing-works.md
@@ -197,7 +197,7 @@ Image tags are SHA256 hashes of the stage's content:
 <registry>/<repo>:<hash>_<arch>
 ```
 
-For example: `quay.io/crucible/engines:a1b2c3d4e5f6_x86_64`
+For example: `<registry>/<repo>:a1b2c3d4e5f6_x86_64`
 
 ### How the hash is computed
 

--- a/docs/how-image-sourcing-works.md
+++ b/docs/how-image-sourcing-works.md
@@ -78,6 +78,10 @@ source-images-service runs inside the controller container
 and may not have direct access to the host filesystem, so
 everything must be transmitted via the API.
 
+The API request is validated against
+`rickshaw/schema/source-images-input.json` and the response
+against `rickshaw/schema/source-images-output.json`.
+
 After submitting the job, the bridge polls for completion
 with adaptive intervals (faster initially, slowing over
 time). It streams build logs to stdout so the user can
@@ -108,6 +112,10 @@ multiple OS distributions with distribution-specific package
 names or build procedures.
 
 ### Requirement types
+
+Workshop.json files are validated against the workshop schema
+(`workshop/schema.json`). The schema enforces valid userenv
+definitions and requirement structures.
 
 Workshop.json supports several requirement types:
 

--- a/docs/how-image-sourcing-works.md
+++ b/docs/how-image-sourcing-works.md
@@ -1,0 +1,385 @@
+# How Image Sourcing Works
+
+This document explains how crucible builds the container images
+that benchmark and tool engines run in. It covers the three-
+component pipeline, the multi-stage build approach, content-
+based tagging, multi-architecture support, and provenance
+tracking.
+
+For how engines use these images, see
+[how-engines-work.md](how-engines-work.md).
+For how workshop.json files are structured, see
+[implementing-a-new-benchmark.md](implementing-a-new-benchmark.md)
+and
+[implementing-a-new-tool.md](implementing-a-new-tool.md).
+
+## Overview
+
+Every benchmark and tool needs a container image with its
+software and dependencies installed. Image sourcing is the
+process of building these images. Each benchmark and tool
+declares its build requirements in a `workshop.json` file,
+and the source-images-service builds images incrementally
+using a multi-stage approach where each stage is independently
+cached.
+
+The key design property: **images are tagged by content hash.**
+The same inputs (workshop requirements, base image, toolbox
+version, etc.) always produce the same image tag, regardless
+of when or where the build runs. This means images are
+automatically reused across runs when nothing has changed,
+and automatically rebuilt when something has.
+
+## The pipeline
+
+Image sourcing involves three components:
+
+```
+rickshaw-run.py (orchestrator)
+    │
+    │  determines what images are needed
+    │  writes input JSON with file paths
+    ▼
+rickshaw-source-images-client.py (bridge)
+    │
+    │  encodes files as base64
+    │  submits job via HTTP API
+    │  polls for completion
+    ▼
+source-images-service (builder)
+    │
+    │  materializes workspace
+    │  builds images incrementally
+    │  pushes to registry
+    ▼
+container registry (<registry>/<repo>)
+```
+
+### Orchestrator (rickshaw-run.py)
+
+The orchestrator determines which images are needed based on
+the benchmarks in the run, the tools configured, and the
+architectures reported by endpoints. It builds an `image_ids`
+data structure mapping each benchmark/tool × userenv ×
+architecture to an image URL (initially empty).
+
+Before calling the builder, the orchestrator deduplicates:
+the same benchmark builds identically for all architectures
+(only the final tag suffix differs), so the bench-dirs and
+workshop content are shared.
+
+### Bridge (rickshaw-source-images-client.py)
+
+The bridge translates local file paths into a self-contained
+API request. It recursively collects all files from benchmark
+directories, userenv definitions, toolbox, roadblock, and
+workshop content, base64-encoding them for transport. The
+source-images-service runs inside the controller container
+and may not have direct access to the host filesystem, so
+everything must be transmitted via the API.
+
+After submitting the job, the bridge polls for completion
+with adaptive intervals (faster initially, slowing over
+time). It streams build logs to stdout so the user can
+monitor progress.
+
+### Builder (source-images-service)
+
+The source-images-service (SIS) is a FastAPI web service that
+runs inside the crucible controller container. It receives
+the base64-encoded workspace, materializes it to a temporary
+directory, and executes the multi-stage image build.
+
+## What drives the build: workshop.json
+
+Each benchmark and tool has a `workshop.json` file declaring
+what needs to be installed in its engine image.
+
+### Userenvs
+
+A userenv (user environment) defines the base container image.
+Userenvs are JSON files specifying an OS distribution and
+version (e.g., `rhubi9`, `fedora-latest`, `alma8`). The
+workshop requirements are layered on top of this base image.
+
+A single workshop.json can define different requirements for
+different userenvs, allowing the same benchmark to support
+multiple OS distributions with distribution-specific package
+names or build procedures.
+
+### Requirement types
+
+Workshop.json supports several requirement types:
+
+- **distro**: Install packages via the distribution's package
+  manager (rpm, deb)
+- **source**: Download and build from source tarball
+- **python3**: Install pip packages
+- **files**: Copy files from the benchmark directory into the
+  image
+- **manual**: Execute arbitrary shell commands
+- **cpan**: Install Perl modules
+- **node**: Install npm packages
+
+### Split workshop files
+
+Benchmarks with fundamentally different client and server
+requirements can use separate `client-workshop.json` and
+`server-workshop.json` files instead of a single
+`workshop.json`. This produces different images for each
+role — for example, trafficgen's client image includes TRex
+and extensive build tools, while its server image only needs
+dpdk-tools.
+
+## Multi-stage incremental builds
+
+The most important efficiency mechanism in image sourcing is
+the multi-stage build approach. Instead of building a single
+monolithic image, the SIS builds in stages, each adding one
+layer of requirements on top of the previous stage.
+
+### Stage ordering
+
+Stages are ordered from most stable to most volatile:
+
+1. **Base userenv** — the OS base image (rarely changes)
+2. **Toolbox files** — shared library files
+3. **Toolbox dependencies** — toolbox's workshop.json
+   requirements
+4. **Roadblock dependencies** — Python libraries for
+   synchronization
+5. **Rickshaw engine** — engine scripts and workshop
+   requirements
+6. **Utilities** — optional utility workshop.json files
+   (e.g., packrat)
+7. **Benchmark/tool** — the benchmark's own workshop.json
+   requirements (most likely to change)
+
+### Why this ordering matters
+
+Each stage gets its own content hash. When you modify a
+benchmark script, only stage 7 changes — stages 1 through 6
+are reused from cache. Since the common infrastructure stages
+are shared across all benchmarks and tools, a benchmark change
+only triggers a rebuild of the final stage, typically taking
+seconds rather than minutes.
+
+### Stage reuse
+
+For each stage, the SIS checks (in order):
+
+1. **Remote registry**: Does an image with this tag already
+   exist? (checked via `skopeo inspect`)
+2. **Local store**: Is the image available locally? (checked
+   via `buildah images`)
+
+If found remotely, the stage is ready. If found locally but
+not remotely, it's pushed to the registry. Only if the stage
+is missing entirely is it built from the previous stage.
+
+The search works backward from the final stage — if the
+complete image already exists in the registry, no building
+happens at all.
+
+## Content-based image tagging
+
+Image tags are SHA256 hashes of the stage's content:
+
+```
+<registry>/<repo>:<hash>_<arch>
+```
+
+For example: `quay.io/crucible/engines:a1b2c3d4e5f6_x86_64`
+
+### How the hash is computed
+
+For each stage, the SIS:
+
+1. Runs the workshop script in `--dump-config` mode to get
+   the resolved configuration
+2. Runs `--dump-files` to discover all input files
+3. Normalizes workspace paths to a canonical prefix (so the
+   hash doesn't depend on the random temp directory name)
+4. Computes SHA256 over the config text + all file contents
+
+### Determinism
+
+The same inputs always produce the same hash:
+
+- Path normalization ensures builds on different hosts with
+  different temp directories produce identical tags
+- File contents are hashed in sorted order
+- The hash captures everything that affects the image:
+  package lists, source URLs, build commands, file contents
+
+This means if nothing has changed since the last run, image
+sourcing finds all stages already built and completes in
+seconds.
+
+## Multi-architecture support
+
+Crucible supports building images for multiple CPU
+architectures (e.g., x86_64 and aarch64) in a single run.
+
+### Architecture discovery
+
+During endpoint validation, each endpoint reports its CPU
+architectures:
+
+- **remotehosts**: `uname -m` on each remote host
+- **kube**: Reads `kubernetes.io/arch` from node info,
+  normalizes K8s names to Linux names (`amd64` → `x86_64`,
+  `arm64` → `aarch64`)
+
+### Per-architecture SIS instances
+
+Each architecture requires its own SIS instance running on a
+host with that native architecture. Cross-architecture builds
+(e.g., building aarch64 images on x86_64) are not supported
+due to buildah/QEMU incompatibilities.
+
+The `config/services.json` file configures SIS instances:
+
+```json
+{
+    "image-sourcing": {
+        "services": {
+            "default": {
+                "start": true,
+                "location": {
+                    "address": "localhost",
+                    "port": 8888,
+                    "protocol": "http"
+                }
+            },
+            "aarch64": {
+                "start": false,
+                "location": {
+                    "address": "arm-builder.example.com",
+                    "port": 8888,
+                    "protocol": "http"
+                }
+            }
+        }
+    }
+}
+```
+
+The `"default"` key maps to the controller's native
+architecture. Non-native architectures must point to remote
+builders with `"start": false`.
+
+### Parallel sourcing
+
+When a run requires multiple architectures, rickshaw sources
+images in parallel — one thread per architecture, each
+communicating with its own SIS instance. The
+`image-sourcing-urls.json` file maps each architecture to its
+service URL.
+
+## Registry and caching
+
+### Image storage
+
+All engine images are stored in a single container registry
+(default: `<registry>/<repo>`). Each stage of each
+build gets its own tag in this registry, enabling fine-grained
+caching.
+
+### Build coordination
+
+When multiple runs are executing simultaneously, they may
+need the same image. The SIS includes a build coordinator
+that prevents redundant builds: if one job is already
+building a particular tag, other jobs requesting the same tag
+wait for the first build to complete rather than starting
+their own.
+
+### Image expiration
+
+The registry (Quay) supports tag expiration — images are
+automatically deleted after a configurable period if not
+refreshed. During image sourcing, the SIS refreshes the
+expiration timer on all existing stages it discovers. This
+ensures actively-used images persist while abandoned images
+are eventually cleaned up.
+
+## The SIS service
+
+### How it runs
+
+The SIS runs inside the crucible controller container,
+managed by `crucible start image-sourcing` and
+`crucible stop image-sourcing`. It listens on a configurable
+port (default 8888) and validates that incoming requests
+match its native architecture.
+
+### Health endpoint
+
+The SIS exposes `/api/v1/health` which reports its status and
+native architecture. Crucible polls this endpoint during
+startup to wait for the service to be ready before proceeding
+with a run.
+
+### Dedicated builders
+
+For non-native architectures, a dedicated builder host runs
+the SIS as a systemd service. The setup script
+(`bin/services/setup-image-sourcing-service.sh`) installs a
+systemd unit that starts the SIS automatically on boot.
+The builder host needs a full crucible installation.
+
+### Workspace materialization
+
+When the SIS receives a job, it materializes the
+base64-encoded content into a temporary directory tree:
+
+```
+/tmp/source-images-service/job-<id>/
+├── workshop/      # workshop script and schema
+├── toolbox/       # toolbox files
+├── roadblock/     # roadblock workshop.json
+├── rickshaw/      # engine scripts and userenvs
+├── bench-dirs/    # benchmark directories
+├── config/        # userenv JSON files
+├── registries/    # registry config and tokens
+└── build/         # build output and audit files
+```
+
+This workspace is deleted after the job completes.
+
+## Provenance tracking
+
+Every image records exactly what went into building it. The
+SIS embeds `/etc/crucible/build-provenance.json` as the final
+layer of each image:
+
+```json
+{
+    "build-date": "2026-06-10T12:34:56Z",
+    "source": {
+        "hostname": "controller.example.com",
+        "ip": "10.1.2.3"
+    },
+    "repos": {
+        "toolbox": {
+            "commit": "abc123...",
+            "dirty": "false"
+        },
+        "roadblock": {
+            "commit": "def456...",
+            "dirty": "false"
+        },
+        "mybench": {
+            "commit": "ghi789...",
+            "dirty": "true",
+            "diff": "--- a/mybench-client\n+++ b/mybench-client\n..."
+        }
+    }
+}
+```
+
+Each contributing repository's git commit and dirty status is
+recorded. If a repo has uncommitted changes, the diff is
+included. This enables exact reproduction of any image and
+makes it clear whether a build used modified code.

--- a/docs/how-releases-work.md
+++ b/docs/how-releases-work.md
@@ -1,0 +1,254 @@
+# How Releases Work
+
+This document explains how crucible's release system operates —
+the quarterly release cycle, how releases are created and
+installed, how repos are pinned to specific versions, and how
+to move between releases.
+
+For how repos and subprojects are managed, see
+[how-the-repo-system-works.md](how-the-repo-system-works.md).
+For how CI tests releases, see
+[how-ci-works.md](how-ci-works.md).
+
+## Overview
+
+Crucible uses a quarterly release system to provide stable,
+reproducible installations. A release is a coordinated
+snapshot of all repositories in the ecosystem — every repo
+gets a branch with the same release name at the same point in
+time. This ensures that all components are compatible and
+have been tested together.
+
+Releases enable:
+
+- **Reproducible testing**: Running the same crucible version
+  across multiple systems for consistent regression results
+- **Stability**: Pinning to a known-good version while
+  upstream development continues
+- **Rollback**: Returning to a previous version if an upgrade
+  introduces issues
+
+## Release naming
+
+Releases follow a `YYYY.Q` naming convention:
+
+- `YYYY` — four-digit year
+- `Q` — quarter number (1 = Jan–Mar, 2 = Apr–Jun,
+  3 = Jul–Sep, 4 = Oct–Dec)
+
+Examples: `2025.4`, `2026.1`, `2026.2`
+
+The four most recent releases are considered **supported**.
+Older releases still exist as branches but are considered
+unsupported.
+
+## How releases are created
+
+Release creation is automated via a GitHub Actions scheduled
+workflow that runs on the first day of each quarter (January
+1, April 1, July 1, October 1). The workflow:
+
+1. Calculates the release name from the current date
+   (`YYYY.Q`)
+2. Creates a release branch in the crucible repo
+3. Reads `config/repos.json` to get the list of all
+   subproject repos
+4. Creates a release branch with the same name in every
+   subproject repo
+
+This produces a synchronized snapshot — all repos have a
+branch named (for example) `2026.2` pointing to their
+current main/master HEAD at the moment the release was
+created.
+
+Releases can also be created manually via `workflow_dispatch`
+for testing or ad-hoc releases.
+
+## Follow vs locked mode
+
+The `repos.json` checkout configuration has two modes that
+control how repos behave:
+
+### Follow mode (default, upstream development)
+
+```json
+{
+    "checkout": {
+        "mode": "follow",
+        "target": "master"
+    }
+}
+```
+
+In follow mode, `crucible update` pulls the latest changes
+from the target branch. The repo stays current with upstream
+development. This is the default for new installations and
+development environments.
+
+### Locked mode (release installations)
+
+```json
+{
+    "checkout": {
+        "mode": "locked",
+        "target": "2026.1"
+    }
+}
+```
+
+In locked mode, `crucible update` does not pull new changes.
+The repo stays pinned to the exact commit on the release
+branch. This provides the stability and reproducibility that
+release installations require.
+
+## Installing a release
+
+### New installation
+
+To install a specific release from scratch:
+
+```bash
+./crucible-install.sh --release 2026.1 [other options]
+```
+
+The installer clones all repos at the specified release
+branch and sets their checkout mode to locked.
+
+### Interactive selection
+
+To choose from available releases interactively:
+
+```bash
+./crucible-install.sh --release select [other options]
+```
+
+This lists the supported releases and prompts for a choice.
+
+## Switching an existing installation
+
+The `--set-release` flag switches an existing installation
+between releases or between release and upstream modes:
+
+```bash
+./crucible-install.sh --set-release 2026.1
+```
+
+### What set-release does
+
+1. **Validates the release** — checks that the requested
+   release branch exists and is within the supported window
+   (the 4 most recent releases)
+2. **Stops all services** — shuts down any running crucible
+   containers to avoid conflicts
+3. **Updates repos.json** — sets all official repos to
+   `mode: "locked"` with `target: "<release>"`
+4. **Checks out crucible** — switches the crucible repo to
+   the release branch, preserving any local changes via stash
+5. **Updates subprojects** — runs `subprojects-install` which
+   clones or checks out each subproject at the release branch
+
+After set-release completes, the installation is fully
+pinned to the specified release version.
+
+## Updates in release mode
+
+When a crucible installation is in release mode (locked),
+`crucible update` behaves differently:
+
+- Repos in **follow mode** pull the latest changes from
+  their target branch
+- Repos in **locked mode** fetch changes from the remote
+  (so the local clone knows about any upstream commits on
+  the release branch) but do not check them out or merge
+  them. The working tree stays at the original commit.
+
+This means `crucible update` in a release installation
+keeps the local clone aware of remote state without
+changing the checked-out code. This is useful because
+release branches may receive critical fixes after the
+initial release — the fetch makes those commits available
+locally if you later decide to pull them, but they don't
+apply automatically. It still updates any unofficial repos
+that may be in follow mode.
+
+## Release CI
+
+Releases are tested automatically in two ways:
+
+### PR-level testing
+
+The `crucible-release-ci.yaml` workflow runs on every pull
+request to crucible's master branch. It exercises the release
+lifecycle by:
+
+1. Deleting a test release branch (`ci-version-test`)
+2. Creating the test release branch
+3. Updating the test release branch
+
+This validates that the release creation and management
+workflows function correctly with the current code.
+
+### Release verification
+
+When a release branch is created or updated, the release
+workflow includes a verification job that:
+
+1. Performs a clean install using the new release
+2. Validates that the installation is functional
+
+This catches installation issues before the release is
+available to users.
+
+## Unsupported releases
+
+Releases older than the four most recent are considered
+unsupported. They remain available as branches but
+`--set-release` will refuse to switch to them by default.
+
+To use an unsupported release, add the force flag:
+
+```bash
+./crucible-install.sh --set-release 2024.3 --set-release-force
+```
+
+This acknowledges that the release is outside the supported
+window and may not work with current infrastructure (CI
+runners, container registries, etc.).
+
+## Moving between releases
+
+To upgrade or downgrade between releases, use `--set-release`
+with the target version:
+
+```bash
+# Upgrade from 2025.4 to 2026.1
+./crucible-install.sh --set-release 2026.1
+
+# Downgrade back to 2025.4
+./crucible-install.sh --set-release 2025.4
+```
+
+The same mechanism works in both directions. Set-release
+stops services, updates `repos.json` to point all repos at
+the new release branch, checks out that branch in every repo,
+and runs `subprojects-install` to ensure everything is
+consistent.
+
+When moving between releases, any local modifications to
+the crucible repo are preserved via git stash. However,
+local changes to subproject repos may conflict with the
+target release and should be committed or stashed manually
+before switching.
+
+## Returning to upstream
+
+To switch from a release back to upstream development mode:
+
+```bash
+./crucible-install.sh --set-release upstream
+```
+
+This changes all repos from `mode: "locked"` back to
+`mode: "follow"` and sets their target back to their
+primary branch (master or main). Running `crucible update`
+afterward pulls the latest upstream changes.

--- a/docs/how-roadblock-works.md
+++ b/docs/how-roadblock-works.md
@@ -342,7 +342,8 @@ with consumer group semantics. This ensures:
 
 ### Timeout settings
 
-Timeouts are configured in `rickshaw-settings.json`:
+Timeouts are configured in `rickshaw-settings.json`
+(validated against `rickshaw/schema/rickshaw-settings.json`):
 
 ```json
 {

--- a/docs/how-roadblock-works.md
+++ b/docs/how-roadblock-works.md
@@ -1,0 +1,388 @@
+# How Roadblock Works
+
+This document explains how crucible's roadblock synchronization
+system operates — the distributed barrier and message passing
+mechanism that coordinates all engines during a benchmark run.
+
+For how engines participate in roadblock synchronization, see
+[how-engines-work.md](how-engines-work.md).
+For the benchmark execution phases that use roadblock, see
+[how-benchmark-execution-works.md](how-benchmark-execution-works.md).
+
+## Overview
+
+Roadblock is a barrier synchronization system that coordinates
+distributed benchmark engines. It solves a fundamental problem:
+when multiple engines (clients, servers, profilers) run across
+different hosts, pods, or VMs, they need to execute in lockstep
+— servers must start before clients connect, all clients must
+finish before data is collected, tools must start before any
+benchmark activity begins.
+
+Roadblock provides two capabilities:
+
+- **Barrier synchronization**: All participants must reach a
+  named synchronization point before anyone proceeds
+- **Message passing**: Participants can exchange JSON messages
+  during synchronization, enabling service discovery, timeout
+  negotiation, and environment injection
+
+Roadblock uses Valkey (Redis-compatible) as its backing store,
+communicating via Redis streams.
+
+## The leader-follower model
+
+Each roadblock synchronization has exactly one **leader** and
+one or more **followers**:
+
+- **Leader**: rickshaw-run.py running on the controller. It
+  orchestrates the run and decides when to proceed or abort.
+- **Followers**: Engine processes and endpoint processes.
+  Engines run inside containers, pods, or chroots on
+  distributed hosts. Endpoints (the scripts that manage
+  engine deployment on each target) also participate as
+  followers — they need to synchronize with the engines
+  they deploy, particularly during the deployment phase,
+  per-sample service creation/teardown (endpoint-start/stop),
+  and data transfer.
+
+Each synchronization point is identified by a UUID-based name:
+
+```
+{run-id}:{phase-name}
+```
+
+For per-sample phases, the name includes the test context:
+
+```
+{run-id}:{iteration}-{sample}-{attempt}:{phase-name}
+```
+
+The leader knows exactly which followers to expect at each
+barrier. If a follower doesn't arrive within the timeout, the
+barrier fails.
+
+## Barrier protocol
+
+Each barrier goes through a series of phases:
+
+### 1. Online
+
+Participants announce their presence:
+
+- Followers send `follower-online` to the leader
+- Leader sends `leader-online` to followers
+- When all expected followers are present, leader broadcasts
+  `all-online`
+
+### 2. Ready
+
+Followers signal they've completed their pre-barrier work:
+
+- **Normal**: Follower sends `follower-ready` — work is done,
+  ready to proceed
+- **Abort**: Follower sends `follower-ready-abort` — an error
+  occurred, requesting the run abort this sample
+- **Waiting**: Follower sends `follower-ready-waiting` — a
+  long-running operation is in progress (see
+  [wait-for mechanism](#the-wait-for-mechanism))
+
+### 3. Decision
+
+The leader evaluates the collected state:
+
+- **All ready, no aborts**: Sends `all-go` — everyone proceeds
+- **Abort detected**: Sends `all-abort` — sample is failed,
+  engines should clean up
+- **Wait-for active**: Sends `all-wait` — switches to heartbeat
+  monitoring mode
+
+### 4. Heartbeat (when wait-for is active)
+
+For barriers where followers are running long operations:
+
+- Leader sends `leader-heartbeat` periodically
+- Each follower responds with `follower-heartbeat`
+- When a follower's operation completes, it sends
+  `follower-waiting-complete`
+- When all complete: leader sends `all-go`
+- If a follower stops responding: `heartbeat-timeout` and abort
+
+### 5. Exit
+
+Participants acknowledge completion:
+
+- Followers send `follower-gone`
+- Leader sends `all-gone` and cleans up Redis keys
+
+## Message passing
+
+Roadblock's message passing allows engines to communicate
+during synchronization without direct network connections
+between them.
+
+### How it works
+
+1. **Before the barrier**: An engine writes JSON messages to
+   its `msgs/tx/` directory
+2. **At the barrier**: The engine's roadblock invocation
+   includes `--user-messages <file>` pointing to the queued
+   messages
+3. **During synchronization**: Messages are transmitted via
+   Redis streams and delivered to recipients
+4. **After the barrier**: Received messages are logged and
+   parsed from the roadblock output
+
+### Message format
+
+```json
+{
+    "recipient": {
+        "type": "all",
+        "id": "all"
+    },
+    "user-object": {
+        "svc": {
+            "ip": "10.244.1.5",
+            "ports": [30000]
+        }
+    }
+}
+```
+
+Messages specify a recipient (leader, follower, or all) and
+carry a JSON payload. The payload is application-defined —
+roadblock delivers it without interpreting it.
+
+### Common use cases
+
+- **Service discovery**: Servers publish their IP and ports
+  so clients know where to connect
+- **Timeout adjustment**: Client engine 1 discovers the
+  benchmark runtime and sends a timeout message so the leader
+  adjusts the next barrier's timeout
+- **Environment injection**: Endpoints send deployment context
+  (node name, userenv, osruntime) to engines during engine-init
+- **Endpoint service modification**: Kubernetes endpoint sends
+  Service ClusterIP/NodePort to replace raw pod IPs
+
+## The synchronization sequence in a run
+
+A complete benchmark run includes these barriers (each with a
+begin and end pair):
+
+### Deployment and initialization
+
+```
+endpoint-pre-deploy-begin/end    — endpoint prepares
+endpoint-deploy-begin/end        — engines are created
+engine-init-begin/end            — engines initialize, receive env vars
+get-data-begin/end               — engines fetch scripts and commands
+collect-sysinfo-begin/end        — system profiling (packrat)
+start-tools-begin/end            — tool collectors launch
+```
+
+### Per-sample execution (repeated for each iteration × sample)
+
+```
+{test}:infra-start-begin/end     — infrastructure setup (e.g., TRex service)
+{test}:server-start-begin/end    — server processes launch, publish service info
+{test}:endpoint-start-begin/end  — endpoint configures networking (e.g., K8s
+                                   Service creation, NodePort/LoadBalancer setup,
+                                   service info transformation)
+{test}:client-start-begin/end    — benchmark execution (runtime discovery, workload)
+{test}:client-stop-begin/end     — clients finish
+{test}:endpoint-stop-begin/end   — endpoint tears down networking (e.g., K8s
+                                   Service deletion)
+{test}:server-stop-begin/end     — servers shut down
+{test}:infra-stop-begin/end      — infrastructure teardown
+```
+
+Where `{test}` is `{iteration}-{sample}-{attempt}`.
+
+### Cleanup
+
+```
+stop-tools-begin/end             — tool collectors shut down
+send-data-begin/end              — data archived and transferred
+```
+
+## Timeout and failure handling
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Successful synchronization |
+| 3 | Timeout — a follower didn't arrive |
+| 4 | Abort — an engine requested abort |
+| 5 | Heartbeat timeout — wait-for follower stopped responding |
+
+### Timeout (exit code 3)
+
+A follower didn't reach the barrier within the allowed time.
+This is treated as a severe failure — the entire run is
+terminated because an unresponsive engine indicates a
+fundamental problem (crashed process, network failure, hung
+workload).
+
+### Abort (exit code 4)
+
+An engine detected an error and sent `follower-ready-abort`.
+The leader propagates this as `all-abort` to all participants.
+The current sample is marked as failed, but the run continues
+to the next sample or iteration (up to `max-sample-failures`).
+
+Abort is the normal failure path — it handles expected error
+conditions like a benchmark script returning non-zero, a
+prerequisite check failing, or a connection error.
+
+### Follower management
+
+The leader tracks which followers are active. When a follower
+fails or is dropped (due to abort or timeout), it's removed
+from the active follower list. Subsequent barriers only expect
+the remaining active followers, preventing cascading timeouts
+from an already-failed engine.
+
+## The wait-for mechanism
+
+Some operations have unpredictable duration — the leader can't
+set a reasonable fixed timeout. The wait-for mechanism handles
+this by switching from fixed-timeout barriers to heartbeat-
+monitored barriers.
+
+### How it works
+
+1. The follower specifies `--wait-for "<command>"` when
+   entering the barrier
+2. The command runs as a subprocess while the follower
+   participates in the barrier
+3. The follower sends `follower-ready-waiting` instead of
+   `follower-ready`
+4. The leader detects waiting followers and sends `all-wait`
+5. The leader begins periodic heartbeat exchanges to verify
+   followers are still alive
+6. When the wait-for command completes, the follower sends
+   `follower-waiting-complete`
+7. Once all followers complete, the leader sends `all-go`
+
+### Where wait-for is used
+
+Wait-for is used in several contexts throughout a run:
+
+- **Unbounded benchmark workloads** (`client-start`): When a
+  benchmark's `get-runtime` script returns `-1` (unknown
+  duration), the client barrier uses wait-for to let the
+  benchmark run until it naturally completes
+- **Tool shutdown** (`stop-tools-end`): Tool stop scripts may
+  need significant time to compress collected data (e.g.,
+  xz-compressing large trace files). Wait-for lets each engine
+  take as long as it needs
+- **Data archival** (`send-data-end`): Archiving the engine's
+  working directory and transferring it via SSH takes variable
+  time depending on data volume and network speed
+
+The common thread: any operation where the duration is
+unpredictable and engines may finish at different times.
+Wait-for allows each engine to proceed at its own pace while
+the leader monitors liveness.
+
+## Valkey backend
+
+Roadblock uses Valkey (Redis-compatible) as its communication
+backbone. All barrier state, participant tracking, and message
+passing flows through Redis streams.
+
+### How it's managed
+
+Crucible starts the Valkey server as a container
+(`crucible-valkey`) alongside the other services at the
+beginning of a run. It runs on port 6379.
+
+The Valkey server is shared across all barriers in a run.
+Redis stream keys are namespaced by the run UUID, so
+concurrent runs don't interfere with each other.
+
+### Password management
+
+Valkey uses password authentication. The password is
+generated when the Valkey service instance starts and
+persists for the lifetime of that instance:
+
+1. When Valkey is started (if not already running),
+   crucible generates a random password by hashing 4KB
+   of `/dev/urandom` with SHA-256
+2. The password is written to `config/valkey_pass`
+3. Valkey starts with `--requirepass` using this password
+4. For each run, the password is read from `config/valkey_pass`
+   and passed to rickshaw-run.py via `--roadblock-password`,
+   which distributes it to all engines and endpoints
+5. When Valkey is stopped, the password file is deleted
+
+The password is tied to the service instance, not to
+individual runs. Multiple runs can share the same Valkey
+instance (and password) as long as the service remains
+running. Each run's roadblock barriers are isolated by
+their unique run UUID, not by authentication.
+
+### Why Redis streams
+
+Redis streams provide ordered, persistent message delivery
+with consumer group semantics. This ensures:
+
+- Messages are delivered in order
+- Messages persist until consumed (survives brief network
+  interruptions)
+- Multiple consumers can read the same stream
+- Streams are automatically cleaned up when the barrier
+  completes
+
+## Configuration
+
+### Timeout settings
+
+Timeouts are configured in `rickshaw-settings.json`:
+
+```json
+{
+    "roadblock": {
+        "timeouts": {
+            "default": 240,
+            "endpoint-deploy": 1440,
+            "collect-sysinfo": 1200,
+            "engine-start": 1440
+        }
+    }
+}
+```
+
+- **default** (240s / 4 min): Most synchronization points
+- **endpoint-deploy** (1440s / 24 min): Engine creation
+  (image pulling, pod scheduling)
+- **collect-sysinfo** (1200s / 20 min): System profiling
+- **engine-start** (1440s / 24 min): Engine bootstrap
+
+These are base values. Dynamic timeout adjustment happens
+for the `client-start` barrier when the benchmark's runtime
+is discovered — the timeout is set to the reported runtime
+plus padding.
+
+### Connection watchdog
+
+An optional connection watchdog can be enabled to monitor
+the Redis connection health. When enabled, a background
+thread pings Redis every second and logs any connection
+failures.
+
+```json
+{
+    "roadblock": {
+        "connection-watchdog": true
+    }
+}
+```
+
+This is primarily a debugging tool for diagnosing
+intermittent connectivity issues between engines and the
+Valkey server.

--- a/docs/how-run-files-work.md
+++ b/docs/how-run-files-work.md
@@ -1,0 +1,450 @@
+# How Run Files Work
+
+This document explains the structure of crucible run files —
+the JSON documents that define what benchmarks to run, where
+to run them, and how to configure the test.
+
+For how parameters are expanded into iterations, see
+[how-benchmark-execution-works.md](how-benchmark-execution-works.md).
+For how endpoints deploy engines, see
+[how-endpoints-work.md](how-endpoints-work.md).
+For how tools are configured, see
+[how-tool-collection-works.md](how-tool-collection-works.md).
+
+## Overview
+
+The run file is the primary user interface for crucible. It's
+a JSON document that specifies:
+
+- **What** to run (benchmarks and their parameters)
+- **Where** to run it (endpoints: hosts, clusters, clouds)
+- **How** to configure the test (tools, samples, tags)
+
+A run is executed with:
+
+```bash
+crucible run my-run-file.json
+```
+
+Run files are validated against
+`rickshaw/schema/run-file.json` and endpoint-specific schemas
+before execution begins.
+
+## Top-level structure
+
+A run file has five sections:
+
+```json
+{
+    "benchmarks": [ ... ],
+    "endpoints": [ ... ],
+    "tool-params": [ ... ],
+    "run-params": { ... },
+    "tags": { ... }
+}
+```
+
+## Benchmarks
+
+The benchmarks section is an array of benchmark
+configurations. Each entry specifies the benchmark name,
+engine IDs, and parameters:
+
+```json
+"benchmarks": [
+    {
+        "name": "uperf",
+        "ids": "1-2",
+        "mv-params": { ... }
+    }
+]
+```
+
+### Fields
+
+- **`name`** (required): The benchmark name, matching a
+  deployed benchmark subproject (e.g., `uperf`, `fio`,
+  `cyclictest`)
+- **`ids`** (required): Engine IDs assigned to this benchmark.
+  Accepts multiple formats:
+  - String with ranges: `"1-4"`, `"1+3"`, `"1-3+5-7"`
+  - Integer: `1`
+  - Array: `[1, 2, 3]`
+- **`mv-params`** (required): Parameter configuration (see
+  below)
+
+### Engine IDs
+
+Engine IDs link benchmarks to endpoints. The same IDs
+referenced in the benchmark's `ids` field must appear in the
+endpoint configuration. For example, if a benchmark has
+`"ids": "1-2"`, the endpoint must include engines with IDs
+1 and 2.
+
+In multi-benchmark runs, each benchmark gets its own set of
+IDs:
+
+```json
+"benchmarks": [
+    { "name": "iperf", "ids": "1", "mv-params": { ... } },
+    { "name": "uperf", "ids": "2", "mv-params": { ... } }
+]
+```
+
+## Parameters (mv-params)
+
+The `mv-params` (multivariate parameters) section defines
+benchmark parameters using a two-tier structure:
+**global-options** (reusable named groups) and **sets** (test
+configurations that reference global-options and add their
+own parameters). This section is processed by the
+**multiplex** subproject, which performs multivariate
+parameter expansion — generating the cartesian product of
+all multi-valued parameters to produce the iteration matrix.
+
+```json
+"mv-params": {
+    "global-options": [
+        {
+            "name": "common",
+            "params": [
+                { "arg": "duration", "vals": ["60"] },
+                { "arg": "protocol", "vals": ["tcp"] }
+            ]
+        }
+    ],
+    "sets": [
+        {
+            "include": "common",
+            "params": [
+                { "arg": "wsize", "vals": ["64", "1024"] }
+            ]
+        }
+    ]
+}
+```
+
+### Parameter fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `arg` | Yes | Parameter name (passed as `--arg` to the benchmark) |
+| `vals` | Yes* | Array of values. Multiple values create iterations via cartesian product. |
+| `val` | Yes* | Single value (alternative to `vals`) |
+| `role` | No | Restrict to a specific role: `"client"`, `"server"`, or `"all"` (default) |
+| `enabled` | No | `"yes"` (default) or `"no"` — disabled params are excluded |
+
+*One of `vals` or `val` is required.
+
+### How parameters become iterations
+
+Each set independently expands its parameters via cartesian
+product. Multiple values in `vals` multiply with other
+multi-valued parameters to create iterations:
+
+- `protocol: ["tcp"]` × `wsize: ["64", "1024"]` = 2 iterations
+- `protocol: ["tcp", "udp"]` × `wsize: ["64", "1024"]` = 4 iterations
+
+Parameters inherited from `global-options` via `include` are
+combined with the set's own parameters.
+
+### Simplified format
+
+For simple cases, parameters can be specified directly
+without the global-options/sets structure:
+
+```json
+"mv-params": {
+    "sets": [
+        {
+            "params": [
+                { "arg": "duration", "vals": ["60"] },
+                { "arg": "wsize", "vals": ["64", "1024"] }
+            ]
+        }
+    ]
+}
+```
+
+## Endpoints
+
+The endpoints section defines where engines are deployed.
+Each endpoint specifies a type and host-specific
+configuration:
+
+### Remotehosts endpoint
+
+```json
+{
+    "type": "remotehosts",
+    "settings": {
+        "user": "root"
+    },
+    "remotes": [
+        {
+            "engines": [
+                { "role": "client", "ids": [1] },
+                { "role": "server", "ids": [2] }
+            ],
+            "config": {
+                "host": "testhost.example.com",
+                "settings": {
+                    "userenv": "rhubi9",
+                    "osruntime": "podman",
+                    "cpu-partitioning": false,
+                    "host-mounts": []
+                }
+            }
+        }
+    ]
+}
+```
+
+### Kubernetes endpoint
+
+```json
+{
+    "type": "kube",
+    "settings": {
+        "user": "root"
+    },
+    "remotes": [
+        {
+            "engines": [
+                { "role": "client", "ids": [1, 2] },
+                { "role": "server", "ids": [3, 4] }
+            ],
+            "config": {
+                "host": "k8s-controller.example.com",
+                "settings": {
+                    "userenv": "rhubi9",
+                    "controller-ip-address": "10.0.0.1"
+                }
+            }
+        }
+    ]
+}
+```
+
+### Key endpoint settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `userenv` | Base container image name | From rickshaw-settings |
+| `osruntime` | Runtime mode: `"podman"` or `"chroot"` | `"podman"` |
+| `cpu-partitioning` | Enable CPU isolation | `false` |
+| `host-mounts` | Host directories to mount into engines | `[]` |
+| `controller-ip-address` | IP for engines to reach the controller | Auto-detected |
+| `disable-tools` | Skip tool collection on this endpoint | `false` |
+
+### Settings hierarchy
+
+Endpoint settings can be specified at multiple levels:
+
+1. **Top-level `settings`**: Defaults for all remotes/configs
+2. **Per-remote/per-config `settings`**: Override defaults for
+   specific hosts or engine groups
+
+Per-remote settings override top-level settings.
+
+### Per-engine configuration
+
+Endpoints support targeting specific engines with different
+settings:
+
+```json
+"config": [
+    {
+        "targets": [
+            { "role": "client", "ids": "1" }
+        ],
+        "settings": {
+            "osruntime": "chroot",
+            "cpu-partitioning": true
+        }
+    },
+    {
+        "targets": "default",
+        "settings": {
+            "osruntime": "podman"
+        }
+    }
+]
+```
+
+## Tool parameters
+
+The `tool-params` section configures which tools run and
+their settings:
+
+```json
+"tool-params": [
+    {
+        "tool": "sysstat",
+        "params": [
+            { "arg": "subtools", "val": "mpstat,sar,iostat" },
+            { "arg": "interval", "val": "3" }
+        ]
+    },
+    {
+        "tool": "procstat"
+    },
+    {
+        "tool": "kernel",
+        "enabled": "no"
+    }
+]
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `tool` | Yes | Tool name (must match a deployed tool subproject) |
+| `params` | No | Array of `{arg, val}` parameter objects |
+| `enabled` | No | `"yes"` (default) or `"no"` |
+
+### Default tools
+
+When `tool-params` is omitted from the run file, crucible
+automatically uses the default tool set (sysstat and
+procstat). Specifying `tool-params` replaces the defaults
+entirely — only the tools listed will run.
+
+Tool parameters use `val` (single value) rather than `vals`
+(array) because tools don't participate in the iteration
+matrix.
+
+## Run parameters
+
+The `run-params` section controls execution behavior:
+
+```json
+"run-params": {
+    "num-samples": 3,
+    "max-sample-failures": 3,
+    "test-order": "random"
+}
+```
+
+### Fields
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `num-samples` | Executions per iteration (for statistical confidence) | 1 |
+| `max-sample-failures` | Failed attempts before a sample is permanently failed | 1 |
+| `test-order` | Execution order: `"sample"`, `"iteration"`, or `"random"` | `"sample"` |
+| `name` | Override user name (both name and email required if either specified) | From identity |
+| `email` | Override user email | From identity |
+
+### Test order
+
+- **`sample`** (or `"s"`): All samples of iteration 1, then
+  all samples of iteration 2, etc.
+- **`iteration`** (or `"i"`): Sample 1 of all iterations,
+  then sample 2 of all iterations, etc.
+- **`random`** (or `"r"`): Randomized order to reduce
+  systematic bias
+
+## Tags
+
+The `tags` section adds free-form metadata for identifying
+and filtering runs:
+
+```json
+"tags": {
+    "purpose": "regression-test",
+    "kernel": "6.8.0-rt",
+    "tuned-profile": "cpu-partitioning",
+    "hardware": "Dell R760"
+}
+```
+
+Tags are indexed into OpenSearch and appear in the CDM web
+dashboard, enabling filtering and comparison across runs.
+They're especially useful for tracking what changed between
+runs (kernel version, tuning profile, hardware configuration).
+
+Values are always strings. Any key names can be used.
+
+## Complete annotated example
+
+```json
+{
+    "tags": {
+        "purpose": "network-throughput-comparison",
+        "kernel": "6.8.0"
+    },
+
+    "run-params": {
+        "num-samples": 3,
+        "test-order": "random"
+    },
+
+    "tool-params": [
+        {
+            "tool": "sysstat",
+            "params": [
+                { "arg": "subtools", "val": "mpstat,sar" },
+                { "arg": "interval", "val": "1" }
+            ]
+        },
+        { "tool": "procstat" }
+    ],
+
+    "endpoints": [
+        {
+            "type": "remotehosts",
+            "settings": { "user": "root" },
+            "remotes": [
+                {
+                    "engines": [
+                        { "role": "client", "ids": [1] },
+                        { "role": "server", "ids": [2] }
+                    ],
+                    "config": {
+                        "host": "testhost.example.com",
+                        "settings": {
+                            "userenv": "rhubi9",
+                            "osruntime": "podman"
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+
+    "benchmarks": [
+        {
+            "name": "uperf",
+            "ids": "1-2",
+            "mv-params": {
+                "global-options": [
+                    {
+                        "name": "common",
+                        "params": [
+                            { "arg": "duration", "vals": ["60"], "role": "client" },
+                            { "arg": "nthreads", "vals": ["1"], "role": "client" }
+                        ]
+                    }
+                ],
+                "sets": [
+                    {
+                        "include": "common",
+                        "params": [
+                            { "arg": "protocol", "vals": ["tcp", "udp"], "role": "client" },
+                            { "arg": "wsize", "vals": ["64", "1024"], "role": "client" }
+                        ]
+                    }
+                ]
+            }
+        }
+    ]
+}
+```
+
+This run file produces 4 iterations (2 protocols × 2 sizes),
+each executed 3 times (num-samples) in random order. Sysstat
+collects CPU and system metrics at 1-second intervals, and
+procstat captures /proc data with default settings. The run
+is tagged for later identification.

--- a/docs/how-services-work.md
+++ b/docs/how-services-work.md
@@ -1,0 +1,380 @@
+# How Services Work
+
+This document explains how crucible manages its supporting
+services — the infrastructure containers that provide
+synchronization, result storage, result browsing, and container
+image building.
+
+For how the image-sourcing service builds images, see
+[how-image-sourcing-works.md](how-image-sourcing-works.md).
+For how roadblock uses the valkey service, see
+[how-roadblock-works.md](how-roadblock-works.md).
+
+## Overview
+
+Crucible runs several supporting services as podman containers.
+These services provide the infrastructure that benchmark
+execution depends on:
+
+- **valkey** — Redis-compatible backend for roadblock
+  synchronization
+- **opensearch** — Result indexing and search engine
+- **cdm-server** — CDM query API server for result analysis
+- **httpd** — Web UI for browsing results and logs
+- **image-sourcing** — Container image builder for engine images
+
+Services are managed via `crucible start <service>` and
+`crucible stop <service>`, and configured in
+`config/services.json`. They run as long-lived detached
+containers that persist across multiple benchmark runs.
+
+## The services
+
+### Valkey
+
+Valkey is a Redis-compatible in-memory data store that serves
+as the backend for roadblock synchronization. Every roadblock
+barrier and message exchange flows through Valkey's Redis
+streams. It runs on port 6379 with per-instance password
+authentication.
+
+An optional valkey monitor container can be enabled for
+debugging. It runs the roadblock `redis-monitor.py` utility
+to observe valkey traffic in real time.
+
+### OpenSearch
+
+OpenSearch stores and indexes benchmark results, enabling
+search and analysis. It supports multiple instances for
+different CDM versions — for example, a local instance for
+the latest CDM format and a remote instance for an older
+format.
+
+OpenSearch runs with dynamically calculated JVM heap size
+(half of system memory, capped at 32GB) and waits for
+cluster health to reach at least "yellow" status before
+accepting connections.
+
+### CDM server
+
+The CDM (Common Data Model) server provides a query API and
+web-based dashboard for analyzing benchmark results stored in
+OpenSearch. The dashboard is a React application that provides
+search, comparison, and deep-dive views for exploring result
+data across runs, iterations, and metrics. The CDM server
+automatically starts when OpenSearch starts and stops when
+OpenSearch stops. It connects to all configured query-from
+OpenSearch instances.
+
+### httpd
+
+The Apache HTTP server provides a web UI for browsing
+benchmark results, logs, and run artifacts. It serves files
+from the crucible result directory (`/var/lib/crucible`) and
+includes transparent decompression of `.xz` files for
+in-browser viewing.
+
+### Image-sourcing
+
+The source-images-service builds container images for
+benchmark and tool engines. It runs per-architecture instances
+— one for each CPU architecture that endpoints require. The
+native architecture runs locally; non-native architectures
+require remote builder hosts.
+
+## Service lifecycle
+
+### Starting and stopping
+
+```bash
+crucible start httpd          # start a specific service
+crucible stop opensearch      # stop a specific service
+crucible start all            # start all services
+crucible stop all             # stop all services
+```
+
+The `service_control()` function in `bin/base` manages the
+lifecycle for all services.
+
+### Start order
+
+Services have implicit dependencies that affect startup
+order:
+
+1. **Valkey** starts first — required by roadblock, which is
+   needed before any engine coordination
+2. **Image-sourcing** starts next — needed to build engine
+   images before a run
+3. **OpenSearch** starts on demand — needed for result indexing
+   after a run completes
+4. **CDM server** auto-starts with OpenSearch — depends on
+   OpenSearch being available
+5. **httpd** starts on demand — needed for result browsing
+
+During a benchmark run, `crucible run` automatically starts
+valkey and image-sourcing. OpenSearch, CDM server, and httpd
+are started later when results are ready for indexing.
+
+### Health checks
+
+Some services require readiness verification after starting:
+
+- **Image-sourcing**: Polls `GET /api/v1/health` every second
+  for up to 60 seconds, waiting for `"status": "healthy"`
+- **OpenSearch**: Two-stage check — first waits for the HTTP
+  endpoint to respond, then waits for cluster health to reach
+  "yellow" or "green" status
+
+### Run protection
+
+Services cannot be stopped while a benchmark run is active.
+The `service_control()` function checks for running
+`crucible-rickshaw-run` containers and refuses to stop
+services if any are found. This prevents accidentally
+disrupting an in-progress run.
+
+## Container management
+
+### Naming convention
+
+All service containers follow the naming pattern
+`crucible-<service>`:
+
+- `crucible-httpd`
+- `crucible-opensearch`
+- `crucible-valkey`
+- `crucible-valkey-monitor` (optional)
+- `crucible-cdm-server`
+- `crucible-image-sourcing-<arch>` (e.g.,
+  `crucible-image-sourcing-x86_64`)
+
+### How they run
+
+Service containers run in detached mode with journald
+logging. They use host networking (`--net=host`), share the
+host PID namespace, and mount the crucible installation and
+result directories. This gives services full access to the
+host's network stack and filesystem where needed.
+
+### Port management
+
+Each service listens on a configurable port. If the
+configured port is already in use (by another process or a
+previous crucible instance), the `find_available_port()`
+function automatically searches for the next available port,
+trying up to 100 sequential ports. If a different port is
+used, `services.json` is updated with the actual port.
+
+Firewall rules are managed automatically — ports are opened
+when services start and closed when they stop.
+
+## Configuration
+
+All service configuration lives in `config/services.json`,
+which is validated against `schema/services.json`.
+
+### Structure
+
+```json
+{
+    "httpd": {
+        "port": 8080
+    },
+    "cdm-server": {
+        "port": 3000
+    },
+    "valkey": {
+        "monitor": {
+            "enabled": false
+        }
+    },
+    "opensearch": {
+        "instances": [
+            {
+                "name": "local-v9",
+                "host": "localhost:9200",
+                "cdmver": "v9dev"
+            }
+        ],
+        "index-to": "local-v9",
+        "query-from": ["local-v9"]
+    },
+    "image-sourcing": {
+        "use": true,
+        "services": {
+            "default": {
+                "start": true,
+                "location": {
+                    "address": "localhost",
+                    "port": 8888,
+                    "protocol": "http"
+                }
+            }
+        }
+    }
+}
+```
+
+### Key settings
+
+- **httpd.port**: Web UI listening port
+- **cdm-server.port**: CDM query API port
+- **valkey.monitor.enabled**: Enable/disable the valkey
+  traffic monitor
+- **opensearch.instances**: Array of OpenSearch instances
+  with name, host, and CDM version
+- **opensearch.index-to**: Which instance receives new results
+- **opensearch.query-from**: Which instances are available for
+  queries
+- **image-sourcing.use**: Enable/disable image sourcing
+- **image-sourcing.services**: Per-architecture SIS
+  configuration
+
+## OpenSearch instance management
+
+OpenSearch supports multiple instances, enabling scenarios
+like:
+
+- A local instance running the latest CDM version for new
+  results
+- A remote shared instance running an older CDM version with
+  historical data
+- Separate instances for different teams or projects
+
+### Index-to vs query-from
+
+The **index-to** setting specifies the single instance where
+new benchmark results are indexed. The **query-from** setting
+is an array of instances that the CDM server queries when
+searching for results. This allows querying across multiple
+instances while only writing to one.
+
+### Managing instances
+
+The `crucible opensearch` command manages OpenSearch instance
+configuration:
+
+```bash
+crucible opensearch list          # show configured instances
+crucible opensearch add <name>    # add a new instance
+crucible opensearch remove <name> # remove an instance
+crucible opensearch set-index <n> # set the index-to instance
+crucible opensearch repair        # repair OpenSearch state
+```
+
+## Image-sourcing service details
+
+The image-sourcing service has unique characteristics compared
+to other services because it supports per-architecture
+instances.
+
+### The "default" key
+
+The `services.json` image-sourcing section uses a `"default"`
+key that maps to the controller's native CPU architecture
+(determined at runtime via `uname -m`). This avoids hardcoding
+the architecture in the committed configuration file.
+
+### Remote builders
+
+Non-native architectures (e.g., aarch64 on an x86_64
+controller) cannot be built locally due to buildah/QEMU
+incompatibilities. These must point to remote builder hosts
+with `"start": false`:
+
+```json
+"aarch64": {
+    "start": false,
+    "location": {
+        "address": "arm-builder.example.com",
+        "port": 8888,
+        "protocol": "http"
+    }
+}
+```
+
+### Systemd service
+
+For dedicated builder hosts, the image-sourcing service can
+be installed as a systemd unit that starts automatically on
+boot and restarts on failure:
+
+```bash
+bin/services/setup-image-sourcing-service.sh install
+bin/services/setup-image-sourcing-service.sh uninstall
+```
+
+The systemd service integrates with `crucible update` — the
+update process stops the service before updating and restarts
+it afterward, using a flag file to survive the update script's
+self-restart mechanism.
+
+## Service interaction with crucible update
+
+When `crucible update` runs, it needs to stop services to
+avoid conflicts with the update process:
+
+1. **Check for active runs** — refuse to update if a benchmark
+   run is in progress
+2. **Stop systemd image-sourcing** — if the systemd service is
+   enabled and active, stop it and set a restart flag
+3. **Stop all container services** — `service_control stop all`
+4. **Perform the update** — git pull, subproject updates,
+   controller image check
+5. **Restart systemd image-sourcing** — if the restart flag
+   exists, restart the service and remove the flag
+
+The flag file (`/tmp/.crucible-restart-image-sourcing`)
+persists across the update script's `exec` self-restart,
+ensuring the service is properly restored after the update
+completes.
+
+## Logging
+
+### Container logs
+
+Service containers use the journald log driver. Access logs
+via:
+
+```bash
+journalctl CONTAINER_NAME=crucible-opensearch
+journalctl CONTAINER_NAME=crucible-httpd
+journalctl CONTAINER_NAME=crucible-valkey
+```
+
+### Service-specific log files
+
+Some services also write to dedicated log files:
+
+- **OpenSearch**: `/var/lib/crucible/logs/opensearch.log`
+- **Image-sourcing**: `/var/lib/crucible/logs/image-sourcing.log`
+
+### Valkey monitor
+
+For debugging roadblock synchronization issues, enable the
+valkey monitor in `services.json`:
+
+```json
+{
+    "valkey": {
+        "monitor": {
+            "enabled": true
+        }
+    }
+}
+```
+
+This starts a companion container (`crucible-valkey-monitor`)
+that logs all valkey commands in real time, useful for
+diagnosing synchronization failures or message delivery
+issues.
+
+### Crucible log
+
+The `crucible log` command provides access to the main
+crucible run log, which includes service startup/shutdown
+messages:
+
+```bash
+crucible log view last    # view the most recent run's log
+```

--- a/docs/how-services-work.md
+++ b/docs/how-services-work.md
@@ -171,7 +171,12 @@ when services start and closed when they stop.
 ## Configuration
 
 All service configuration lives in `config/services.json`,
-which is validated against `schema/services.json`.
+which is validated against `schema/services.json`. The schema
+enforces valid port numbers, endpoint types, image-sourcing
+structure, and OpenSearch instance fields. Changes made via
+crucible commands are validated before being saved; manual
+edits should be checked with `crucible repo config show` to
+confirm validity.
 
 ### Structure
 

--- a/docs/how-services-work.md
+++ b/docs/how-services-work.md
@@ -9,6 +9,10 @@ For how the image-sourcing service builds images, see
 [how-image-sourcing-works.md](how-image-sourcing-works.md).
 For how roadblock uses the valkey service, see
 [how-roadblock-works.md](how-roadblock-works.md).
+For how the controller image contains these services, see
+[how-the-controller-image-works.md](how-the-controller-image-works.md).
+For how crucible captures command output, see
+[how-the-logger-works.md](how-the-logger-works.md).
 
 ## Overview
 

--- a/docs/how-the-controller-image-works.md
+++ b/docs/how-the-controller-image-works.md
@@ -173,7 +173,7 @@ Architecture-specific images use:
 ```
 
 For example:
-`quay.io/crucible/controller:2026-06-10_a1b2c3d4_x86_64`
+`<registry>/<repo>:2026-06-10_a1b2c3d4_x86_64`
 
 ### Tag management
 

--- a/docs/how-the-controller-image-works.md
+++ b/docs/how-the-controller-image-works.md
@@ -1,0 +1,339 @@
+# How the Controller Image Works
+
+This document explains the crucible controller image — the
+container that all crucible operations run inside. It covers
+what the image contains, how it's built, how it's updated,
+and how the automated build pipeline works.
+
+For how engine images are built, see
+[how-image-sourcing-works.md](how-image-sourcing-works.md).
+For how services run inside the controller, see
+[how-services-work.md](how-services-work.md).
+
+## Overview
+
+The controller image is a Fedora-based container image
+containing all the software needed to orchestrate benchmark
+runs. Every `crucible` command runs inside this image — when
+you type `crucible run`, `crucible update`, or
+`crucible start`, the command is executed inside a controller
+container.
+
+A key property: **the controller image is shared across all
+releases.** There is one controller image used by all crucible
+installations, regardless of which release they're running.
+This is why controller image changes trigger multi-release
+CI testing — a change could affect any release.
+
+## What it contains
+
+The controller image includes everything needed for
+benchmark orchestration, service management, and image
+building:
+
+### Core components
+
+The orchestration framework and its dependencies:
+
+- **Rickshaw** — benchmark orchestration, source-images-service
+- **Toolbox** — shared Python and Bash libraries
+- **Roadblock** — distributed synchronization client and
+  utilities
+- **CommonDataModel** — result schema, query engine, web UI
+- **Multiplex** — parameter expansion engine
+- **Workshop** — container image building engine
+
+### Container tools
+
+The controller builds engine images internally, so it needs
+its own container tooling:
+
+- **Podman** — container runtime (for building and running
+  nested containers)
+- **Buildah** — image building
+- **Skopeo** — image inspection and registry operations
+- **fuse-overlayfs** — overlay filesystem for rootless
+  containers
+
+### Services
+
+Infrastructure services that run as processes within
+controller containers:
+
+- **Valkey** — Redis-compatible backend for roadblock
+- **OpenSearch** — result indexing and search
+- **httpd** — web UI for browsing results
+- **CDM server** — result query API
+
+### Build tools and languages
+
+- **Python 3** with pip, FastAPI, uvicorn, pydantic,
+  jsonschema, invoke
+- **Perl** with JSON, validation, REST, and UUID modules
+- **GCC, make, autoconf, automake, libtool** — for source
+  builds during engine image construction
+- **Node.js** — for CDM query engine
+
+### Utilities
+
+- git, curl, jq, ssh tools, network utilities
+- GitHub CLI (gh) — for GitHub API operations
+- tar, xz, gzip — for data archival
+
+## Contributing repos
+
+The controller image is built from the workshop.json files
+of 7 repos, each contributing its own dependencies:
+
+| Repo | What it adds |
+|------|-------------|
+| crucible | Core packages: podman, buildah, valkey, opensearch, httpd, build tools, gh CLI |
+| rickshaw | Python packages for orchestration (FastAPI, pydantic, etc.) |
+| workshop | Workshop script dependencies (Perl modules for JSON, HTTP) |
+| toolbox | Python libraries and utilities |
+| roadblock | Python libraries for synchronization |
+| CommonDataModel | Node.js runtime and CDM packages |
+| multiplex | Python jsonschema |
+
+### Controller vs engine userenvs
+
+Each contributing repo's `workshop.json` has entries for the
+`crucible-controller` userenv. This is distinct from the
+userenvs used for engine images (like `rhubi9`,
+`fedora-latest`, `alma8`):
+
+- **Controller userenv** (`crucible-controller`): Fedora-based,
+  contains orchestration software. Only built as the
+  controller image.
+- **Engine userenvs** (`rhubi9`, etc.): Various distributions,
+  contain benchmark/tool software. Built per-benchmark by
+  the source-images-service.
+
+Some core repos target both images. For example, roadblock's
+`workshop.json` has entries for `crucible-controller` (the
+leader runs on the controller) and engine userenvs (followers
+run on engines). Packrat targets engine images only.
+
+## How it's built
+
+The `workshop/controller-image.py` tool manages the build
+process with three subcommands:
+
+### Build
+
+```bash
+controller-image.py build
+```
+
+Assembles the image by:
+
+1. Loading the controller configuration from
+   `workshop/controller.json`
+2. Collecting workshop.json files from all 7 contributing
+   repos
+3. Calling `workshop.py` with all requirements to build the
+   image layer by layer
+4. Embedding provenance data into the image
+
+### Push
+
+```bash
+controller-image.py push --authfile /path/to/auth.json
+```
+
+Pushes the built image to the container registry with a
+content-based tag.
+
+### Manifest
+
+```bash
+controller-image.py manifest <tag>
+```
+
+Creates a multi-architecture manifest combining the x86_64
+and aarch64 images under a single tag. This allows users to
+pull the correct architecture automatically.
+
+## Image tagging
+
+### Composite hash
+
+The controller image tag is based on a **composite hash** —
+a SHA-256 of the HEAD commits of all 7 contributing repos.
+This provides content-based addressing: the same set of
+repo versions always produces the same tag, and any change
+to any contributing repo produces a new tag.
+
+### Tag format
+
+Architecture-specific images use:
+
+```
+<registry>:<YYYY-MM-DD>_<composite_hash>_<arch>
+```
+
+For example:
+`quay.io/crucible/controller:2026-06-10_a1b2c3d4_x86_64`
+
+### Tag management
+
+The registry maintains special tags:
+
+- **`latest`** — the current recommended controller image
+- **`previous`** — the former `latest` (kept for rollback)
+
+When a new image is published, the automated pipeline:
+1. Moves the current `latest` to `previous`
+2. Moves the new manifest to `latest`
+
+## Automated build pipeline
+
+Controller rebuilds are triggered automatically when
+contributing repos merge changes that affect the image.
+
+### Trigger chain
+
+1. A subproject PR merges to its default branch
+2. The subproject's `controller-build.yaml` workflow fires
+3. It generates a GitHub App token and dispatches a
+   `controller-build` event to the crucible repo
+4. Crucible's `build-publish-controller.yaml` workflow
+   receives the dispatch
+5. It calls `build-publish-controller-worker.yaml`
+
+### Build process
+
+The worker workflow runs three jobs:
+
+1. **Build and push** (matrix: x86_64 + aarch64):
+   - Each architecture runs on a native self-hosted runner
+   - Installs crucible fresh
+   - Runs `controller-image.py build` then
+     `controller-image.py push`
+   - Both architectures build in parallel
+
+2. **Create manifest** (after both builds complete):
+   - Verifies both architecture images exist in the registry
+   - Creates a multi-arch manifest
+   - Pushes the manifest
+
+3. **Update tags** (after manifest):
+   - Rotates `latest` → `previous` via the Quay API
+   - Points `latest` to the new manifest
+
+### Cross-repo dispatch
+
+Subproject repos can't directly trigger crucible workflows
+(they're in different repos). The system uses a GitHub App
+(`APP_ID__CRUCIBLE_WORKFLOW_DISPATCH`) to generate tokens
+that allow cross-repo `repository_dispatch` events.
+
+## How crucible uses the image
+
+### Configuration
+
+The controller image URL is configured in
+`config/registries.json` and loaded as the
+`CRUCIBLE_CONTROLLER_IMAGE` variable.
+
+### Runtime
+
+Every crucible command runs inside a controller container
+via podman. The `bin/base` script sets up container arguments
+that mount the crucible installation, user home directories,
+and result storage into the container. Services run as
+detached containers; one-off commands run as ephemeral
+containers.
+
+The controller container runs with host networking, host
+PID namespace, and privileged mode. This gives it full access
+to the host's network stack and devices, which is necessary
+for managing engine containers, SSH connections to remote
+hosts, and accessing hardware for benchmarking.
+
+### The `crucible wrapper` and `crucible console` commands
+
+For ad-hoc operations, two commands provide direct access
+to the controller environment:
+
+- **`crucible wrapper <command>`** — runs a single command
+  inside the controller container and returns. Useful for
+  running scripts that depend on software installed in the
+  controller image (Python packages, Perl modules, etc.)
+  that may not be available on the host.
+
+- **`crucible console`** — opens an interactive bash shell
+  inside the controller container. Useful for exploring the
+  controller environment, debugging, or running multiple
+  commands interactively. The session persists until you
+  exit the shell.
+
+The controller image is purposefully configured with full
+man page documentation for all installed software. Container
+base images typically strip man pages via `tsflags=nodocs`
+in the package manager configuration to save space. The
+controller build process removes this restriction and
+reinstalls all packages to restore their man pages. This
+means when using `crucible console`, you can run `man`
+commands to inspect the exact documentation for the
+specific versions of tools installed in the controller —
+useful when debugging or investigating behavior that
+depends on precise tool versions.
+
+## Updating the controller image
+
+### How updates work
+
+When `crucible update` runs (for `all`, `crucible`, or
+`controller-image` targets):
+
+1. Records the current image ID
+2. Pulls the latest image: `podman pull <image>`
+3. Compares old vs new image ID
+4. If different: removes the old image to free space
+
+### Shared-across-releases implication
+
+Because the controller image is shared across all releases,
+updating the controller image affects the installation
+regardless of which release it's running. A controller update
+brings new orchestration capabilities, service versions, and
+build tools to every release.
+
+This is intentional — the controller handles orchestration,
+not workload execution. Workload behavior is determined by
+the engine images (which are release-specific), not the
+controller.
+
+## Provenance
+
+Every controller image embeds build traceability data at
+`/etc/crucible/build-provenance.json`:
+
+```json
+{
+    "build-date": "2026-06-10T12:34:56Z",
+    "composite-hash": "a1b2c3d4e5f6...",
+    "source": {
+        "hostname": "build-host.example.com",
+        "ip": "10.1.2.3"
+    },
+    "repos": {
+        "crucible": { "commit": "abc123..." },
+        "rickshaw": { "commit": "def456..." },
+        "toolbox": { "commit": "ghi789..." },
+        "roadblock": { "commit": "jkl012..." },
+        "workshop": { "commit": "mno345..." },
+        "CommonDataModel": { "commit": "pqr678..." },
+        "multiplex": { "commit": "stu901..." }
+    }
+}
+```
+
+The same data is also stored as OCI image annotations,
+making it accessible via `skopeo inspect` or
+`buildah inspect` without pulling the full image.
+
+This enables exact reproduction of any controller image
+and makes it clear which code versions are running in any
+installation.

--- a/docs/how-the-installer-works.md
+++ b/docs/how-the-installer-works.md
@@ -1,0 +1,216 @@
+# How the Installer Works
+
+This document explains how `crucible-install.sh` installs
+crucible — the prerequisites, installation flow, registry
+configuration, and post-install steps.
+
+For how releases interact with the installer, see
+[how-releases-work.md](how-releases-work.md).
+For how the repo system is set up during install, see
+[how-the-repo-system-works.md](how-the-repo-system-works.md).
+
+## Overview
+
+The crucible installer (`crucible-install.sh`) handles fresh
+installations, release selection, and switching between
+releases. It clones the crucible repository, installs all
+subprojects, pulls the controller container image, and
+configures the registry settings.
+
+The host system has minimal requirements — only podman, git,
+and jq are needed. All other software dependencies are
+satisfied by the controller container image.
+
+## Prerequisites
+
+The installer requires three tools on the host:
+
+- **podman** — container runtime for running all crucible
+  operations
+- **git** — for cloning and updating repositories
+- **jq** — for manipulating JSON configuration files
+
+The installer checks for these at startup and attempts to
+install them via `yum` if they're missing. If automatic
+installation fails, the user must install them manually.
+
+## Fresh install
+
+A basic installation:
+
+```bash
+./crucible-install.sh \
+    --engine-registry <engine-registry-url> \
+    --name "Your Name" \
+    --email "you@example.com"
+```
+
+### What happens during install
+
+1. **Dependency check** — verifies podman, git, and jq are
+   available
+2. **User identity** — prompts for name and email if not
+   provided via flags (or reads from existing
+   `~/.crucible/identity`)
+3. **Clean previous install** — if `/opt/crucible` exists,
+   backs it up with a timestamp suffix
+4. **Clone crucible** — clones the repository to
+   `/opt/crucible`, optionally checking out a specific
+   branch or release
+5. **Install subprojects** — runs `subprojects-install` to
+   clone all component repos and create symlinks
+6. **Pull controller image** — downloads the controller
+   container image from the configured registry
+7. **Configure registries** — creates `config/registries.json`
+   with engine and controller registry settings
+8. **Create sysconfig** — writes `/etc/sysconfig/crucible`
+   with environment variables for the installation
+
+## Install options
+
+### Required
+
+| Flag | Description |
+|------|-------------|
+| `--engine-registry <url>` | Registry URL for engine container images |
+
+### Optional
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--controller-registry <url>` | Controller image URL | `<controller-registry-url>:latest` |
+| `--name <name>` | User's full name | Prompted interactively |
+| `--email <email>` | User's email address | Prompted interactively |
+| `--release <version\|select>` | Install a specific release | Latest upstream |
+| `--git-repo <url>` | Clone from a custom repository | Auto-detected or default upstream |
+| `--git-branch <branch>` | Check out a specific branch | Default branch |
+| `--engine-auth-file <file>` | Docker auth JSON for engine registry | None |
+| `--engine-tls-verify <bool>` | TLS verification for engine registry | `true` |
+| `--quay-engine-expiration-refresh-token <file>` | Quay OAuth token for image expiration | None |
+| `--quay-engine-expiration-refresh-api-url <url>` | Quay API URL for expiration management | None |
+| `--quay-engine-expiration-length <duration>` | Image expiration duration | `13w` |
+| `--verbose` | Enable verbose output | Off |
+
+### Release and management
+
+| Flag | Description |
+|------|-------------|
+| `--set-release <version\|upstream\|select>` | Switch existing install to a different release |
+| `--set-release-force` | Allow switching to unsupported (older) releases |
+| `--list-releases` | List available releases and exit |
+
+## Registry configuration
+
+The installer creates `config/registries.json` which tells
+crucible where to find container images:
+
+- **Engine registry**: Where benchmark and tool engine images
+  are stored and pulled from. This is the registry that the
+  source-images-service pushes to and engines pull from.
+- **Controller registry**: Where the controller image is
+  stored. Typically the project's official controller image registry.
+
+### Authentication
+
+If the engine registry requires authentication, provide a
+Docker/Podman auth JSON file via `--engine-auth-file`. This
+file is referenced (not copied) by the configuration.
+
+### Quay expiration management
+
+For registries hosted on Quay.io, crucible can automatically
+refresh image tag expirations to prevent auto-deletion of
+cached images. This requires:
+
+- An OAuth refresh token (`--quay-engine-expiration-refresh-token`)
+- The Quay API URL (`--quay-engine-expiration-refresh-api-url`)
+- Optionally, a custom expiration duration (`--quay-engine-expiration-length`, default 13 weeks)
+
+## User identity
+
+Crucible tracks who runs benchmarks for result attribution.
+The user identity is stored at `~/.crucible/identity`:
+
+```bash
+CRUCIBLE_NAME="Jane Smith"
+CRUCIBLE_EMAIL="jsmith@example.com"
+```
+
+This file is created during installation (prompted
+interactively or set via `--name` and `--email` flags) and
+preserved across reinstalls and updates. The name and email
+appear in benchmark result metadata.
+
+## The sysconfig file
+
+The installer creates `/etc/sysconfig/crucible` which is
+sourced by every crucible command to set up the environment:
+
+```bash
+CRUCIBLE_USE_CONTAINERS=1
+CRUCIBLE_USE_LOGGER=1
+CRUCIBLE_HOME=/opt/crucible
+```
+
+This file tells crucible where it's installed and enables
+container-based execution and logging. It's sourced by every
+crucible command as the first step of initialization.
+
+## Release installs
+
+To install a specific quarterly release:
+
+```bash
+./crucible-install.sh \
+    --release 2026.1 \
+    --engine-registry <engine-registry-url>
+```
+
+This clones all repos at the release branch and sets their
+checkout mode to `locked`, ensuring the installation stays
+at that exact version.
+
+For interactive release selection:
+
+```bash
+./crucible-install.sh \
+    --release select \
+    --engine-registry <engine-registry-url>
+```
+
+This lists the supported releases (the four most recent) and
+prompts for a choice.
+
+## Switching releases
+
+An existing installation can switch between releases using
+`--set-release`:
+
+```bash
+./crucible-install.sh --set-release 2026.2
+./crucible-install.sh --set-release upstream
+./crucible-install.sh --set-release select
+```
+
+For details on how release switching works, see
+[how-releases-work.md](how-releases-work.md).
+
+## Post-install
+
+After installation:
+
+1. **Verify the install**: Run `crucible help` to see
+   available commands
+2. **Enable tab completion**: Source the completions file or
+   re-login:
+   ```bash
+   source /etc/profile.d/crucible_completions.sh
+   ```
+3. **Run your first benchmark**: Create a run file and
+   execute:
+   ```bash
+   crucible run my-benchmark.json
+   ```
+
+For how to write run files, see
+[how-run-files-work.md](how-run-files-work.md).

--- a/docs/how-the-logger-works.md
+++ b/docs/how-the-logger-works.md
@@ -1,0 +1,203 @@
+# How the Logger Works
+
+This document explains how crucible's logging system captures
+and stores command output for later review.
+
+## Overview
+
+Every crucible command's stdout and stderr is automatically
+captured to a SQLite database. This means you can review the
+output from any past command — even ones that ran days ago —
+without needing to manually redirect to log files.
+
+The logger works transparently: output still appears on the
+terminal in real time, but it's simultaneously recorded with
+timestamps, stream identification (stdout vs stderr), and
+session metadata. Each command invocation gets a unique
+session ID, making it easy to isolate and review specific
+runs.
+
+## How it works
+
+The logger uses a pipe-based architecture with a
+containerized logger process:
+
+### Startup
+
+When you run any crucible command:
+
+1. The `crucible` script generates a unique session ID (UUID)
+2. Creates two named pipes (FIFOs) — one for stdout, one
+   for stderr
+3. Spawns a logger container that reads from both pipes
+4. Redirects the main process's stdout and stderr to the
+   pipes
+5. Runs the actual command (via `_main`)
+
+### During execution
+
+Three threads run inside the logger container:
+
+- **Pipe reader**: Reads lines from both named pipes using
+  non-blocking I/O. Each line is timestamped and placed in
+  a thread-safe queue.
+- **Flusher**: Periodically writes markers to the pipes to
+  ensure timely processing even during quiet periods.
+- **Writer**: Batches lines from the queue, inserts them
+  into the SQLite database in a single transaction, and
+  echoes them back to the terminal.
+
+Output appears on your terminal with no visible delay —
+the pipe adds negligible latency.
+
+### Shutdown
+
+When the command finishes:
+
+1. Close markers are sent through both pipes
+2. The logger drains any remaining buffered output
+3. Final database commit
+4. Logger container exits
+5. Named pipes are cleaned up
+
+## The log database
+
+All log data is stored in a SQLite database at
+`~/.crucible/log.db`.
+
+### What's recorded
+
+For each command invocation:
+
+- **Session**: UUID, timestamp, source ("console"), and
+  the full command string
+- **Lines**: Every line of output with millisecond-precision
+  timestamps and stream identification (stdout or stderr)
+
+### Database structure
+
+```
+sessions table:
+  session_id  │  timestamp  │  source   │  command
+  ────────────┼─────────────┼───────────┼──────────────────────
+  6afd39a8... │  1718012345 │  console  │  crucible run foo.json
+
+lines table:
+  session  │  timestamp     │  stream  │  line
+  ─────────┼────────────────┼──────────┼─────────────────────────
+  1        │  1718012345.12 │  STDOUT  │  Starting benchmark...
+  1        │  1718012345.45 │  STDERR  │  WARNING: low memory
+  1        │  1718012346.78 │  STDOUT  │  Benchmark complete
+```
+
+The millisecond timestamps enable precise ordering of
+interleaved stdout and stderr lines.
+
+## Viewing logs
+
+### View a session's output
+
+```bash
+crucible log view              # most recent session
+crucible log view last         # same as above
+crucible log view first        # oldest session
+crucible log view sessionid <uuid>  # specific session
+```
+
+### Filtering options
+
+```bash
+crucible log view --grep "ERROR"        # lines matching pattern
+crucible log view --stream stderr       # stderr only
+crucible log view --tail 20             # last 20 lines
+crucible log view --head 50             # first 50 lines
+crucible log view --since 1h            # last hour
+crucible log view --since 2d            # last 2 days
+crucible log view --since 2026-06-10    # since specific date
+crucible log view --color               # ANSI colors (stderr in red)
+```
+
+Options can be combined:
+
+```bash
+crucible log view --grep "ERROR" --since 1h --color
+```
+
+### Follow mode
+
+```bash
+crucible log view --follow
+```
+
+Continuously displays new log lines as they're written,
+similar to `tail -f`. Useful for monitoring a long-running
+`crucible run` from another terminal.
+
+### List sessions
+
+```bash
+crucible log sessions
+```
+
+Shows a table of all recorded sessions:
+
+```
+Timestamp                  Session ID      Duration  Command
+2026-06-10 10:45:23.123    6afd39a8...     1m23s     crucible run foo.json
+2026-06-10 11:02:45.456    b3c7e912...     0m02s     crucible repo info
+2026-06-10 11:15:00.789    d4e8f123...     45m12s    crucible run bar.json
+```
+
+### Database info
+
+```bash
+crucible log info
+```
+
+Shows database statistics: file size, total sessions, total
+lines, and date range.
+
+## Log management
+
+The log database grows over time as more commands are
+executed. There is no automatic retention policy.
+
+### Maintenance commands
+
+```bash
+crucible log clear    # delete all sessions and lines
+crucible log tidy     # VACUUM to reclaim disk space
+```
+
+`crucible log clear` removes all data. `crucible log tidy`
+compacts the database file after deletions — SQLite doesn't
+automatically shrink the file when rows are deleted, so
+`tidy` reclaims that space.
+
+### Typical growth
+
+The database grows proportionally to the volume of command
+output. A typical `crucible run` produces thousands of lines;
+simple commands like `crucible repo info` produce a handful.
+Over time, the database may grow to tens or hundreds of
+megabytes. Periodic `crucible log clear` or `crucible log
+tidy` keeps the size manageable.
+
+### Database location
+
+The database lives at `~/.crucible/log.db`, making it
+per-user. Each user on a shared system has their own log
+history.
+
+## Why the logger runs in a container
+
+The logger process runs inside a controller container rather
+than directly on the host. This is consistent with crucible's
+overall pattern: the host system has minimal dependencies
+(just podman and git), and all crucible functionality runs
+inside the controller image where Python, SQLite, and other
+dependencies are guaranteed to be available.
+
+This means logging works identically regardless of the host
+OS or what's installed on it — the controller image provides
+a consistent environment.

--- a/docs/how-the-repo-system-works.md
+++ b/docs/how-the-repo-system-works.md
@@ -296,4 +296,7 @@ crucible repo config update \
 ```
 
 All configuration changes are validated against the
-`schema/repos.json` schema before being saved.
+`schema/repos.json` JSON schema before being saved. The
+schema enforces valid repo types, checkout modes, branch
+names, and URL formats, preventing misconfiguration that
+could break the update or install process.

--- a/docs/how-the-repo-system-works.md
+++ b/docs/how-the-repo-system-works.md
@@ -1,0 +1,299 @@
+# How the Repo System Works
+
+This document explains how crucible manages its multi-repo
+ecosystem — the configuration, cloning, activation, and
+updating of the 40+ repositories that make up the framework.
+
+For how releases interact with the repo system, see
+[how-releases-work.md](how-releases-work.md).
+
+## Overview
+
+Crucible is a multi-repo framework. Rather than a single
+monolithic repository, it's composed of many independently
+versioned repos: the core orchestration components, each
+benchmark, each tool, and supporting projects.
+
+The repo system has three layers:
+
+- **`config/repos.json`** — defines the ecosystem: which repos
+  exist, where to clone them from, and what version to use
+- **`repos/`** — stores the actual git clones, organized by
+  remote URL
+- **`subprojects/`** — activates specific clones via symlinks,
+  organized by category
+
+This separation allows multiple forks of the same repo to
+coexist, switching between sources without re-cloning, and
+mixing upstream and local development versions.
+
+## repos.json
+
+The `config/repos.json` file is the central configuration
+that defines the entire crucible ecosystem.
+
+### Structure
+
+```json
+{
+    "official": [
+        {
+            "name": "rickshaw",
+            "type": "core",
+            "repository": "https://github.com/perftool-incubator/rickshaw",
+            "primary-branch": "master",
+            "checkout": {
+                "mode": "follow",
+                "target": "master"
+            }
+        }
+    ],
+    "unofficial": []
+}
+```
+
+### Official vs unofficial
+
+- **Official repos**: The standard crucible ecosystem —
+  maintained by the project and included in releases. Users
+  should not add repos to this array directly.
+- **Unofficial repos**: User-supplied repos not part of the
+  official upstream. Added via `crucible repo config add` and
+  preserved across updates and release switches.
+
+### Repo types
+
+| Type | Description | Directory |
+|------|-------------|-----------|
+| `primary` | Crucible itself (only one) | — |
+| `core` | Orchestration components (rickshaw, toolbox, roadblock, etc.) | `subprojects/core/` |
+| `benchmark` | Workload generators (fio, uperf, cyclictest, etc.) | `subprojects/benchmarks/` |
+| `tool` | Data collectors (sysstat, procstat, ftrace, etc.) | `subprojects/tools/` |
+| `doc` | Documentation and examples | `subprojects/docs/` |
+
+### Fields
+
+- **name**: Unique identifier used in commands and symlinks
+  (e.g., `rickshaw`, `fio`, `sysstat`)
+- **type**: Category that determines the subprojects directory
+- **repository**: Full git clone URL
+- **primary-branch**: The repo's default branch (`master` or
+  `main`)
+- **checkout**: Controls version pinning:
+  - `mode: "follow"` — track upstream, pull changes on update
+  - `mode: "locked"` — pin to a specific version, don't update
+  - `target` — the branch, tag, or commit to check out
+
+### URL conventions
+
+The committed upstream `repos.json` uses HTTPS URLs, which
+work without SSH keys for end-user installations. Development
+environments typically override these with SSH URLs for easier
+push access. Both URL formats are fully supported — the repo
+system handles URL normalization transparently.
+
+## The repos/ directory
+
+The `repos/` directory stores all git clones, organized by
+remote URL prefix:
+
+```
+repos/
+├── git@github.com:perftool-incubator/
+│   ├── crucible.git/
+│   ├── rickshaw.git/
+│   ├── bench-fio.git/
+│   ├── tool-sysstat.git/
+│   └── ...
+└── https:github.com:perftool-incubator/
+    ├── crucible/
+    ├── rickshaw/
+    └── ...
+```
+
+### URL-based organization
+
+Clones are keyed by their full remote URL, not by repo name.
+The URL is normalized into a directory path: protocol markers
+are stripped, slashes become colons, and the result forms the
+directory name.
+
+### Multiple forks
+
+Because clones are keyed by URL, the same logical repo can
+exist from multiple sources simultaneously:
+
+```
+repos/git@github.com:perftool-incubator/rickshaw.git    (upstream)
+repos/git@github.com:myuser/rickshaw.git                (personal fork)
+```
+
+Only one clone is active at a time (via the symlink in
+`subprojects/`), but both exist on disk. Switching between
+them is a symlink change, not a re-clone.
+
+## The subprojects/ directory
+
+The `subprojects/` directory is where repos become **active**.
+Each active repo has a symlink from its category directory
+pointing to the actual clone in `repos/`:
+
+```
+subprojects/
+├── core/
+│   ├── rickshaw -> ../../repos/git@github.com:perftool-incubator/rickshaw.git
+│   ├── toolbox -> ../../repos/git@github.com:perftool-incubator/toolbox.git
+│   └── ...
+├── benchmarks/
+│   ├── fio -> ../../repos/git@github.com:perftool-incubator/bench-fio.git
+│   ├── uperf -> ../../repos/git@github.com:perftool-incubator/bench-uperf.git
+│   └── ...
+├── tools/
+│   ├── sysstat -> ../../repos/git@github.com:perftool-incubator/tool-sysstat.git
+│   └── ...
+└── docs/
+    ├── examples -> ../../repos/git@github.com:perftool-incubator/crucible-examples.git
+    └── ...
+```
+
+### Relative symlinks
+
+All symlinks use relative paths (`../../repos/...`) so the
+entire tree is portable — it works regardless of where
+crucible is installed.
+
+### Type to directory mapping
+
+Repo types map to directory names with a pluralization
+convention:
+
+- `benchmark` → `benchmarks/`
+- `tool` → `tools/`
+- `doc` → `docs/`
+- `core` → `core/` (unchanged)
+
+### Switching sources
+
+To switch a subproject to a different source (e.g., from
+upstream to a personal fork), update the repository URL:
+
+```bash
+crucible repo config update \
+    name=rickshaw \
+    repository=git@github.com:myuser/rickshaw.git
+```
+
+Then run `crucible update rickshaw` to clone from the new
+source and update the symlink. The old clone remains in
+`repos/` under its original URL path and can be reactivated
+by changing the URL back.
+
+## Installing subprojects
+
+The `subprojects-install` script processes `repos.json` and
+ensures all repos are cloned and symlinked:
+
+1. **Parse repos.json** — reads the official and unofficial
+   arrays
+2. **Clean stale symlinks** — scans `subprojects/` for
+   symlinks that no longer correspond to a repo in the
+   config and removes them. This handles repos that have
+   been removed from `repos.json` or changed type. Only the
+   symlink is removed — the git clone in `repos/` is
+   preserved in case the repo is reactivated later.
+3. **For each repo**:
+   - Parse the repository URL to determine the clone path
+   - Clone if not already present
+   - Check out the specified branch/tag/commit
+   - Create or update the symlink in `subprojects/`
+
+This script runs during initial installation, during
+`crucible update`, and when switching releases.
+
+## Updating repos
+
+### crucible update
+
+The `crucible update` command updates all repos to their
+latest versions:
+
+```bash
+crucible update              # update everything
+crucible update crucible     # update just crucible
+crucible update rickshaw     # update a specific subproject
+```
+
+### The two-pass self-update
+
+Crucible has a unique challenge: the update script itself
+lives in the crucible repo. If the script changes during a
+`git pull`, bash may not handle the mid-execution file change
+correctly.
+
+To solve this, `crucible update` uses a two-pass mechanism:
+
+1. **Pass 1**: Creates a temporary copy of the update script,
+   appends a command to re-execute the real update script, and
+   `exec`s the copy. This ensures bash runs a stable copy
+   while the real script gets updated by git.
+2. **Pass 2**: The freshly-updated real script runs and
+   handles all subproject updates.
+
+### Per-repo update behavior
+
+For each repo, the `_update-git` script:
+
+1. Fetches all changes from the remote
+2. Stashes any local modifications
+3. Checks out the target branch
+4. In **follow mode**: merges upstream changes via
+   `git pull --ff-only`
+5. In **locked mode**: stays at the current commit (fetch
+   only, no checkout of new changes)
+6. Reapplies stashed modifications
+
+### New subproject discovery
+
+After updating all existing repos, `crucible update` runs
+`subprojects-install` to clone and activate any new repos
+that were added to `repos.json` since the last update.
+
+## Managing repos
+
+The `crucible repo` command provides repo management:
+
+### Viewing status
+
+```bash
+crucible repo info            # one-line status per repo
+crucible repo details         # full git status and diffs
+crucible repo config show     # tabular config dump
+```
+
+### Adding repos
+
+```bash
+crucible repo config add \
+    name=myrepo \
+    type=tool \
+    repository=https://github.com/myuser/tool-myrepo \
+    primary-branch=main \
+    checkout-mode=follow \
+    checkout-target=main
+```
+
+This adds the repo to the `unofficial` array in repos.json.
+Run `crucible update myrepo` afterward to clone and activate
+it.
+
+### Modifying repos
+
+```bash
+crucible repo config update \
+    name=myrepo \
+    checkout-mode=locked \
+    checkout-target=v1.0
+```
+
+All configuration changes are validated against the
+`schema/repos.json` schema before being saved.

--- a/docs/how-tool-collection-works.md
+++ b/docs/how-tool-collection-works.md
@@ -33,7 +33,24 @@ stages:
 
 ### 1. Configuration
 
-Tools are configured in the run file's `tool-params` section:
+Crucible includes a default tool set that runs automatically if
+the run file does not specify `tool-params`. The defaults are
+defined in `rickshaw/config/tool-params.json`:
+
+```json
+[
+    { "tool": "sysstat" },
+    { "tool": "procstat" }
+]
+```
+
+This means every run automatically collects CPU, memory, I/O,
+and process metrics via sysstat and procstat unless the user
+overrides or disables them.
+
+Users can customize the tool set by specifying `tool-params` in
+the run file. This replaces the defaults entirely — only the
+tools listed in the run file will run:
 
 ```json
 "tool-params": [
@@ -53,9 +70,13 @@ Tools are configured in the run file's `tool-params` section:
 ]
 ```
 
-Each tool entry specifies the tool name and parameters. Parameters
-become `--key value` arguments passed to the tool's start script.
-Tools can be disabled for a specific run by adding `"enabled": "no"`.
+Each tool entry specifies the tool name and optional parameters.
+Parameters become `--key value` arguments passed to the tool's
+start script. When no parameters are specified (as in the
+defaults), the tool uses its own built-in defaults.
+
+Tools can be disabled for a specific run by adding
+`"enabled": "no"`.
 
 ### 2. Deployment
 

--- a/docs/how-tool-collection-works.md
+++ b/docs/how-tool-collection-works.md
@@ -224,8 +224,10 @@ and kernel trace data.
 ## Tool deployment: where tools run
 
 Tools deploy to specific node types based on their `rickshaw.json`
-collector configuration. Each tool defines a whitelist (where it
-should run) and a blacklist (where it should not run).
+collector configuration, which is validated against
+`rickshaw/schema/tool.json`. Each tool defines a whitelist
+(where it should run) and a blacklist (where it should not
+run).
 
 ### Collector types
 

--- a/docs/how-tool-collection-works.md
+++ b/docs/how-tool-collection-works.md
@@ -1,0 +1,450 @@
+# How Tool Collection Works
+
+This document explains how crucible's tool collection system operates
+— from configuration through data collection, post-processing, and
+querying. It covers the orchestration model, timing relationships,
+data flow, and how the CDM (Common Data Model) system extracts
+relevant subsets of tool data for analysis.
+
+For instructions on creating a new tool, see
+[implementing-a-new-tool.md](implementing-a-new-tool.md).
+
+## Overview
+
+Tools are passive data collectors that run in the background alongside
+benchmarks. While benchmarks actively generate workload, tools observe
+and record system behavior — CPU utilization, interrupt rates, process
+activity, power consumption, and more.
+
+The key design principle: **tools start before any benchmark activity
+and stop after all benchmark iterations complete.** This produces a
+continuous stream of data that spans the entire run. The CDM query
+system then uses benchmark period timestamps to extract the relevant
+subset of tool data for any given measurement window.
+
+This design means tools don't need to know about benchmark timing,
+iterations, or samples. They simply collect continuously, and the
+analysis layer handles the time-based filtering.
+
+## Collection lifecycle
+
+A tool's lifecycle within a crucible run proceeds through these
+stages:
+
+### 1. Configuration
+
+Tools are configured in the run file's `tool-params` section:
+
+```json
+"tool-params": [
+    {
+        "tool": "sysstat",
+        "params": [
+            { "arg": "subtools", "val": "mpstat,sar,iostat,pidstat" },
+            { "arg": "interval", "val": "3" }
+        ]
+    },
+    {
+        "tool": "procstat",
+        "params": [
+            { "arg": "interval", "val": "1" }
+        ]
+    }
+]
+```
+
+Each tool entry specifies the tool name and parameters. Parameters
+become `--key value` arguments passed to the tool's start script.
+Tools can be disabled for a specific run by adding `"enabled": "no"`.
+
+### 2. Deployment
+
+Rickshaw determines which nodes each tool runs on based on the
+tool's `rickshaw.json` whitelist and blacklist configuration (see
+[Tool deployment](#tool-deployment-where-tools-run) below). It then
+generates start and stop command files for each collector type and
+distributes them to the appropriate engine containers.
+
+### 3. Startup
+
+Tool startup is coordinated by roadblock synchronization. The
+sequence within each engine is:
+
+1. **System information collection** (packrat)
+2. **`start-tools-begin` / `start-tools-end`** — all tools launch
+3. **Benchmark iterations begin** — tools are already running
+
+The `start_tools()` function in the engine creates a
+`tool-data/<tool-name>/` directory for each tool, changes into it,
+and executes the tool's start script. The start script typically
+launches one or more background processes and records their PIDs
+for later shutdown.
+
+Tools start **before** any benchmark iteration runs. This ensures
+the first measurement samples are captured even during initial
+benchmark activity.
+
+### 4. Continuous collection
+
+While benchmarks execute their iterations and samples, tools
+continue collecting in the background. The benchmark execution
+loop — which may include multiple iterations, multiple samples per
+iteration, server startup, client execution, and server shutdown —
+runs entirely within the window that tools are active.
+
+### 5. Shutdown
+
+After all benchmark iterations complete:
+
+1. **`stop-tools-begin` / `stop-tools-end`** — all tools shut down
+2. Data archival and transfer
+
+The `stop_tools()` function executes each tool's stop script, which
+typically sends SIGINT to the collection processes, waits for
+graceful shutdown, and compresses output files.
+
+### 6. Data transfer
+
+Each engine archives its entire working directory (benchmark
+outputs, tool data, system info) into a compressed tarball and
+transfers it back to the controller via SSH. The controller extracts
+and reorganizes the data into the result directory structure (see
+[Data flow](#data-flow-and-directory-structure) below).
+
+### 7. Post-processing
+
+The `rickshaw-post-process-tools.py` script iterates over all tool
+data directories. For each collector/engine/tool combination, it
+creates a `postprocess/` subdirectory, then executes the tool's
+post-process script. The post-processor reads raw collection output,
+converts it to CDM-format metrics using the toolbox metrics library,
+and writes the results to `postprocess/`.
+
+### 8. Document generation and indexing
+
+`rickshaw-gen-docs.py` scans tool data directories for
+`metric-data-*.json` files (in `postprocess/` or the directory
+root for older runs). It generates OpenSearch NDJSON documents that
+link each metric to the run's metadata (run ID, iteration, sample,
+collector type, engine ID). These documents are then indexed into
+OpenSearch by the CDM `add-run` process.
+
+## Collection models
+
+Tools use different collection strategies depending on what they
+measure. There are four primary models:
+
+### Periodic sampling
+
+The tool runs a process that outputs data at fixed intervals.
+
+**Example: sysstat** — launches `mpstat`, `sar`, `iostat`, and
+`pidstat` as background processes, each sampling system metrics
+every N seconds (configurable via `--interval`). Each subtool writes
+timestamped records to its own output file until killed by SIGINT.
+
+This model works well for metrics that change gradually (CPU
+utilization, memory usage, I/O throughput) where the sampling
+interval is much shorter than the phenomena being measured.
+
+### Periodic snapshot
+
+The tool periodically reads system state files and records
+snapshots. Delta computation happens during post-processing.
+
+**Example: procstat** — reads files from `/proc` (interrupts,
+vmstat, meminfo, softnet_stat, etc.) at fixed intervals. Each
+read captures a point-in-time snapshot. The post-processor computes
+rates and deltas between consecutive snapshots.
+
+This model is used when the data source provides cumulative counters
+(like `/proc/interrupts`) rather than instantaneous rates.
+
+### Event-driven
+
+The tool captures events as they occur, with no fixed sampling
+interval.
+
+**Example: forkstat** — monitors process fork, exec, and exit
+events via the kernel's process event connector. Events are logged
+with timestamps as they happen, producing variable-density data
+that reflects actual system activity rather than a fixed sampling
+cadence.
+
+This model captures transient events that might be missed by
+periodic sampling.
+
+### Benchmark-controlled tracing
+
+The tool sets up tracing infrastructure but delegates activation
+timing to the benchmark itself. This is used for high-volume
+tracing where continuous collection would produce unmanageable
+data volumes.
+
+**Example: kernel tool (sysfs-trace subtool) + oslat** — the kernel
+tool configures the ftrace subsystem (tracers, events, buffer
+sizes, CPU masks) via sysfs but explicitly leaves tracing disabled
+(`echo 0 > tracing_on`). The oslat benchmark binary, compiled with
+a `--trace-control` patch, calls `tracing_on()` just before its
+measurement loop and `tracing_off()` immediately after. The kernel
+tool's stop script then collects the trace buffer contents.
+
+This cooperative model gives highly focused precision: trace data
+is collected only during the actual measurement window, avoiding
+the massive data volumes that continuous tracing would produce
+during warm-up, cool-down, and between iterations. The benchmark
+controls exactly when the high-resolution capture occurs.
+
+Similarly, `--trace-markers` allows benchmarks to write markers
+into the ftrace buffer at key points (like latency threshold
+violations), enabling precise correlation between benchmark events
+and kernel trace data.
+
+## Tool deployment: where tools run
+
+Tools deploy to specific node types based on their `rickshaw.json`
+collector configuration. Each tool defines a whitelist (where it
+should run) and a blacklist (where it should not run).
+
+### Collector types
+
+| Type | Endpoint | Description |
+|------|----------|-------------|
+| `profiler` | remotehosts, kube | Dedicated profiling node |
+| `compute` | osp | OpenStack compute node |
+| `worker` | kube | Kubernetes worker node |
+| `master` | kube | Kubernetes master node |
+| `client` | remotehosts, kube, osp | Benchmark client engine |
+| `server` | remotehosts, kube, osp | Benchmark server engine |
+
+### Why tools run on profiler nodes
+
+Most tools block `client` and `server` collector types and
+whitelist only `profiler` (and sometimes `compute` for OpenStack).
+This is by design:
+
+- **Resource isolation**: Tool data collection on benchmark engine
+  nodes would compete for CPU, memory, and I/O with the workload
+  under test, distorting both the benchmark results and the tool
+  measurements.
+- **System-level perspective**: Tools like sysstat and procstat
+  measure host-level metrics (CPU utilization across all cores,
+  system-wide interrupt rates). Running them on a dedicated
+  profiler node gives an undistorted view of the system under test.
+- **Separation of concerns**: The profiler node observes the
+  system; the client and server nodes run the workload.
+
+### Multi-instance tools
+
+A tool can be deployed multiple times with different parameters.
+Each instance gets a unique tool ID and runs as a separate
+collector. For example, you might run sysstat with a 1-second
+interval on one profiler and a 10-second interval on another.
+
+## Data flow and directory structure
+
+### On the engine (during collection)
+
+Each tool writes to its own directory within the engine's working
+space:
+
+```
+tool-data/
+├── sysstat/
+│   ├── sysstat-start-stderrout.txt
+│   ├── mpstat.json.xz
+│   ├── sar-stdout.txt.xz
+│   ├── iostat.json.xz
+│   └── pidstat-stdout.txt.xz
+├── procstat/
+│   ├── procstat-start-stderrout.txt
+│   └── procstat-collect-output.txt.xz
+└── forkstat/
+    ├── forkstat-date.txt
+    └── forkstat-stderrout.txt.xz
+```
+
+### Transfer and reorganization
+
+After collection, the engine archives everything and sends it to
+the controller. The controller extracts and reorganizes by
+collector type and engine ID:
+
+```
+run/tool-data/
+├── profiler/
+│   ├── kube-1-sysstat-1/
+│   │   └── sysstat/
+│   │       ├── mpstat.json.xz
+│   │       ├── sar-stdout.txt.xz
+│   │       └── postprocess/
+│   │           ├── metric-data-sar-mem.csv.xz
+│   │           ├── metric-data-sar-mem.json.xz
+│   │           ├── metric-data-mpstat-0.csv.xz
+│   │           ├── metric-data-mpstat-0.json.xz
+│   │           └── post-process-output.txt
+│   ├── kube-1-procstat-1/
+│   │   └── procstat/
+│   │       └── ...
+│   └── kube-1-sysstat-2/
+│       └── sysstat/
+│           └── ...
+└── client/
+    └── 1/
+        └── (typically empty — tools blocked on client nodes)
+```
+
+### Post-processed output
+
+The `postprocess/` subdirectory inside each tool directory contains
+the CDM-format metric files produced by the tool's post-processor.
+On re-processing, the orchestrator deletes and recreates this
+directory, providing clean artifact isolation without
+filename-dependent cleanup.
+
+## The relationship between tool data and benchmark periods
+
+This is the most important conceptual piece for understanding how
+tool data is used in analysis.
+
+### Tools collect continuously; benchmarks define time windows
+
+Tools run for the entire duration of the benchmark execution and
+produce a continuous stream of timestamped data. They have no
+concept of iterations, samples, or measurement periods.
+
+Benchmarks, on the other hand, define **periods** — named time
+windows like "measurement" with explicit begin and end timestamps.
+These periods are determined during post-processing from the actual
+benchmark output data.
+
+### CDM queries bridge the gap
+
+When you query the CDM for tool metrics during a specific benchmark
+period, the system:
+
+1. Looks up the period document to get its `begin` and `end`
+   timestamps
+2. **Removes the period from the metric query** — tool metrics are
+   not attributed to any period in the database
+3. Uses the period's timestamps as a time range filter on the tool
+   metric data
+4. Returns only the tool data points that fall within that time
+   window
+
+This means asking for "sysstat CPU utilization during the
+measurement period" is really asking: "give me sysstat CPU data
+between timestamp X and timestamp Y, where X and Y are the
+measurement period's boundaries."
+
+### Partial overlap handling
+
+When a tool data point spans a period boundary (its begin-to-end
+range partially overlaps the period), the CDM query system
+interpolates the value proportionally based on how much of the data
+point falls within the period.
+
+### Custom time ranges
+
+Because tool data exists as a continuous time series independent of
+benchmark periods, you are not limited to querying by iteration,
+sample, or period boundaries. If you know the timestamps you care
+about, you can query tool data for any arbitrary time range —
+including ranges that span multiple samples, cover the entire run,
+or focus on a specific event you identified in the data.
+
+For example, if you noticed a CPU utilization spike at a particular
+timestamp in the sysstat data, you could query a narrow window
+around that spike regardless of which benchmark period it fell in.
+Or you could query the entire tool collection window to see system
+behavior from before the first iteration through after the last,
+including any activity during benchmark startup and teardown.
+
+The iteration/sample/period segmentation is a convenience for the
+common case — correlating tool observations with benchmark results.
+But the underlying data is a flat time series, and custom timestamp
+queries give you full access to it.
+
+### Exception: benchmark-controlled collection
+
+The "collect continuously, filter later" model has one notable
+exception. For high-volume tracing tools (like the kernel tool's
+sysfs-trace subtool), continuous collection would produce
+unmanageable data volumes. Instead, the tool sets up the collection
+infrastructure in advance but leaves it inactive. The benchmark
+binary itself activates collection only during its measurement
+window. In this model, the tool data inherently covers only the
+measurement period because the benchmark controlled when collection
+was active.
+
+## Tool parameters
+
+Parameters flow from the run file to the tool start script through
+this path:
+
+1. **Run file**: User specifies `tool-params` with `arg`/`val`
+   pairs
+2. **rickshaw-run.py**: Builds a Bash command with a declared
+   `ARGS` array:
+   ```bash
+   declare -a ARGS=('--interval' '3' '--subtools' 'mpstat,sar')
+   && sysstat-start "${ARGS[@]}"
+   ```
+3. **Serialization**: Commands are written to compressed JSON files
+   (`tool-cmds/<collector-type>/start.json.xz`) in the run config
+   directory
+4. **Engine execution**: The engine deserializes the JSON and
+   evaluates the command string
+
+This indirection allows the controller to build tool commands once
+and distribute them to multiple engines, with each engine's start
+script receiving the same parameters.
+
+## Result directory structure
+
+The complete result directory for a run with tool data:
+
+```
+<run-dir>/
+├── config/
+│   ├── tool-cmds/
+│   │   ├── profiler/
+│   │   │   ├── start.json.xz    # tool start commands
+│   │   │   └── stop.json.xz     # tool stop commands
+│   │   ├── client/1/
+│   │   │   ├── start.json.xz
+│   │   │   └── stop.json.xz
+│   │   └── server/1/
+│   │       ├── start.json.xz
+│   │       └── stop.json.xz
+│   └── rickshaw-run.json         # full run configuration
+├── run/
+│   ├── iterations/
+│   │   └── iteration-1/
+│   │       └── sample-1/
+│   │           ├── client/1/     # benchmark output
+│   │           └── server/1/     # benchmark output
+│   ├── tool-data/
+│   │   └── profiler/
+│   │       ├── kube-1-sysstat-1/
+│   │       │   └── sysstat/
+│   │       │       ├── mpstat.json.xz        # raw collection
+│   │       │       ├── sar-stdout.txt.xz     # raw collection
+│   │       │       └── postprocess/          # CDM metrics
+│   │       │           ├── metric-data-*.csv.xz
+│   │       │           └── metric-data-*.json.xz
+│   │       └── kube-1-procstat-1/
+│   │           └── procstat/
+│   │               ├── interrupts.xz         # raw snapshots
+│   │               └── postprocess/
+│   │                   └── metric-data-*.json.xz
+│   └── opensearch/
+│       └── *-docs.ndjson         # indexed CDM documents
+└── crucible.log.xz              # run log
+```
+
+The `tool-data/` subtree is organized by collector type, then
+engine ID, then tool name. Each tool directory contains both the
+raw collection output and the `postprocess/` subdirectory with
+CDM-format metrics. The `opensearch/` directory contains the
+generated NDJSON documents ready for indexing.


### PR DESCRIPTION
## Summary

Add 16 new documentation files covering how each crucible subsystem operates, plus an architecture overview as the entry point. Update CLAUDE.md and README.md to reference all guides.

### New docs
- **Architecture overview** — high-level component map and data flow
- **Benchmark execution** — parameter expansion, synchronized execution, periods, results
- **Tool collection** — collection models, deployment, continuous data and period filtering
- **Engines** — bootstrap, execution phases, CPU partitioning, data archival
- **Endpoints** — remotehosts (podman/chroot), kube, osp deployment targets
- **Image sourcing** — multi-stage builds, content-based tagging, multi-arch
- **Roadblock** — distributed synchronization, barrier protocol, messaging, wait-for
- **CDM** — document hierarchy, metric model, query system, web dashboard
- **Services** — valkey, opensearch, httpd, CDM server, image-sourcing management
- **Controller image** — what it contains, build pipeline, provenance
- **Repo system** — repos.json, clone/symlink architecture, updating
- **Releases** — quarterly releases, follow/locked mode, set-release
- **CI** — workflow hierarchy, capability matching, release matrix testing
- **Logger** — pipe-based output capture, SQLite storage, viewing commands
- **Installer** — prerequisites, install flow, registry config, release installs
- **Run files** — run file structure, benchmarks, parameters, endpoints, tools, tags

### Updated docs
- Schema references added across all guides
- Cross-references between related guides
- CLAUDE.md and README.md documentation index
- CLAUDE.md: added documentation maintenance instruction requiring docs/ updates with code changes
- Registry URLs genericized across all docs (no hardcoded registry references)

## Jira
[PERFNFV-317](https://redhat.atlassian.net/browse/PERFNFV-317)

## Test plan
- [ ] Verify all docs render correctly on GitHub
- [ ] Verify all cross-references resolve (no broken links)
- [ ] Verify CI treats this as docs-only (faux CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)