### PR TITLE
fix: defer stale controller image cleanup until logger exits

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -1507,6 +1507,7 @@ fi
 LOG_DB=${USER_STORE}/log.db
 UPDATE_STATUS_FILE="${USER_STORE}/update-status"
 UPDATE_STATUS_LOCK_FILE="${UPDATE_STATUS_FILE}.file-lock"
+STALE_CONTROLLER_IMAGE_FILE="${USER_STORE}/stale-controller-image"
 touch "${UPDATE_STATUS_LOCK_FILE}"
 
 if [ -z "${HOSTFS_DIR}" ]; then

--- a/bin/crucible
+++ b/bin/crucible
@@ -208,4 +208,22 @@ else
     echo "WARNING: The _logger container exited prematurely!"
 fi
 
+# clean up stale controller image left by a previous update — deferred
+# to this point because the logger container held a reference to the
+# old image while it was running
+if [ -e "${STALE_CONTROLLER_IMAGE_FILE}" ]; then
+    stale_id=$(cat "${STALE_CONTROLLER_IMAGE_FILE}")
+    if [ -n "${stale_id}" ]; then
+        if podman image exists ${stale_id} 2>/dev/null; then
+            if podman rmi ${stale_id} 2>/dev/null; then
+                rm -f "${STALE_CONTROLLER_IMAGE_FILE}"
+            fi
+        else
+            rm -f "${STALE_CONTROLLER_IMAGE_FILE}"
+        fi
+    else
+        rm -f "${STALE_CONTROLLER_IMAGE_FILE}"
+    fi
+fi
+
 exit ${RET_VAL}

--- a/bin/update
+++ b/bin/update
@@ -148,8 +148,8 @@ case "${repo}" in
         else
             new_id=$(podman images -q ${CRUCIBLE_CONTROLLER_IMAGE})
             if [ -n "${old_id}" ] && [ "${old_id}" != "${new_id}" ]; then
-                echo "Removing previous controller image ${old_id}"
-                podman rmi ${old_id} 2>/dev/null || true
+                echo "Deferring removal of previous controller image ${old_id}"
+                echo "${old_id}" > "${STALE_CONTROLLER_IMAGE_FILE}"
             fi
         fi
         ;;


### PR DESCRIPTION
## Summary

During `crucible update`, the old controller image cannot be removed with `podman rmi` because the logger container is still running and holds a reference to it. The `2>/dev/null || true` silently hid the failure, leaving stale images accumulating.

Fix: write the old image ID to a marker file (`$USER_STORE/stale-controller-image`) during update, then clean it up in `bin/crucible` after the logger container exits. The cleanup handles three cases:
- Image still exists: attempt `podman rmi`, remove marker only on success
- Image already gone (manually removed): remove the marker
- Empty/corrupt marker file: remove the marker

## Test plan
- [ ] CI passes
- [ ] `crucible update controller-image` when a new image is available — verify old image is cleaned up after the command completes
- [ ] `crucible update controller-image` when already up to date — no marker file created

🤖 Generated with [Claude Code](https://claude.ai/claude-code)