### PR TITLE
docs: update validation protocol for engine-userenv keyword

### DIFF
--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -57,8 +57,9 @@ Endpoints output specific keywords that rickshaw-run.py parses:
 
 - **`arch`** — CPU architectures available (e.g., `x86_64`,
   `aarch64`). Used to determine which container images to build.
-- **`userenv`** — user environments (base images) available.
-  Repeated for each userenv.
+- **`engine-userenv`** — maps each engine to its userenv.
+  Format: `engine-userenv <role> <id> <userenv>`. One line per
+  non-profiler engine.
 - **`client`** / **`server`** — engine IDs for each role
 - **`engine-types`** — what roles this endpoint supports
   (client, server, profiler, worker, master)

--- a/docs/implementing-a-new-endpoint.md
+++ b/docs/implementing-a-new-endpoint.md
@@ -141,7 +141,7 @@ using specific keywords that `rickshaw-run.py` parses:
 | Keyword | Format | Purpose |
 |---------|--------|---------|
 | `arch` | `arch x86_64 [aarch64...]` | CPU architectures available |
-| `userenv` | `userenv rhubi9` (one per line) | User environments available |
+| `engine-userenv` | `engine-userenv client 1 rhubi9` | Maps each engine (by role and ID) to its userenv |
 | `engine-types` | `engine-types client server profiler` | Supported engine roles |
 | `client` | `client 1 2 3` | Client engine IDs |
 | `server` | `server 4 5 6` | Server engine IDs |
@@ -180,7 +180,10 @@ using specific keywords that `rickshaw-run.py` parses:
 engine-types client server profiler
 client 1 2
 server 3 4
-userenv rhubi9
+engine-userenv client 1 rhubi9
+engine-userenv client 2 rhubi9
+engine-userenv server 3 rhubi9
+engine-userenv server 4 rhubi9
 arch x86_64
 ```
 


### PR DESCRIPTION
## Summary
- Updated `implementing-a-new-endpoint.md` keyword table and example output to show `engine-userenv` instead of `userenv`
- Updated `how-endpoints-work.md` validation section to describe the new format

Follows rickshaw PR #833.

## Test plan
- [ ] Review docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)