### PR TITLE
feat: configurable SSH key algorithm for FIPS compliance

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -480,6 +480,54 @@ elif [ "${1}" == "run" ]; then
         exit ${EXIT_VAL}
     fi
 
+    # determine SSH key algorithm and optional key size from run-file
+    ssh_key_algorithm=$(jq_query ${run_file} '.["run-params"]["ssh-key-algorithm"] // empty')
+    if [ -z "${ssh_key_algorithm}" ]; then
+        ssh_key_algorithm="ed25519"
+    fi
+    case "${ssh_key_algorithm}" in
+        ecdsa|ed25519|rsa)
+            ;;
+        *)
+            exit_error "Invalid ssh-key-algorithm '${ssh_key_algorithm}'. Must be one of: ecdsa, ed25519, rsa"
+            ;;
+    esac
+
+    ssh_key_bits=$(jq_query ${run_file} '.["run-params"]["ssh-key-bits"] // empty')
+    ssh_key_bits_args=""
+    if [ -n "${ssh_key_bits}" ]; then
+        if [ "${ssh_key_algorithm}" == "ed25519" ]; then
+            exit_error "ssh-key-bits cannot be used with ed25519 (fixed key size)"
+        fi
+        ssh_key_bits_args="-b ${ssh_key_bits}"
+    fi
+
+    # validate that the controller's sshd accepts the requested algorithm
+    accepted_algos=$(sshd -T 2>/dev/null | grep "^pubkeyacceptedalgorithms ")
+    if [ -n "${accepted_algos}" ]; then
+        case "${ssh_key_algorithm}" in
+            ed25519)
+                algo_pattern="ssh-ed25519"
+                ;;
+            rsa)
+                algo_pattern="rsa-sha2-"
+                ;;
+            ecdsa)
+                algo_pattern="ecdsa-sha2-nistp"
+                ;;
+        esac
+        if ! echo "${accepted_algos}" | grep -q "${algo_pattern}"; then
+            supported=""
+            echo "${accepted_algos}" | grep -q "ssh-ed25519" && supported+=" ed25519"
+            echo "${accepted_algos}" | grep -q "rsa-sha2-" && supported+=" rsa"
+            echo "${accepted_algos}" | grep -q "ecdsa-sha2-nistp" && supported+=" ecdsa"
+            supported="${supported# }"
+            exit_error "The controller's sshd does not accept '${ssh_key_algorithm}' keys (not in PubkeyAcceptedAlgorithms). Supported algorithms: ${supported:-none detected}"
+        fi
+    fi
+
+    echo "Using SSH key algorithm: ${ssh_key_algorithm}${ssh_key_bits:+ (${ssh_key_bits} bits)}"
+
     # create and add SSH key
     RUN_SSH_DIR="${base_run_dir}/config/ssh"
     SSH_AUTH_KEYS_FILE="/root/.ssh/authorized_keys"
@@ -492,7 +540,7 @@ elif [ "${1}" == "run" ]; then
             exit_error "Setting ssh_home_t SELinux label on ${RUN_SSH_DIR} failed"
         fi
     fi
-    ssh-keygen -f ${RUN_SSH_DIR}/${SESSION_ID} -C "${SSH_KEY_PREFIX}-${SESSION_ID}@$(hostname -f)" -N "" > ${RUN_SSH_DIR}/${SESSION_ID}.log.txt 2>&1
+    ssh-keygen -t ${ssh_key_algorithm} ${ssh_key_bits_args} -f ${RUN_SSH_DIR}/${SESSION_ID} -C "${SSH_KEY_PREFIX}-${SESSION_ID}@$(hostname -f)" -N "" > ${RUN_SSH_DIR}/${SESSION_ID}.log.txt 2>&1
     RC=$?
     if [ ${RC} != 0 ]; then
         exit_error "ssh-keygen failed with RC=${RC}"

--- a/docs/how-run-files-work.md
+++ b/docs/how-run-files-work.md
@@ -392,6 +392,8 @@ behavior. When omitted entirely, all defaults apply:
 | `test-order` | Execution order: `"sample"`, `"iteration"`, or `"random"` | `"sample"` |
 | `name` | Override user name (both name and email required if either specified) | From identity |
 | `email` | Override user email | From identity |
+| `ssh-key-algorithm` | SSH key algorithm for engine communication (`ecdsa`, `ed25519`, or `rsa`). Use `ecdsa` or `rsa` in FIPS environments. | `ed25519` |
+| `ssh-key-bits` | Key size in bits for RSA or ECDSA. Cannot be used with Ed25519. RSA: 2048/3072/4096. ECDSA: 256/384/521. | ssh-keygen default |
 
 ### Test order
 
@@ -401,6 +403,41 @@ behavior. When omitted entirely, all defaults apply:
   then sample 2 of all iterations, etc.
 - **`random`** (or `"r"`): Randomized order to reduce
   systematic bias
+
+### SSH key algorithm
+
+Crucible generates a per-run SSH key for secure communication
+between the controller and engines. By default, Ed25519 is
+used. In FIPS-compliant environments where Ed25519 is not an
+approved algorithm, specify `"ecdsa"` or `"rsa"`:
+
+```json
+"run-params": {
+    "ssh-key-algorithm": "ecdsa"
+}
+```
+
+To also specify key size (optional — ssh-keygen defaults are
+used when omitted):
+
+```json
+"run-params": {
+    "ssh-key-algorithm": "rsa",
+    "ssh-key-bits": 4096
+}
+```
+
+Valid key sizes depend on the algorithm:
+
+- **RSA**: 2048, 3072 (default), 4096
+- **ECDSA**: 256 (default, P-256 curve), 384 (P-384), 521 (P-521)
+- **Ed25519**: fixed size, `ssh-key-bits` cannot be used
+
+Before generating the key, crucible validates that the
+controller's sshd configuration accepts the requested
+algorithm. If the algorithm is not in the server's
+`PubkeyAcceptedAlgorithms`, the run fails with a clear error
+listing the supported algorithms.
 
 ## Tags
 


### PR DESCRIPTION
## Summary
- Extracts `ssh-key-algorithm` and `ssh-key-bits` from the run-file's `run-params` section before generating the per-run SSH key
- Validates the requested algorithm against the controller's sshd `PubkeyAcceptedAlgorithms` — error message lists which algorithms are actually supported
- Rejects `ssh-key-bits` with ed25519 (fixed key size)
- Default remains ed25519 for full backward compatibility
- Documents the new params in `docs/how-run-files-work.md`

Depends on [rickshaw#834](https://github.com/perftool-incubator/rickshaw/pull/834) (merged).

Addresses [PERFNFV-327](https://redhat.atlassian.net/browse/PERFNFV-327).

## Test plan
- [ ] Run with no `ssh-key-algorithm` — confirm ed25519 key generated (default)
- [ ] Run with `"ssh-key-algorithm": "rsa"` — confirm RSA key generated
- [ ] Run with `"ssh-key-algorithm": "ecdsa", "ssh-key-bits": 384` — confirm ECDSA-P384
- [ ] Run with `"ssh-key-bits"` on ed25519 — confirm clear error
- [ ] Verify sshd pre-validation error message lists supported algorithms

🤖 Generated with [Claude Code](https://claude.com/claude-code)