### PR TITLE
fix: remove duplicate cpio in controller requirements

### DIFF
--- a/workshop/crucible-controller-requirements.json
+++ b/workshop/crucible-controller-requirements.json
@@ -51,7 +51,6 @@
           "gzip",
           "jq",
           "git",
-          "cpio",
           "findutils",
           "hostname",
           "iputils",


### PR DESCRIPTION
## Summary

- Remove duplicate `cpio` entry from `core-utils` packages in `workshop/crucible-controller-requirements.json`

This duplicate was harmless when the workshop schema had a misspelled `uniqueuItems` keyword (silently ignored). Workshop PR perftool-incubator/workshop#121 fixes the schema spelling, which then correctly rejects duplicates. This PR must merge first to unblock that workshop CI.

Part of epic PERFNFV-334 (codebase audit), covered by crucible issue #625.

## Test plan
- [ ] `python3 -c "import json; json.load(open('workshop/crucible-controller-requirements.json'))"` — valid JSON
- [ ] No functional change — `cpio` is still installed, just listed once

🤖 Generated with [Claude Code](https://claude.com/claude-code)