### PR TITLE
docs: add endpoint guide and developer guide to doc indexes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Follow existing code style conventions exactly — check surrounding code for pa
 - **JSON processing**: Use `jq_query()` helper from `bin/base`; validate configs against schemas in `schema/`
 - **Variable naming**: Lowercase with underscores for locals; uppercase for exported/environment variables (e.g., `CRUCIBLE_HOME`, `CRUCIBLE_CONTROLLER_IMAGE`)
 - **CLI parameters**: When adding a new CLI parameter, option, or subcommand, update all three locations: `bin/_help` (main help output), `bin/_crucible_completions` (bash tab completions), and the relevant command's own help text
+- **Comments**: Write comments that explain the intent behind the code — why a decision was made, what constraint is being satisfied, or what behavior would surprise a future reader. Focus on the WHY rather than restating WHAT the code does.
 
 ## Language Strategy
 - **New code**: Write new functionality in Python 3 by default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ When creating new benchmarks or tools, consult these before writing any code:
 
 - **`docs/implementing-a-new-benchmark.md`** — Required files, rickshaw.json schema, client-server messaging, post-processing, multiplex.json, and reference implementations.
 - **`docs/implementing-a-new-tool.md`** — Required files, collector whitelist/blacklist, tool parameters, and reference implementations.
+- **`docs/implementing-a-new-endpoint.md`** — Directory structure, validation protocol, base module, engine deployment, roadblock integration, and reference implementations.
+- **`docs/developer-guide.md`** — Development environment, repository structure, testing, cross-repo coordination, PR workflow, code conventions, and debugging.
 
 These guides define the required file structure, naming conventions, JSON schemas, script patterns, and integration points. Follow them rather than inferring structure from existing code alone.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Through the use of containers built at runtime for software distribution (which 
 
 - [Implementing a New Benchmark](docs/implementing-a-new-benchmark.md)
 - [Implementing a New Tool](docs/implementing-a-new-tool.md)
+- [Implementing a New Endpoint](docs/implementing-a-new-endpoint.md)
+- [Developer Guide](docs/developer-guide.md)
 
 ## Subprojects
 

--- a/docs/crucible-architecture-overview.md
+++ b/docs/crucible-architecture-overview.md
@@ -215,3 +215,5 @@ before they cause runtime failures.
 | How command output is captured | [How the logger works](how-the-logger-works.md) |
 | How to write a new benchmark | [Implementing a new benchmark](implementing-a-new-benchmark.md) |
 | How to write a new tool | [Implementing a new tool](implementing-a-new-tool.md) |
+| How to write a new endpoint | [Implementing a new endpoint](implementing-a-new-endpoint.md) |
+| Development workflow | [Developer guide](developer-guide.md) |

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,428 @@
+# Developer Guide
+
+This guide covers the crucible development workflow — setting
+up a development environment, working on subprojects, testing
+changes, coordinating cross-repo work, and submitting PRs.
+
+For the architecture and how each subsystem operates, see the
+[architecture overview](crucible-architecture-overview.md) and
+the subsystem guides it references.
+
+## Development environment setup
+
+### Prerequisites
+
+The host needs only three tools:
+
+- **podman** — container runtime
+- **git** — for cloning and updating repositories
+- **jq** — for JSON manipulation
+
+All other dependencies (Python packages, Perl modules, build
+tools) live inside the controller container image.
+
+### Installing for development
+
+Install crucible in upstream/follow mode (the default):
+
+```bash
+./crucible-install.sh \
+    --engine-registry <engine-registry-url> \
+    --name "Your Name" \
+    --email "you@example.com"
+```
+
+This installs all repos in `follow` mode, tracking their
+default branches. Running `crucible update` pulls the latest
+changes.
+
+### The controller container
+
+Most crucible software runs inside the controller container.
+Two commands give you access:
+
+- **`crucible wrapper <command>`** — runs a single command
+  inside the controller and returns. Use this for scripts that
+  need controller dependencies (Python packages, Perl modules,
+  workshop scripts).
+- **`crucible console`** — opens an interactive shell inside
+  the controller. Useful for debugging, running multiple
+  commands, or exploring installed software. Man pages are
+  available for all installed tools.
+
+### Developer tooling
+
+Crucible includes a Claude Code plugin for development
+workflows. Register it after installation:
+
+```bash
+claude plugin marketplace add \
+    ${CRUCIBLE_HOME}/subprojects/core/crucible-dev-tools
+```
+
+Available skills:
+
+- `/crucible-tools:repo-status` — git status across all repos
+- `/crucible-tools:open-prs` — open PRs in the org
+- `/crucible-tools:dev-activity` — development activity charts
+- `/crucible-tools:weekly-summary` — weekly activity report
+- `ci-analyzer` agent — diagnose CI failures
+
+## Repository structure
+
+### The clone/symlink model
+
+Crucible uses a two-directory model:
+
+- **`repos/`** — git clones, organized by remote URL. The same
+  repo can exist from multiple sources (upstream, fork A, fork
+  B).
+- **`subprojects/`** — symlinks to the active clone of each
+  repo, organized by category:
+  - `subprojects/core/` — rickshaw, toolbox, roadblock,
+    workshop, CommonDataModel, multiplex, packrat, crucible-ci
+  - `subprojects/benchmarks/` — fio, uperf, iperf, etc.
+  - `subprojects/tools/` — sysstat, procstat, ftrace, etc.
+  - `subprojects/docs/` — examples, testing
+
+For example:
+
+```
+subprojects/core/rickshaw ->
+    ../../repos/git@github.com:perftool-incubator/rickshaw.git
+```
+
+### repos.json
+
+`config/repos.json` defines all subproject repositories with
+two categories:
+
+- **official** — maintained by the crucible project, included
+  in releases
+- **unofficial** — user-added repos extending crucible with
+  custom benchmarks, tools, or other subprojects
+
+Each entry specifies:
+
+```json
+{
+    "name": "rickshaw",
+    "type": "core",
+    "repository": "https://github.com/perftool-incubator/rickshaw.git",
+    "primary-branch": "main",
+    "checkout": {
+        "mode": "follow",
+        "target": "main"
+    }
+}
+```
+
+The committed `repos.json` uses HTTPS URLs (for end users).
+Developers typically override locally with SSH URLs for push
+access — these local changes should never be committed.
+
+### subprojects-install
+
+Running `subprojects-install` (called during install and
+update) clones any repos that aren't present, checks out the
+configured branch/tag/commit, and creates or updates symlinks
+in `subprojects/`. It also cleans up symlinks for repos that
+have been removed from `repos.json`.
+
+### Working directory
+
+Run Claude Code from `/opt/crucible` for most work — all
+subproject code is accessible through symlinks, and cross-repo
+changes have full visibility. Only work from a subproject root
+(e.g., `subprojects/core/rickshaw/`) for deep isolated work on
+that specific component.
+
+## Working on subprojects
+
+Each subproject is its own git repo with independent history,
+branches, and commits. Running `git status` or `git diff` from
+`/opt/crucible` only shows changes to the crucible repo itself.
+
+To work on a subproject:
+
+```bash
+cd subprojects/core/rickshaw
+git checkout -b my-feature-branch
+# edit, test, commit
+```
+
+Check status across all repos:
+
+```bash
+crucible repo info      # one-line status per repo
+crucible repo details   # full git status and diffs
+```
+
+New repos use `main` as their primary branch. Some older repos
+still use `master` — this is a legacy configuration. Check the
+repo's `repos.json` entry if unsure.
+
+## Switching sources and forks
+
+To work from a different fork or source:
+
+```bash
+crucible repo config update \
+    name=rickshaw \
+    repository=git@github.com:myuser/rickshaw.git
+crucible update rickshaw
+```
+
+This clones the new source into `repos/` and repoints the
+symlink. Multiple clones of the same repo from different
+forks can coexist — only one is active at a time.
+
+To switch back to upstream:
+
+```bash
+crucible repo config update \
+    name=rickshaw \
+    repository=https://github.com/perftool-incubator/rickshaw.git
+crucible update rickshaw
+```
+
+## Testing changes
+
+### Unit tests
+
+Individual repos have their own test suites:
+
+- **Python repos** (multiplex, source-images-service): `pytest`
+- **Bash repos** (roadblock): `test/run-test.sh`
+- **Crucible installer**: `./tests/test-installer`
+
+### Container-side testing
+
+Scripts that run inside the controller container (workshop
+scripts, Python packages only available in the container) must
+be tested with:
+
+```bash
+crucible wrapper <command>
+```
+
+Running them directly on the host will fail due to missing
+dependencies.
+
+### Service testing
+
+When modifying the source-images-service, stop all services
+first so the service picks up your code changes:
+
+```bash
+crucible stop valkey opensearch image-sourcing httpd
+```
+
+Then start them again or run a benchmark to exercise the
+changes.
+
+### Integration testing
+
+The most thorough test is running a benchmark:
+
+```bash
+crucible run my-run-file.json
+```
+
+This exercises the full pipeline: image sourcing, engine
+deployment, benchmark execution, tool collection,
+post-processing, and result indexing.
+
+### CI testing
+
+Run the full CI suite locally:
+
+```bash
+crucible run-ci
+```
+
+This executes the same test matrix that runs on PRs, including
+benchmark scenarios across endpoints and userenvs. It requires
+a runner environment with the necessary infrastructure.
+
+## Cross-repo changes
+
+Changes that span multiple repos require coordination:
+
+1. **Identify affected repos** — consult the docs index and
+   key integration points:
+   - `toolbox` changes ripple across all benchmarks, tools, and
+     core components
+   - `rickshaw.json` changes in benchmarks/tools affect how
+     they integrate with the orchestrator
+   - `workshop.json` changes affect container image builds
+   - Schema changes in `rickshaw/schema/` affect run file
+     validation
+
+2. **Create feature branches** in each affected repo
+
+3. **Test locally** — run a benchmark that exercises the
+   changed code paths
+
+4. **Submit separate PRs** for each repo — CI tests each PR
+   independently against upstream
+
+5. **Merge in dependency order** — shared libraries first
+   (toolbox), then consuming repos. If a benchmark PR depends
+   on a rickshaw change, merge the rickshaw PR first.
+
+6. **Controller image rebuilds** — when a contributing repo
+   (crucible, rickshaw, workshop, toolbox, roadblock,
+   CommonDataModel, multiplex) merges changes that affect the
+   controller image, a rebuild is triggered automatically.
+
+## Pull request workflow
+
+- Always create a feature branch — never push directly to
+  the default branch
+- Submit PRs from branches on the **upstream repository**, not
+  from forks. Fork PRs are automatically closed because CI
+  workflows need access to org secrets and variables.
+- Request review from the **Developers** team and self-assign
+- Use conventional commit messages: `feat:`, `fix:`, `docs:`,
+  `refactor:`, etc.
+- One commit per independent change — only group changes
+  together when they depend on each other
+- CI runs automatically on every PR: installer tests and
+  integration tests
+- Docs-only changes trigger faux CI (lightweight pass without
+  running benchmarks)
+- Branch rulesets require 1 approving review and all review
+  threads resolved before merge
+
+## Code conventions
+
+### Languages
+
+- **New code**: Python 3 by default
+- **Host-side scripts** (in `bin/`): Bash, to minimize host OS
+  dependencies
+- **Extending existing files**: use that file's language
+
+### Style
+
+- **Bash**: 4-space indentation, tabs expanded to spaces.
+  Include vim and emacs modelines:
+  ```
+  # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+  # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+  ```
+- **Python**: PEP 8, 4-space indentation
+- **JSON keys**: `kebab-case`
+- **CLI arguments**: `--kebab-case`
+
+### Naming
+
+- Lowercase with underscores for local variables
+- Uppercase for exported/environment variables (`CRUCIBLE_HOME`,
+  `TOOLBOX_HOME`)
+
+### CLI changes
+
+When adding a new CLI parameter, option, or subcommand, update
+all three locations:
+
+1. `bin/_help` — main help output
+2. `bin/_crucible_completions` — bash tab completions
+3. The relevant command's own help text
+
+### Documentation
+
+- When making structural changes to a subproject, update that
+  subproject's CLAUDE.md in the same PR
+- When changes affect user-facing behavior, configuration,
+  architecture, or workflows, check whether the `docs/` guides
+  need corresponding updates — treat stale docs as a bug
+
+### Comments
+
+Write comments that explain the intent behind the code —
+why a decision was made, what constraint is being satisfied,
+or what behavior would surprise a future reader. Focus on
+the WHY rather than restating WHAT the code does.
+
+## Releases
+
+Crucible produces quarterly releases named `YYYY.Q` (e.g.,
+`2026.2` for Q2 2026). Release branches are created
+automatically on the first day of each quarter across all
+repos.
+
+### For developers
+
+- Most development happens on upstream (follow mode) —
+  releases are automatic snapshots
+- The 4 most recent releases are supported
+- `crucible update` in follow mode pulls the latest upstream
+  changes
+- Use `--set-release <version>` to test against a specific
+  release, `--set-release upstream` to return to development
+
+### Controller image
+
+The controller image is shared across all releases. Changes to
+any of the 7 contributing repos (crucible, rickshaw, workshop,
+toolbox, roadblock, CommonDataModel, multiplex) trigger an
+automatic rebuild. A controller update brings new capabilities
+to every release.
+
+For details on the release system, see
+[how-releases-work.md](how-releases-work.md).
+
+## Key integration points
+
+| Component | What it affects | How |
+|-----------|----------------|-----|
+| toolbox (`TOOLBOX_HOME`) | Everything | Shared Python and Bash libraries |
+| `rickshaw.json` | Benchmarks and tools | Declares integration with the orchestrator |
+| `workshop.json` | Container images | Declares build requirements |
+| JSON schemas (`rickshaw/schema/`) | Run file validation | Define valid configurations |
+| Controller image | All operations | Contains all orchestration software |
+
+Changes to these components have wide blast radius. Test
+thoroughly and consider CI impact.
+
+## Debugging
+
+### Run logs
+
+```bash
+crucible log view last     # most recent run
+crucible log view list     # browse available logs
+```
+
+### Engine logs
+
+Engine stdout/stderr is archived in the run directory:
+
+```
+/var/lib/crucible/run/<run-id>/
+```
+
+### Interactive debugging
+
+```bash
+crucible console           # shell inside the controller
+```
+
+This gives you access to all controller software (Python
+packages, Perl modules, tools) with full man page
+documentation.
+
+### Run file validation
+
+If a run file fails validation, check it against the schema:
+
+```bash
+crucible wrapper python3 -c "
+from toolbox.json import load_json_file, validate_schema
+data, _ = load_json_file('my-run-file.json')
+valid, err = validate_schema(data, '/opt/crucible/subprojects/core/rickshaw/schema/run-file.json')
+print('Valid' if valid else f'Error: {err}')
+"
+```

--- a/docs/implementing-a-new-endpoint.md
+++ b/docs/implementing-a-new-endpoint.md
@@ -1,0 +1,616 @@
+# Implementing a New Endpoint
+
+This guide explains how to implement a new endpoint type for
+crucible. Endpoints are the deployment abstraction layer that
+handles engine deployment, image management, service discovery,
+and cleanup across different infrastructure targets.
+
+For how endpoints operate at runtime, see
+[how-endpoints-work.md](how-endpoints-work.md).
+For how engines run inside endpoints, see
+[how-engines-work.md](how-engines-work.md).
+For how roadblock synchronization works, see
+[how-roadblock-works.md](how-roadblock-works.md).
+
+## When you need a new endpoint
+
+You need a new endpoint when you want to deploy benchmark and
+tool engines on an infrastructure type that isn't supported by
+the existing endpoints:
+
+- **remotehosts** — remote Linux hosts via SSH (podman or
+  chroot)
+- **kube** — Kubernetes clusters
+- **osp** — OpenStack environments
+
+Examples of infrastructure that would require a new endpoint:
+cloud VMs on a specific provider (AWS, GCP, Azure), bare-metal
+provisioning systems (Ironic), or specialized HPC schedulers
+(Slurm).
+
+## Directory structure
+
+Each endpoint type lives in its own directory under
+`rickshaw/endpoints/`:
+
+```
+endpoints/
+├── endpoints.py              # Base module (shared by all)
+├── myendpoint/
+│   ├── myendpoint.py         # Main implementation
+│   └── myendpoint            # Symlink: myendpoint -> myendpoint.py
+```
+
+The symlink is required — rickshaw invokes the endpoint by
+running `./myendpoint` from the endpoint directory.
+
+Additionally, create a JSON schema for validating endpoint
+configuration in run files:
+
+```
+rickshaw/schema/myendpoint.json
+```
+
+### Optional marker files
+
+Place these files in the endpoint directory to signal status:
+
+- **`deprecated`** — contains a deprecation message shown to
+  users. Indicates the endpoint will be removed in a future
+  release.
+- **`experimental`** — contains a warning message shown to
+  users. Indicates the endpoint is not yet stable.
+
+## How rickshaw discovers and invokes endpoints
+
+### Discovery
+
+Rickshaw uses directory-based discovery — no registration is
+needed. If `endpoints/myendpoint/` exists with an executable
+named `myendpoint`, rickshaw can use it. The endpoint type name
+in the run file must match the directory name exactly.
+
+### Invocation
+
+Endpoints are invoked as **subprocesses**, not imported as
+Python modules. Rickshaw calls the endpoint executable with
+command-line arguments in two modes:
+
+**Validation mode** (`--validate`):
+
+```bash
+./myendpoint \
+    --endpoint-label=myendpoint-1 \
+    --base-run-dir=/var/lib/crucible/run/latest \
+    --rickshaw-dir=/opt/crucible/subprojects/core/rickshaw \
+    --run-file=/path/to/run.json \
+    --endpoint-index=0 \
+    --crucible-dir=/opt/crucible \
+    --log-level=normal \
+    --validate \
+    --<endpoint-specific-opts>
+```
+
+**Deployment mode** (no `--validate`):
+
+```bash
+./myendpoint \
+    --rickshaw-dir=... \
+    --packrat-dir=... \
+    --endpoint-label=myendpoint-1 \
+    --run-id=<uuid> \
+    --base-run-dir=... \
+    --max-sample-failures=1 \
+    --endpoint-deploy-timeout=<seconds> \
+    --engine-script-start-timeout=<seconds> \
+    --image=<image-specs> \
+    --roadblock-id=<uuid> \
+    --roadblock-passwd=<password> \
+    --crucible-dir=... \
+    --log-level=normal \
+    --run-file=/path/to/run.json \
+    --endpoint-index=0
+```
+
+### Two integration paths
+
+Rickshaw currently has two integration paths for endpoints
+(visible in `rickshaw-run.py`):
+
+1. **Run-file native endpoints** (remotehosts, kube): Receive
+   `--run-file` and `--endpoint-index` so they can read the
+   run file directly and extract their own configuration.
+   Also receive `--crucible-dir` and `--log-level`. Use the
+   `endpoints.py` base module for settings management and
+   roadblock integration.
+
+2. **Legacy bash endpoints** (osp): Receive options as a single
+   `--endpoint-opts=<serialized-string>` argument. Use the
+   legacy `base` bash script.
+
+New endpoints should follow the Python path.
+
+## The validation protocol
+
+When invoked with `--validate`, the endpoint must verify
+connectivity, detect capabilities, and report them to stdout
+using specific keywords that `rickshaw-run.py` parses:
+
+### Required output keywords
+
+| Keyword | Format | Purpose |
+|---------|--------|---------|
+| `arch` | `arch x86_64 [aarch64...]` | CPU architectures available |
+| `userenv` | `userenv rhubi9` (one per line) | User environments available |
+| `engine-types` | `engine-types client server profiler` | Supported engine roles |
+| `client` | `client 1 2 3` | Client engine IDs |
+| `server` | `server 4 5 6` | Server engine IDs |
+| `profiler` | `profiler <id>...` | Profiler engine IDs (if applicable) |
+
+### Output conventions
+
+- Lines starting with `#` are treated as comments (ignored by
+  the parser)
+- Lines starting with `ERROR:` signal validation failures
+- All other non-empty lines must use a recognized keyword or
+  rickshaw will abort with an error
+- Use the helper functions from `endpoints.py`:
+  - `endpoints.validate_log(msg)` — output a keyword line
+  - `endpoints.validate_comment(msg)` — output a comment
+  - `endpoints.validate_error(msg)` — output an error
+
+### What validation should check
+
+1. **Schema validation** — validate the endpoint section of the
+   run file against `schema/myendpoint.json`
+2. **Connectivity** — verify the endpoint can reach its
+   infrastructure (SSH, API access, etc.)
+3. **Architecture detection** — detect CPU architecture(s)
+   available on the target infrastructure
+4. **Capability detection** — verify required software or
+   services are available (e.g., podman, kubectl)
+5. **Engine enumeration** — report what engine roles and IDs
+   this endpoint will provide
+
+### Example validation output
+
+```
+# environment: {'HOME': '/root', ...}
+# endpoint-settings: {'type': 'myendpoint', ...}
+engine-types client server profiler
+client 1 2
+server 3 4
+userenv rhubi9
+arch x86_64
+```
+
+## The base module (`endpoints.py`)
+
+The `endpoints.py` module provides extensive shared
+functionality. New endpoints should use these functions rather
+than reimplementing them.
+
+### Key function groups
+
+**Entry point and settings:**
+
+| Function | Purpose |
+|----------|---------|
+| `process_options()` | Parse standard CLI arguments via argparse; returns args namespace |
+| `load_settings(settings, ...)` | Load run file, rickshaw settings, and endpoint config; calls your normalizer callback |
+| `init_settings(settings, args)` | Initialize basic settings from CLI args |
+| `log_settings(settings, ...)` | Log settings for debugging |
+| `create_local_dirs(settings)` | Create local run/log/roadblock directories |
+
+**Remote execution:**
+
+| Function | Purpose |
+|----------|---------|
+| `remote_connection(host, user)` | Create SSH connection via Fabric with retry logic |
+| `run_remote(connection, command)` | Execute command on remote host via SSH |
+| `run_local(command)` | Execute command locally |
+
+**Roadblock synchronization:**
+
+| Function | Purpose |
+|----------|---------|
+| `process_pre_deploy_roadblock(...)` | Execute pre-deployment synchronization |
+| `process_roadblocks(callbacks, ...)` | Main roadblock loop — manages all test phases |
+| `process_bench_roadblocks(...)` | Handle per-iteration/sample roadblocks |
+| `do_roadblock(...)` | Execute a single roadblock checkpoint |
+| `create_roadblock_msg(...)` | Construct a roadblock message |
+| `evaluate_roadblock(...)` | Evaluate roadblock result and handle abort/timeout |
+
+**Image and engine lookups:**
+
+| Function | Purpose |
+|----------|---------|
+| `get_image(settings, ...)` | Retrieve container image URL for a benchmark/tool |
+| `get_engine_id_image(settings, ...)` | Get image for a specific engine by role and ID |
+| `get_benchmark(settings, id)` | Look up benchmark name from engine ID |
+| `build_benchmark_engine_mapping(...)` | Build mapping of benchmarks to engine IDs |
+| `expand_ids(ids)` | Expand ID range strings to lists |
+
+**Validation output:**
+
+| Function | Purpose |
+|----------|---------|
+| `validate_log(msg)` | Print a keyword line (parsed by rickshaw-run.py) |
+| `validate_comment(msg)` | Print a comment line (prefixed with #) |
+| `validate_error(msg)` | Print an error line (prefixed with ERROR:) |
+
+**Network utilities:**
+
+| Function | Purpose |
+|----------|---------|
+| `get_controller_ip(host)` | Determine controller IP reachable from a remote host |
+| `is_ip(address)` | Validate an IPv4 or IPv6 address |
+
+### The main pipeline
+
+Every Python endpoint follows this pipeline in `main()`:
+
+```python
+def main():
+    args = endpoints.process_options()
+    endpoints.setup_logger(args.log_level)
+
+    if args.validate:
+        return validate()
+
+    endpoints.init_settings(settings, args)
+    endpoints.load_settings(
+        settings,
+        endpoint_name="myendpoint",
+        endpoint_normalizer_callback=normalize_endpoint_settings
+    )
+    endpoints.create_local_dirs(settings)
+
+    # Endpoint-specific deployment
+    check_requirements()
+    pull_images()
+    launch_engines()
+
+    # Pre-deployment synchronization
+    endpoints.process_pre_deploy_roadblock(...)
+
+    # Main test loop with callbacks
+    callbacks = {
+        "engine-init": engine_init,
+        "collect-sysinfo": collect_sysinfo,
+        "test-start": test_start,
+        "test-stop": test_stop,
+        "remote-cleanup": remote_cleanup
+    }
+    return endpoints.process_roadblocks(
+        callbacks=callbacks, ...
+    )
+```
+
+## Settings normalization
+
+Each endpoint must provide a `normalize_endpoint_settings()`
+function that is passed as a callback to
+`endpoints.load_settings()`. This function:
+
+1. Merges endpoint-level default settings with per-host or
+   per-config overrides
+2. Expands engine ID ranges (e.g., `"1-5"` → `[1,2,3,4,5]`)
+   using `endpoints.expand_ids()`
+3. Resolves the controller IP address using
+   `endpoints.get_controller_ip()`
+4. Builds the internal data structures the endpoint needs for
+   deployment
+
+```python
+def normalize_endpoint_settings(endpoint, rickshaw):
+    # Apply defaults
+    for key, default in endpoint_defaults.items():
+        endpoint.setdefault(key, default)
+
+    # Expand ID ranges
+    for remote in endpoint["remotes"]:
+        for engine in remote["engines"]:
+            if "ids" in engine:
+                engine["ids"] = endpoints.expand_ids(engine["ids"])
+
+    # Resolve controller IP
+    for remote in endpoint["remotes"]:
+        host = remote["config"]["host"]
+        remote["config"]["settings"].setdefault(
+            "controller-ip-address",
+            endpoints.get_controller_ip(host)
+        )
+```
+
+## Engine deployment
+
+### Creating engines
+
+How you create engines depends on your infrastructure. The
+existing endpoints demonstrate three approaches:
+
+- **remotehosts/podman**: SSH to host, `podman create` + `podman
+  start` with the engine container image
+- **remotehosts/chroot**: SSH to host, `podman create` (without
+  starting), mount the container filesystem, `chroot` into it
+- **kube**: Generate Kubernetes Job CRDs, apply them with
+  `kubectl create`
+
+Regardless of method, each engine must:
+
+1. Run the bootstrap script (`/usr/local/bin/bootstrap`) which
+   is embedded in every engine container image
+2. Have access to a shared data directory for inter-engine
+   communication
+3. Be able to reach the controller's Valkey instance for
+   roadblock synchronization
+4. Receive its configuration (engine name, role, run ID,
+   controller IP, etc.)
+
+### Configuration delivery
+
+Engines receive configuration through different mechanisms
+depending on the runtime:
+
+- **Environment variables** (podman, kube): Written to an env
+  file, passed via `--env-file` or pod spec
+- **CLI arguments** (chroot): Passed directly to the bootstrap
+  script
+- **Command files** (all): Workload-specific parameters written
+  to the shared data directory
+
+### Thread pool pattern
+
+Both remotehosts and kube use thread pools for parallel
+deployment across multiple hosts or nodes. If your endpoint
+manages multiple targets, follow this pattern using Python's
+`threading` module with a work queue.
+
+### Engine persistence
+
+Engines are created once during the deployment phase and persist
+for the entire run. They execute all iterations and samples
+sequentially. This avoids the overhead of creating and
+destroying engines for each sample.
+
+## Image management
+
+### Image format
+
+Container images are passed to endpoints via the `--image` CLI
+argument using a structured format:
+
+```
+benchmark::role::userenv::arch::image_url[::auth_file]
+```
+
+The `role` field is `all` for standard benchmarks or
+`client`/`server` for benchmarks with separate images per role.
+
+### Pulling images
+
+Your endpoint must pull the required images onto its
+infrastructure before launching engines. Use the helper
+functions:
+
+- `endpoints.get_engine_id_image(settings, role, id, userenv,
+  arch)` — get the image URL for a specific engine
+- `endpoints.get_image(settings, image_role, engine_role,
+  userenv, arch)` — get an image by role and userenv
+
+### Authentication
+
+When an image requires authentication, the auth file path is
+appended as a 6th `::` field in the image string. Your endpoint
+must:
+
+1. Copy the auth file to the remote infrastructure (or create
+   the equivalent, e.g., a Kubernetes ImagePullSecret)
+2. Use the credentials during image pull
+3. Clean up the credentials after pulling
+
+## Roadblock integration
+
+Endpoints participate as roadblock followers in the distributed
+synchronization system. The base module handles most of the
+complexity, but your endpoint must provide callbacks for key
+lifecycle events.
+
+### Pre-deployment
+
+Before deploying engines, call
+`endpoints.process_pre_deploy_roadblock()` to synchronize with
+rickshaw-run and other endpoints. This is where endpoints can
+exchange deployment metadata (e.g., additional follower IDs for
+auto-provisioned profiler engines).
+
+### The main roadblock loop
+
+Call `endpoints.process_roadblocks()` with a callbacks dict.
+This function manages the entire test execution lifecycle,
+calling your callbacks at the appropriate phases:
+
+```python
+callbacks = {
+    "engine-init": engine_init,
+    "collect-sysinfo": collect_sysinfo,
+    "test-start": test_start,
+    "test-stop": test_stop,
+    "remote-cleanup": remote_cleanup
+}
+```
+
+### Required callbacks
+
+| Callback | When called | What to do |
+|----------|-------------|------------|
+| `engine-init` | After engines are running | Register engines as roadblock followers, send metadata (endpoint label, userenv, host info) |
+| `collect-sysinfo` | During system info collection | Gather infrastructure metadata (host info, platform details) |
+| `test-start` | Before each benchmark iteration | Set up networking (services, firewall rules) for client-server communication |
+| `test-stop` | After each benchmark iteration | Tear down per-iteration networking |
+| `remote-cleanup` | After all tests complete | Collect logs, destroy engines, clean up resources |
+
+### Registering new followers
+
+If your endpoint auto-provisions profiler engines (for tool
+collection), add them to `settings["engines"]["new-followers"]`
+before the roadblock loop. This tells roadblock to wait for
+these additional participants.
+
+## Service discovery
+
+Client-server benchmarks need clients to discover where servers
+are running. The mechanism depends on your endpoint's networking
+model:
+
+- **Direct IP** (remotehosts): Server publishes its host IP and
+  ports via roadblock messaging. Client reads the message and
+  connects directly.
+- **Service abstraction** (kube): Server publishes pod IP via
+  roadblock. Endpoint creates a networking abstraction (K8s
+  Service) and sends the service IP to the client via a
+  follow-up roadblock message.
+
+Implement service discovery in your `test_start` callback by
+reading server-start-end messages from the roadblock messages
+directory and creating any necessary networking resources.
+
+## Cleanup
+
+Your `remote-cleanup` callback must:
+
+1. **Collect engine logs** — retrieve stdout/stderr from each
+   engine, compress, and store locally
+2. **Destroy engines** — stop and remove containers, pods, VMs,
+   or whatever your endpoint created
+3. **Clean up networking** — remove services, firewall rules,
+   or other networking resources
+4. **Clean up authentication** — remove auth files or secrets
+5. **Manage image cache** — optionally prune old images to
+   conserve disk space
+
+## Schema definition
+
+Create `schema/myendpoint.json` to validate your endpoint's
+run file configuration. Follow the pattern from existing
+schemas:
+
+```json
+{
+    "title": "My Endpoint Schema",
+    "description": "This schema defines the user interface to
+        the myendpoint endpoint.",
+    "type": "object",
+    "properties": {
+        "type": {
+            "description": "The endpoint type identifier.",
+            "type": "string",
+            "enum": [ "myendpoint" ]
+        },
+        ...
+    },
+    "required": [ "type", ... ],
+    "additionalProperties": false
+}
+```
+
+Include `description` fields on every property. Reuse the
+`number-lists` definition from existing schemas if your
+endpoint uses engine ID specifications.
+
+Validation in your endpoint code:
+
+```python
+from toolbox.json import load_json_file, validate_schema
+
+valid, err = validate_schema(
+    endpoint_settings,
+    args.rickshaw_dir + "/schema/myendpoint.json"
+)
+if not valid:
+    endpoints.validate_error(err)
+    return 1
+```
+
+## CI integration
+
+CI integration requires a runner pool that can provide the
+infrastructure your endpoint needs. For example, the kube
+endpoint requires a runner with a Kubernetes cluster, and
+the remotehosts endpoint requires a runner with SSH-accessible
+hosts.
+
+If no suitable test environment is available, CI testing can
+be deferred — not all endpoints can be CI-tested. The osp
+endpoint, for instance, has no CI coverage because no runner
+pool provides an OpenStack environment.
+
+When a suitable environment exists, add your endpoint to the
+CI configuration:
+
+1. Define the endpoint in `crucible-ci.json` with its
+   `enabled` state and capability `requirements`
+2. Ensure a runner pool exists that `provides` those
+   capabilities
+3. Add benchmark scenarios that use your endpoint
+
+See [how-ci-works.md](how-ci-works.md) for details on the
+CI system.
+
+## Reference implementations
+
+### remotehosts (recommended starting point)
+
+`rickshaw/endpoints/remotehosts/remotehosts.py` (~2500 lines)
+
+The remotehosts endpoint is the simpler of the two Python
+endpoints. It demonstrates:
+
+- SSH-based remote execution via Fabric
+- Dual runtime modes (podman and chroot)
+- Thread pool deployment across multiple hosts
+- Image pulling and cache management
+- CPU partitioning
+- Host mount configuration
+
+### kube (complex reference)
+
+`rickshaw/endpoints/kube/kube.py` (~3400 lines)
+
+The kube endpoint demonstrates more advanced patterns:
+
+- Kubernetes API interaction via kubectl
+- Pod/Job CRD generation and management
+- Namespace lifecycle management with ownership labels
+- K8s Service creation for client-server networking
+- ImagePullSecret management
+- Architecture detection from K8s node API
+- Multi-container pods (engine grouping)
+
+### osp (legacy, not recommended)
+
+`rickshaw/endpoints/osp/osp` (~700 lines, bash)
+
+The osp endpoint uses the older bash integration path. It is
+not recommended as a template for new endpoints — use the
+Python pattern instead.
+
+## Checklist
+
+- [ ] Create `endpoints/myendpoint/` directory
+- [ ] Write `myendpoint.py` with `validate()` and `main()`
+- [ ] Create symlink `myendpoint -> myendpoint.py`
+- [ ] Create `schema/myendpoint.json` with description fields
+- [ ] Implement validation: connectivity, arch detection,
+      schema validation, engine enumeration
+- [ ] Implement settings normalization callback
+- [ ] Implement engine deployment (create + start)
+- [ ] Implement image pulling with auth support
+- [ ] Implement roadblock callbacks (engine-init,
+      collect-sysinfo, test-start, test-stop, remote-cleanup)
+- [ ] Implement service discovery in test-start callback
+- [ ] Implement cleanup: log collection, engine teardown,
+      resource cleanup
+- [ ] Test with a simple benchmark (e.g., `sleep`)
+- [ ] Add CI integration if a suitable test environment exists


### PR DESCRIPTION
## Summary
- Reference `docs/implementing-a-new-endpoint.md` and `docs/developer-guide.md` in CLAUDE.md, README.md, and the architecture overview doc index

Follow-up to PR #604 which added the docs but missed updating the indexes.

## Test plan
- [ ] Verify cross-references resolve
- [ ] CI passes (docs-only, faux CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)