### PR TITLE
docs: update image specification and remove Perl examples

### DIFF
--- a/docs/how-benchmark-execution-works.md
+++ b/docs/how-benchmark-execution-works.md
@@ -193,8 +193,9 @@ requirements (like trafficgen) can use separate
 `client-workshop.json` and `server-workshop.json` files instead
 of a single `workshop.json`. This produces different container
 images for each role, reducing image size and allowing different
-base images (userenvs) per role. The `--image` format includes
-a role field (`bench::role::userenv::arch::image`) so each engine
+base images (userenvs) per role.  The image-map JSON file
+passed to endpoints includes a role key in its hierarchy
+(`bench → role → userenv → arch → image`) so each engine
 gets the correct image for its role.
 
 ### Userenvs

--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -144,24 +144,51 @@ containers or pods for each sample.
 
 ## Image management
 
-### The image format
+### The image map
 
-Container images are passed to endpoints using a structured
-format:
+Container images are passed to endpoints via a structured JSON
+file (`image-map.json`) using the `--image-map=<filepath>` CLI
+argument.  The file maps benchmark and tool names to their
+container image URLs, organized by engine role, userenv, and
+CPU architecture:
 
-```
-benchmark::role::userenv::arch::image_url[::auth_file]
+```json
+{
+    "uperf": {
+        "all": {
+            "rhubi9": {
+                "x86_64": {
+                    "image": "<registry>/<repo>:abc123_x86_64"
+                }
+            }
+        }
+    },
+    "trafficgen": {
+        "client": {
+            "alma8": {
+                "x86_64": {
+                    "image": "<registry>/<repo>:def456_x86_64"
+                }
+            }
+        }
+    },
+    "sysstat": {
+        "all": {
+            "fedora-latest": {
+                "x86_64": {
+                    "image": "<registry>/<repo>:ghi789_x86_64",
+                    "auth-file": "/path/to/pull-token.json"
+                }
+            }
+        }
+    }
+}
 ```
 
-Examples:
-```
-uperf::all::rhubi9::x86_64::<registry>/<repo>:abc123_x86_64
-trafficgen::client::alma8::x86_64::<registry>/<repo>:def456_x86_64
-sysstat::all::fedora-latest::x86_64::<registry>/<repo>:ghi789_x86_64
-```
-
-The `role` field is `all` for standard benchmarks or
+The role key is `all` for standard benchmarks or
 `client`/`server` for benchmarks with split workshop files.
+The optional `auth-file` field provides a path to a
+Docker/Podman auth JSON file for private registries.
 
 ### Image pulling
 

--- a/docs/implementing-a-new-benchmark.md
+++ b/docs/implementing-a-new-benchmark.md
@@ -512,7 +512,6 @@ Perl.
 
 Post-process scripts use the toolbox metrics library:
 
-**Python:**
 ```python
 import sys, os, json, math
 from pathlib import Path
@@ -521,12 +520,6 @@ TOOLBOX_HOME = os.environ.get('TOOLBOX_HOME')
 p = Path(TOOLBOX_HOME) / 'python'
 sys.path.append(str(p))
 from toolbox.metrics import log_sample, finish_samples
-```
-
-**Perl:**
-```perl
-use lib "$ENV{'TOOLBOX_HOME'}/perl";
-use toolbox::metrics;
 ```
 
 ### Key functions

--- a/docs/implementing-a-new-endpoint.md
+++ b/docs/implementing-a-new-endpoint.md
@@ -103,7 +103,7 @@ command-line arguments in two modes:
     --max-sample-failures=1 \
     --endpoint-deploy-timeout=<seconds> \
     --engine-script-start-timeout=<seconds> \
-    --image=<image-specs> \
+    --image-map=<path-to-image-map.json> \
     --roadblock-id=<uuid> \
     --roadblock-passwd=<password> \
     --crucible-dir=... \
@@ -225,8 +225,8 @@ than reimplementing them.
 
 | Function | Purpose |
 |----------|---------|
-| `get_image(settings, ...)` | Retrieve container image URL for a benchmark/tool |
-| `get_engine_id_image(settings, ...)` | Get image for a specific engine by role and ID |
+| `get_image(settings, ...)` | Retrieve image info dict for a benchmark/tool |
+| `get_engine_id_image(settings, ...)` | Get image info dict for a specific engine by role and ID |
 | `get_benchmark(settings, id)` | Look up benchmark name from engine ID |
 | `build_benchmark_engine_mapping(...)` | Build mapping of benchmarks to engine IDs |
 | `expand_ids(ids)` | Expand ID range strings to lists |
@@ -376,34 +376,34 @@ destroying engines for each sample.
 
 ## Image management
 
-### Image format
+### Image map
 
-Container images are passed to endpoints via the `--image` CLI
-argument using a structured format:
-
-```
-benchmark::role::userenv::arch::image_url[::auth_file]
-```
-
-The `role` field is `all` for standard benchmarks or
-`client`/`server` for benchmarks with separate images per role.
+Container images are passed to endpoints via the
+`--image-map=<filepath>` CLI argument, pointing to a JSON file
+(schema: `schema/image-map.json`) that maps benchmark and tool
+names to container image URLs organized by role, userenv, and
+architecture.
 
 ### Pulling images
 
 Your endpoint must pull the required images onto its
-infrastructure before launching engines. Use the helper
+infrastructure before launching engines.  Use the helper
 functions:
 
 - `endpoints.get_engine_id_image(settings, role, id, userenv,
-  arch)` — get the image URL for a specific engine
+  arch)` — get the image info for a specific engine
 - `endpoints.get_image(settings, image_role, engine_role,
-  userenv, arch)` — get an image by role and userenv
+  userenv, arch)` — get image info by role and userenv
+
+Both return a dict with an `image` key (the container image
+URL) and an optional `auth-file` key (path to auth
+credentials), or None if no matching image is found.
 
 ### Authentication
 
-When an image requires authentication, the auth file path is
-appended as a 6th `::` field in the image string. Your endpoint
-must:
+When an image requires authentication, the image info dict
+contains an `auth-file` key with the path to a Docker/Podman
+auth JSON file.  Your endpoint must:
 
 1. Copy the auth file to the remote infrastructure (or create
    the equivalent, e.g., a Kubernetes ImagePullSecret)

--- a/docs/implementing-a-new-tool.md
+++ b/docs/implementing-a-new-tool.md
@@ -312,7 +312,6 @@ scripts can be written in Python (preferred for new tools) or Perl.
 
 Post-process scripts use the toolbox metrics library:
 
-**Python:**
 ```python
 import sys, os, json
 from pathlib import Path
@@ -321,12 +320,6 @@ TOOLBOX_HOME = os.environ.get('TOOLBOX_HOME')
 p = Path(TOOLBOX_HOME) / 'python'
 sys.path.append(str(p))
 from toolbox.metrics import log_sample, finish_samples
-```
-
-**Perl:**
-```perl
-use lib "$ENV{'TOOLBOX_HOME'}/perl";
-use toolbox::metrics;
 ```
 
 ### Key functions


### PR DESCRIPTION
## Summary
- Update docs to reflect the replacement of the packed `::` delimited image format string with structured JSON (`image-map.json`) passed via `--image-map`
- Update accessor function descriptions to document the new dict return type
- Remove Perl `toolbox::metrics` examples from implementation guides — all current benchmarks and tools use Python post-processors

Companion to perftool-incubator/rickshaw#829

## Test plan
- [ ] Verify all cross-references resolve
- [ ] Confirm no remaining references to the old `::` image format in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)