### PR TITLE
fix: silence systemctl stdout during update

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -67,8 +67,8 @@ fi
 
 case "${repo}" in
     "all"|"crucible"|"controller-image")
-        if systemctl is-enabled crucible-image-sourcing 2>/dev/null &&
-           systemctl is-active crucible-image-sourcing 2>/dev/null; then
+        if systemctl is-enabled crucible-image-sourcing &>/dev/null &&
+           systemctl is-active crucible-image-sourcing &>/dev/null; then
             echo "Stopping crucible-image-sourcing systemd service for update..."
             systemctl stop crucible-image-sourcing
             touch /tmp/.crucible-restart-image-sourcing


### PR DESCRIPTION
## Summary
- On systemd 238+, `systemctl is-enabled` prints the unit state (e.g., "not-found") to stdout when a unit doesn't exist
- The existing `2>/dev/null` only silenced stderr, so the "not-found" string leaked into `crucible update` output
- Switch to `&>/dev/null` to silence both streams

## Test plan
- [ ] Run `crucible update` on a system without the `crucible-image-sourcing` systemd unit — verify no "not-found" output

🤖 Generated with [Claude Code](https://claude.com/claude-code)