### PR TITLE
docs: document per-ID param scoping and CDM metric breakouts

### DIFF
--- a/docs/how-cdm-works.md
+++ b/docs/how-cdm-works.md
@@ -204,19 +204,99 @@ within that time window.
 
 ### Breakout dimensions
 
-Metrics can be broken down by their dimension values. For
+Metrics can be broken down by their dimension values.  For
 example, `Busy-CPU` from mpstat has dimensions like
-`hostname` and `cpu`. Querying with `breakouts: ["hostname"]`
-returns separate time series per host. Adding `"cpu"` splits
+`hostname` and `cpu`.  Querying with `breakouts: ["hostname"]`
+returns separate time series per host.  Adding `"cpu"` splits
 further by individual CPU.
 
-The query API supports:
+#### Response format
 
-- **Expanding**: Add a breakout dimension to see more detail
-- **Filtering**: Limit to specific dimension values (exact
-  match, regex, or multiple values)
-- **Collapsing**: Remove a breakout to aggregate across that
-  dimension
+The metric-data API response includes three fields that
+describe breakout state:
+
+```json
+{
+    "values": {
+        "": [{ "begin": 1648111546729, "end": 1648111635267, "value": 45.2 }]
+    },
+    "usedBreakouts": [],
+    "remainingBreakouts": ["hostname", "cpu", "type"]
+}
+```
+
+- **`values`** — metric data keyed by breakout labels.
+  Without breakouts, the key is an empty string (aggregated
+  across all dimensions).  With breakouts, each key encodes
+  the dimension values in angle brackets:
+  `"<host1>-<0>"`, `"<host1>-<1>"`, `"<host2>-<0>"`.
+- **`usedBreakouts`** — dimensions currently applied to
+  produce the value keys.
+- **`remainingBreakouts`** — dimensions still available for
+  further disaggregation.  These are the dimensions you can
+  add to the `breakouts` array to split the data further.
+
+With breakouts applied:
+
+```json
+{
+    "values": {
+        "<host1>-<0>": [{ "begin": 1648111546729, "end": 1648111635267, "value": 78.5 }],
+        "<host1>-<1>": [{ "begin": 1648111546729, "end": 1648111635267, "value": 65.2 }],
+        "<host2>-<0>": [{ "begin": 1648111546729, "end": 1648111635267, "value": 82.1 }]
+    },
+    "usedBreakouts": ["hostname", "cpu"],
+    "remainingBreakouts": ["type"]
+}
+```
+
+#### Breakout query syntax
+
+The `breakouts` array supports three forms:
+
+- **Basic**: `["hostname", "cpu"]` — split by all values
+  of each dimension
+- **Value-filtered**: `["hostname=host1+host2"]` — return
+  separate series only for the specified values
+- **Regex**: `["hostname=r/^worker-.*/"]` — return series
+  for values matching the pattern
+
+#### Available dimensions
+
+The dimensions available for breakout depend on the metric
+source.  Each metric's `metric_desc` document in OpenSearch
+records which dimensions are present.  Common dimensions
+include:
+
+| Dimension | Description |
+|-----------|-------------|
+| `hostname` | Host where the metric was collected |
+| `cpu` | CPU number |
+| `csid` | Client-server ID — identifies which engine pair produced the metric |
+| `cstype` | Client-server type (e.g., `client`, `server`, `profiler`) |
+| `engine-id` | Numeric engine ID |
+| `type` | Sub-metric type (e.g., CPU mode for mpstat: `usr`, `sys`, `irq`) |
+| `dev` | Device name (for storage or network metrics) |
+| `cmd` | Process command name |
+
+The `remainingBreakouts` field in the API response is the
+authoritative source for what dimensions are available on a
+given metric.
+
+#### Per-pair analysis
+
+Runs with multiple parallel engine pairs (`"ids": "1+2"`)
+produce combined metric values by default.  To separate
+results per pair, add a breakout on `csid` or `engine-id`.
+
+Note that benchmark metrics and tool metrics use different
+`csid` label formats.  Benchmark `csid` values are numeric
+(e.g., `1`, `2`), while tool `csid` values include the
+endpoint and tool name (e.g., `remotehosts-1-sysstat-1`).
+Use the `remainingBreakouts` response to discover which
+dimensions are available, then query breakout values with
+`POST /api/v1/iterations/breakout-values` to see the actual
+values before filtering.
 
 ## The web dashboard
 

--- a/docs/how-run-files-work.md
+++ b/docs/how-run-files-work.md
@@ -139,8 +139,57 @@ all multi-valued parameters to produce the iteration matrix.
 | `val` | Yes* | Single value (alternative to `vals`) |
 | `role` | No | Restrict to a specific role: `"client"`, `"server"`, or `"all"` (default) |
 | `enabled` | No | `"yes"` (default) or `"no"` — disabled params are excluded |
+| `id` | No | Restrict this parameter to a single engine ID.  When set, only the engine whose ID matches receives this parameter.  Without `id`, the parameter applies to all engines of the specified role. |
+| `ids` | No | Array of engine ID ranges (e.g., `["1", "2-4"]`) that this parameter applies to.  Alternative to `id` for targeting multiple engines. |
 
 *One of `vals` or `val` is required.
+
+### Per-engine parameter scoping
+
+When running multiple client-server pairs in parallel, each
+engine may need different parameter values.  For example, in a
+two-pair run comparing RHEL 9 vs RHEL 10, each client must
+connect to its own paired server — not to all servers.
+
+Without per-engine scoping, a `remotehost` parameter applies
+to all clients, causing every client to connect to every
+server.  The `id` field solves this by restricting a parameter
+to the engine whose ID matches:
+
+```json
+"mv-params": {
+    "sets": [{
+        "params": [
+            { "arg": "test-type", "vals": ["stream"], "role": "client" },
+            { "arg": "protocol", "vals": ["tcp"], "role": "client" },
+            { "arg": "duration", "vals": ["60"], "role": "client" },
+            { "arg": "wsize", "vals": ["256", "1024"], "role": "client" },
+            { "arg": "nthreads", "vals": ["1", "4"], "role": "client" },
+            { "arg": "remotehost", "vals": ["10.0.0.2"], "role": "client", "id": "1" },
+            { "arg": "remotehost", "vals": ["10.0.0.4"], "role": "client", "id": "2" }
+        ]
+    }]
+}
+```
+
+Here, client 1 connects to 10.0.0.2 (its paired server) and
+client 2 connects to 10.0.0.4.  All other parameters
+(test-type, protocol, etc.) apply to both clients since they
+have no `id` field.
+
+The `id` value is a string matching the engine IDs assigned
+in the endpoint's `engines` array.  Two parameters with the
+same `arg` and `role` but different `id` values are treated
+as distinct — they coexist rather than overriding each other.
+
+The `ids` field accepts an array of ID ranges for targeting
+multiple engines:
+
+```json
+{ "arg": "bs", "vals": ["64"], "ids": ["1", "3-5"] }
+```
+
+This applies to engines 1, 3, 4, and 5.
 
 ### How parameters become iterations
 


### PR DESCRIPTION
## Summary
- **Per-ID param scoping** (closes #610): Document the `id` and `ids` fields on mv-params entries in `docs/how-run-files-work.md`.  Adds fields to the parameter table and a new "Per-engine parameter scoping" subsection with a multi-pair example showing per-client remotehost targeting. [PERFNFV-324](https://redhat.atlassian.net/browse/PERFNFV-324)
- **CDM metric breakouts** (closes #611): Expand the breakout dimensions section in `docs/how-cdm-works.md` with response format (`values`, `usedBreakouts`, `remainingBreakouts`), label encoding, query syntax (basic, value-filtered, regex), available dimensions table, and per-pair analysis guidance. [PERFNFV-326](https://redhat.atlassian.net/browse/PERFNFV-326)

## Test plan
- [ ] Review per-ID scoping example against multiplex schema and test fixtures
- [ ] Review breakout documentation against CDM server API behavior
- [ ] Verify JSON examples are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)