### PR TITLE
docs: update service discovery and messaging for targeted delivery

### DIFF
--- a/docs/how-benchmark-execution-works.md
+++ b/docs/how-benchmark-execution-works.md
@@ -279,36 +279,42 @@ roadblock synchronization.
 
 ### How it works
 
-1. During **server-start**, the server script writes a JSON
-   message to `msgs/tx/svc` containing its IP and port(s):
+1. During **server-start**, the server script writes a raw
+   payload to `msgs/tx/svc`:
    ```json
-   {
-       "recipient": {"type": "all", "id": "all"},
-       "user-object": {
-           "svc": {"ip": "10.244.1.5", "ports": [30000]}
-       }
-   }
+   {"svc": {"ip": "10.244.1.5", "ports": [30002, 30003]}}
    ```
 
-2. During the roadblock synchronization between server-start-end
-   and client-start-begin, messages are collected and delivered
-   to all participants.
+   The benchmark does not specify recipients or use roadblock
+   addressing. The engine infrastructure handles delivery.
 
-3. **Endpoints may modify the service information.** On
+2. The **engine-script-library** detects the raw payload (no
+   `recipient` key) and automatically wraps it in two targeted
+   roadblock messages: one to the server's endpoint and one
+   directly to the paired client.
+
+3. At the **server-start-end** barrier, both messages are
+   delivered via roadblock. The endpoint receives its copy;
+   the client receives its copy. Each follower's message log
+   only contains messages targeted to it.
+
+4. **Endpoints may modify the service information.** On
    Kubernetes, the endpoint creates a Service resource and
    replaces the pod IP with the Service ClusterIP, NodePort
-   address, or LoadBalancer VIP. This is written as an
-   `endpoint-start-end` message.
+   address, or LoadBalancer VIP. The endpoint sends a
+   targeted message to the client with the transformed address.
 
-4. During **client-start**, the client reads service information
-   from `msgs/rx/`, preferring `endpoint-start-end` messages
-   (which have endpoint-transformed addresses) over
-   `server-start-end` messages (which have raw pod IPs).
+5. After **endpoint-start-end**, the engine-script-library
+   resolves the best message — preferring endpoint-relayed
+   (potentially transformed) over server-direct — and writes
+   it to `msgs/rx/svc`.
 
-This indirection allows the same benchmark code to work across
-different endpoint types without modification — the client always
-reads from `msgs/rx/` and gets the appropriate address for its
-deployment context.
+6. During **client-start**, the client reads `msgs/rx/svc`
+   for the resolved service information.
+
+Benchmarks never deal with roadblock addressing or endpoint
+details. The engine infrastructure handles message targeting,
+delivery, and resolution transparently.
 
 ## Controller scripts
 

--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -232,8 +232,10 @@ system. The client reads the message and connects directly.
 Kubernetes networking requires additional abstraction because
 pod IPs are internal to the cluster:
 
-1. During **server-start**, the server pod publishes its pod IP
-   and ports via `msgs/tx/svc`
+1. During **server-start**, the server pod writes its pod IP
+   and ports as a raw payload to `msgs/tx/svc`. The engine
+   infrastructure wraps it in targeted messages to the
+   endpoint and the paired client.
 2. During **endpoint-start**, the kube endpoint creates a
    Kubernetes Service (ClusterIP, NodePort, or LoadBalancer)
    that routes to the server pod

--- a/docs/how-roadblock-works.md
+++ b/docs/how-roadblock-works.md
@@ -138,8 +138,8 @@ between them.
 ```json
 {
     "recipient": {
-        "type": "all",
-        "id": "all"
+        "type": "follower",
+        "id": "client-1"
     },
     "user-object": {
         "svc": {
@@ -150,9 +150,28 @@ between them.
 }
 ```
 
-Messages specify a recipient (leader, follower, or all) and
-carry a JSON payload. The payload is application-defined —
-roadblock delivers it without interpreting it.
+Messages specify a recipient and carry a JSON payload. The
+payload is application-defined — roadblock delivers it
+without interpreting it.
+
+### Message addressing
+
+The `recipient` field controls delivery:
+
+- **Broadcast**: `{"type": "all", "id": "all"}` — delivered
+  to all participants via the global Redis stream
+- **Targeted**: `{"type": "follower", "id": "<follower-id>"}`
+  — delivered only to the named follower via its personal
+  Redis stream. Only that follower sees the message in its
+  message log.
+
+Targeted messaging avoids unnecessary traffic and processing.
+The engine-script-library automatically wraps benchmark
+service payloads in targeted messages to the server's endpoint
+(for potential address transformation) and the paired client
+(as a direct fallback). Broadcast is used only when all
+participants genuinely need the message (e.g., error abort,
+timeout adjustment).
 
 ### Common use cases
 

--- a/docs/implementing-a-new-benchmark.md
+++ b/docs/implementing-a-new-benchmark.md
@@ -409,9 +409,10 @@ Starts the server process, publishes service information, and exits:
    ```bash
    let "port = 2 * $id + 30000"
    ```
-5. Publish service info for clients via messaging:
+5. Publish service info as a raw payload — the engine
+   infrastructure handles delivery:
    ```bash
-   echo '{"recipient":{"type":"all","id":"all"},"user-object":{"svc":{"ip":"'$ip'","ports":['$port']}}}' >msgs/tx/svc
+   echo '{"svc":{"ip":"'$ip'","ports":['$port']}}' >msgs/tx/svc
    ```
 6. Start the server in the background:
    ```bash
@@ -453,49 +454,51 @@ instead they write and read JSON files in `msgs/` directories.
 
 ### How it works
 
-1. **Server writes** a JSON message to `msgs/tx/svc` containing its
-   IP and port(s) during the server-start phase.
-2. **Roadblock** collects messages from `msgs/tx/` and delivers them
-   to other participants during synchronization.
-3. **Endpoints** (Kubernetes, remote hosts) may modify the service
-   information (e.g., creating a LoadBalancer or NodePort) and write
-   an adjusted message.
-4. **Client reads** service information from `msgs/rx/` before
-   connecting to the server.
+1. **Server writes** a raw JSON payload to `msgs/tx/svc`
+   during the server-start phase. No roadblock addressing
+   or recipient information is needed.
+2. **Engine infrastructure** wraps the payload in targeted
+   roadblock messages and delivers them to the endpoint and
+   paired client.
+3. **Endpoints** (Kubernetes, remote hosts) may modify the
+   service information (e.g., creating a LoadBalancer or
+   NodePort) and send a targeted message to the client with
+   the adjusted address.
+4. **Engine infrastructure** resolves the best message
+   (preferring endpoint-relayed over server-direct) and
+   writes it to `msgs/rx/svc`.
+5. **Client reads** `msgs/rx/svc` before connecting to the
+   server.
 
 ### Message format
 
+The server writes a plain payload (no roadblock wrapping):
+
 ```json
 {
-    "recipient": { "type": "all", "id": "all" },
-    "user-object": {
-        "svc": {
-            "ip": "192.168.1.100",
-            "ports": [30000, 30001]
-        }
+    "svc": {
+        "ip": "192.168.1.100",
+        "ports": [30000, 30001]
     }
 }
 ```
 
 ### Reading messages on the client side
 
-The client should check for messages in this order of preference:
+The engine infrastructure resolves the best message and writes
+it to `msgs/rx/svc`. The client reads from this single file:
 
 ```bash
-file="msgs/rx/endpoint-start-end:1"
-if [ ! -e "${file}" ]; then
-    file="msgs/rx/server-start-end:1"
-fi
+file="msgs/rx/svc"
 if [ -e "$file" ]; then
     remotehost=$(jq -r '.svc.ip' $file)
     port=$(jq -r '.svc.ports[0]' $file)
 fi
 ```
 
-The `endpoint-start-end` message takes priority because the endpoint
-may have transformed the server's IP/port (e.g., through a Kubernetes
-Service). The `server-start-end` message is the fallback when no
-endpoint transformation occurred.
+The engine automatically prefers endpoint-relayed messages
+(which may have transformed addresses) over direct server
+messages.
 
 ---
 
@@ -776,7 +779,7 @@ Once your benchmark repository is ready:
 - [ ] `multiplex.json` with parameter defaults and validations (recommended)
 - [ ] `<name>-base` script sourcing toolbox bench-base (recommended)
 - [ ] For client-server: `<name>-server-start` and `<name>-server-stop`
-- [ ] For client-server: messaging via `msgs/tx/svc` and `msgs/rx/`
+- [ ] For client-server: service info via `msgs/tx/svc` (server) and `msgs/rx/svc` (client)
 - [ ] `LICENSE` (Apache 2.0)
 - [ ] `README.md`
 - [ ] Entry in `crucible/config/repos.json`


### PR DESCRIPTION
## Summary
- Updated messaging section in `how-roadblock-works.md` with targeted addressing details
- Rewrote service discovery flow in `how-benchmark-execution-works.md` to describe the simplified API
- Updated `implementing-a-new-benchmark.md` with new server-start/client reading patterns
- Updated `how-endpoints-work.md` K8s networking description

Follows rickshaw PR #832 and the benchmark PRs (bench-uperf #84, bench-iperf #52, bench-trafficgen #116).

## Test plan
- [ ] Review docs for accuracy against the new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)