### PR TITLE
Wait for CDM server to be online before proceeding

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -571,7 +571,28 @@ function start_cdm_server() {
         if [ ${RC} != 0 ]; then
             echo "ERROR: Could not start CDM server"
         else
-            echo "Successfully started CDM server on port ${cdm_server_port}"
+            local cdm_available=0
+            local cdm_count=1
+            local cdm_timeout=120
+            local cdm_status_cmd="curl --silent --show-error --stderr - -X GET localhost:${cdm_server_port}/health"
+            echo "Waiting for CDM server to be available (${cdm_timeout} seconds maximum)..."
+            while [ ${cdm_available} != 1 -a ${cdm_count} -lt ${cdm_timeout} ]; do
+                local pod_name=crucible-cdm-server-status-check-${SESSION_ID}-$(uuidgen)
+                local status_check=$(${podman_run} --name ${pod_name} "${container_common_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${cdm_status_cmd})
+                if echo "${status_check}" | grep -q '"status":"OK"'; then
+                    echo "CDM server is online after ${cdm_count} seconds"
+                    cdm_available=1
+                else
+                    sleep 1
+                fi
+                (( cdm_count += 1 ))
+            done
+            if [ ${cdm_available} -eq 0 ]; then
+                echo "ERROR: CDM server failed to become available within ${cdm_timeout} seconds"
+                RC=1
+            else
+                echo "Successfully started CDM server on port ${cdm_server_port}"
+            fi
         fi
     fi
     return ${RC}


### PR DESCRIPTION
## Summary
- CDM server container starts detached (`-d`), so `start-server.sh` runs `npm ci` and starts Express asynchronously
- Without a readiness check, crucible proceeds immediately to `add-run.sh` which fails because `node_modules` aren't installed yet
- This caused concurrent `npm install` races (ENOTEMPTY) and missing module errors during OpenSearch indexing
- Add a wait loop matching the existing OpenSearch pattern: poll `/health` endpoint with 120s timeout

## Context
Root cause of indexing failures across multiple agentic-perf tickets (PERF-D095E672, PERF-7140E67D, PERF-EBA8D9C8). The `start-server.sh` container and the `add-run.sh` container share the same bind-mounted `node_modules` via `CRUCIBLE_HOME`. Two concurrent `npm install` processes on the same directory caused overlay fs `rmdir` failures and missing packages.

## Test plan
- [ ] `crucible run` with fio — verify CDM server wait message appears in log, add-run succeeds
- [ ] `crucible start opensearch` — verify wait loop completes and server is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)