### PR TITLE
feat: add rclone to controller image for remote archive support

### DIFF
--- a/workshop/crucible-controller-requirements.json
+++ b/workshop/crucible-controller-requirements.json
@@ -23,7 +23,8 @@
         "opensearch",
         "logging-perl-modules",
         "gh-cli-repo",
-        "gh-cli"
+        "gh-cli",
+        "rclone"
       ]
     }
   ],
@@ -211,6 +212,15 @@
       "distro_info": {
         "packages": [
           "gh"
+        ]
+      }
+    },
+    {
+      "name": "rclone",
+      "type": "distro",
+      "distro_info": {
+        "packages": [
+          "rclone"
         ]
       }
     }


### PR DESCRIPTION
## Summary

- Add rclone as a distro package requirement in `workshop/crucible-controller-requirements.json`
- This is the first step toward remote archive storage support — rclone will enable uploading/downloading result archives to S3, Google Drive, and other storage backends
- rclone is available as `rclone` in the Fedora repos (v1.74.0 in Fedora 44)

## Context

This is Phase 1 of the remote archive storage feature. Once this PR merges and the controller image rebuilds with rclone included, subsequent PRs will add:
- Configuration in services.json for remote storage backends
- `crucible remote` management command
- `--local`/`--remote` flags on archive/unarchive commands
- Remote archive listing via `crucible ls --type archive --remote <name>`

## Test plan

- [x] JSON validates (`jq .`)
- [ ] CI builds controller image successfully with rclone included

🤖 Generated with [Claude Code](https://claude.com/claude-code)