### PR TITLE
fix: critical bugs in result-processor, _main, and completions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,10 +208,14 @@ claude plugin marketplace add ${CRUCIBLE_HOME}/subprojects/core/crucible-dev-too
 Claude Code will prompt you to install the crucible-tools plugin — accept it.
 
 Available skills:
+- `/crucible-tools:activity-summary` — generate an activity summary for the GitHub organization
+- `/crucible-tools:debug-log` — analyze crucible logs to debug failed runs or commands
+- `/crucible-tools:dev-activity` — generate development activity charts (commits, PRs, workflow runs)
+- `/crucible-tools:image-cleanup` — clean up local podman images (engine images, dangling images, local builds)
+- `/crucible-tools:new-repo` — create a new repository in the GitHub organization with standard config
+- `/crucible-tools:open-prs` — show all open PRs in the org (optionally filter by author)
 - `/crucible-tools:repo-status` — git status across all crucible repos
-- `/crucible-tools:open-prs` — open PRs in the org (optionally filter by author)
-- `/crucible-tools:dev-activity` — development activity charts (commits, PRs, workflow runs)
-- `/crucible-tools:weekly-summary` — weekly activity report with PR links
+- `/crucible-tools:workflow-status` — show active CI workflow runs across crucible repos
 - `ci-analyzer` agent — analyze GitHub Actions CI workflow runs to diagnose failures
 
 ## Common Terminology

--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -16,7 +16,7 @@ _crucible_completions() {
     num_words=${#COMP_WORDS[@]} # Total number of words on the command
     let num_index=$num_words-1
     if [ $num_words -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo userenvs update run wrapper console start stop ps images get rm index postprocess opensearch extract ls tags archive unarchive reset" -- "${COMP_WORDS[1]}"))
+        COMPREPLY=($(compgen -W "help log repo registries userenvs update run run-ci wrapper console start stop ps images get rm index postprocess opensearch extract ls tags archive unarchive reset" -- "${COMP_WORDS[1]}"))
     elif [ $num_words -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)
@@ -30,6 +30,9 @@ _crucible_completions() {
                 ;;
             repo)
                 COMPREPLY=($(compgen -W "info details config" -- "${COMP_WORDS[2]}"))
+                ;;
+            registries)
+                COMPREPLY=($(compgen -W "add info" -- "${COMP_WORDS[2]}"))
                 ;;
             userenvs)
                 COMPREPLY=($(compgen -W "list help" -- "${COMP_WORDS[2]}"))
@@ -48,9 +51,6 @@ _crucible_completions() {
                 ;;
             rm)
                 COMPREPLY=($(compgen -W "--run" -- "${COMP_WORDS[2]}"))
-                ;;
-            opensearch)
-                COMPREPLY=($(compgen -W "init" -- "${COMP_WORDS[2]}"))
                 ;;
             extract)
                 COMPREPLY=($(compgen -W "run-id primary-periods" -- "${COMP_WORDS[2]}"))

--- a/bin/_main
+++ b/bin/_main
@@ -164,7 +164,7 @@ elif [ "${1}" == "rm" ]; then
             ${access_opt} ${cdmver_opt} "$@"
         RC=$?
     fi
-    EXIT_VAL=$?
+    EXIT_VAL=${RC}
 
 elif [ "${1}" == "index" ]; then
     shift

--- a/bin/_main
+++ b/bin/_main
@@ -574,7 +574,7 @@ elif [ "${1}" == "run" ]; then
     logfile="${base_run_dir}/crucible.log.xz"
     echo "Archiving crucible log to ${logfile}"
     crucible_log view ${LOG_DB} sessionid ${SESSION_ID} | xz -9 -T0 > ${logfile}
-    PIPES_RCS=$(echo ${PIPESTATUS[@]})
+    PIPES_RC=$(echo ${PIPESTATUS[@]})
     RC=0
     for PIPE_RC in ${PIPES_RC}; do
         RC=$(( ${RC} + ${PIPE_RC} ))

--- a/bin/result-processor.py
+++ b/bin/result-processor.py
@@ -167,7 +167,7 @@ def load_rickshaw_run(result_directory):
             else:
                 myglobal.log.debug("did not find %s" % (rickshaw_run_output))
 
-                rickshaw_run_output = result_directory / 'run' / 'rickshaw-run.json'
+                rickshaw_run_output = result_directory / 'config' / 'rickshaw-run.json'
                 if rickshaw_run_output.exists():
                     myglobal.log.debug("found %s" % (rickshaw_run_output))
                     with open(rickshaw_run_output, 'rt') as json_file:
@@ -229,7 +229,7 @@ def replace_rickshaw_run(result_directory, data):
 
             rickshaw_run_output = result_directory / 'config' / 'rickshaw-run.json.xz'
             if rickshaw_run_output.exists():
-                myglobal.log.debug("found %s" % (rickshaw_run_ouput))
+                myglobal.log.debug("found %s" % (rickshaw_run_output))
 
                 backup_rickshaw_run(rickshaw_run_output)
 
@@ -467,7 +467,7 @@ def archives_ls_mode():
 
             ls_archive(archive)
     else:
-        myglobal.log.error("Invalid Crucible archive directory '%s'!" % (myglobal.archive_Dir))
+        myglobal.log.error("Invalid Crucible archive directory '%s'!" % (myglobal.archive_dir))
         return 1
 
     return 0

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -62,11 +62,15 @@ claude plugin marketplace add \
 
 Available skills:
 
-- `/crucible-tools:repo-status` — git status across all repos
-- `/crucible-tools:open-prs` — open PRs in the org
-- `/crucible-tools:dev-activity` — development activity charts
-- `/crucible-tools:weekly-summary` — weekly activity report
-- `ci-analyzer` agent — diagnose CI failures
+- `/crucible-tools:activity-summary` — generate an activity summary for the GitHub organization
+- `/crucible-tools:debug-log` — analyze crucible logs to debug failed runs or commands
+- `/crucible-tools:dev-activity` — generate development activity charts (commits, PRs, workflow runs)
+- `/crucible-tools:image-cleanup` — clean up local podman images (engine images, dangling images, local builds)
+- `/crucible-tools:new-repo` — create a new repository in the GitHub organization with standard config
+- `/crucible-tools:open-prs` — show all open PRs in the org (optionally filter by author)
+- `/crucible-tools:repo-status` — git status across all crucible repos
+- `/crucible-tools:workflow-status` — show active CI workflow runs across crucible repos
+- `ci-analyzer` agent — analyze GitHub Actions CI workflow runs to diagnose failures
 
 ## Repository structure
 


### PR DESCRIPTION
## Summary

- **result-processor.py** (PERFNFV-335): Fix three variable name bugs — copy-paste duplicate fallback path (`run/` instead of `config/`), `rickshaw_run_ouput` typo (NameError), and `archive_Dir` typo (AttributeError)
- **bin/_main** (PERFNFV-336): Fix `PIPES_RCS`/`PIPES_RC` variable name mismatch that silently ignores pipeline failures during log archival; fix `EXIT_VAL=$?` capturing `fi` exit status (always 0) instead of the podman delete command's `RC` in the `rm` subcommand
- **bin/_crucible_completions** (PERFNFV-337): Remove duplicate `opensearch)` case that shadows the full subcommand list; add missing `registries` and `run-ci` commands to the main completions list; add `registries` subcommand completions
- **CLAUDE.md, docs/developer-guide.md**: Update stale 4-skill crucible-dev-tools list to the full 8 skills (remove non-existent `weekly-summary`, add 5 missing skills)

## Jira

- [PERFNFV-335](https://redhat.atlassian.net/browse/PERFNFV-335) — result-processor.py NameError and AttributeError crashes
- [PERFNFV-336](https://redhat.atlassian.net/browse/PERFNFV-336) — bin/_main silently ignores pipe failures and rm exit status
- [PERFNFV-337](https://redhat.atlassian.net/browse/PERFNFV-337) — tab completions broken for opensearch and missing commands

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bin/result-processor.py').read())"` — syntax OK
- [x] `bash -n bin/_main` — syntax OK
- [x] `bash -n bin/_crucible_completions` — syntax OK
- [x] No remaining typos (`rickshaw_run_ouput`, `archive_Dir`, `PIPES_RCS`)
- [x] Only 1 `opensearch)` case in completions
- [x] `registries` and `run-ci` present in main completions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)