### PR TITLE
fix: variable scoping, installer bugs, and missing subparser

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Download and run crucible-install.sh script
 
 ```
 curl -LkO https://raw.githubusercontent.com/perftool-incubator/crucible/master/crucible-install.sh
-bash crucible-install.sh --client-server-registry <registry> [--client-server-auth-file </path/to/auth-file.json>]
+bash crucible-install.sh --engine-registry <registry> [--engine-auth-file </path/to/auth-file.json>]
 ```
 
 See `bash crucible-install.sh --help` for the full list of options.

--- a/bin/base
+++ b/bin/base
@@ -70,7 +70,7 @@ function check_id {
 }
 
 function crucible_log() {
-    ${podman_run} --name crucible-log-${SESSION_ID} ${container_log_args[@]} ${container_common_args[@]} ${container_non_service_args[@]} ${CRUCIBLE_CONTROLLER_IMAGE} ${CRUCIBLE_HOME}/bin/_log.py $@
+    ${podman_run} --name crucible-log-${SESSION_ID} "${container_log_args[@]}" "${container_common_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${CRUCIBLE_HOME}/bin/_log.py "$@"
 }
 
 function root_or_die {
@@ -192,7 +192,7 @@ function find_available_port() {
 }
 
 function start_httpd() {
-    local RC httpd_cmd httpd_port actual_port
+    local RC=0 httpd_cmd httpd_port actual_port
 
     httpd_port=$(jq_query ${SERVICES_CFG} '.httpd.port')
 
@@ -242,7 +242,7 @@ function stop_httpd() {
 }
 
 function start_valkey() {
-    local RC valkey_cmd valkey_monitor_cmd valkey_monitor_enabled
+    local RC=0 valkey_cmd valkey_monitor_cmd valkey_monitor_enabled
 
     valkey_monitor_enabled=$(jq_query ${SERVICES_CFG} '.valkey.monitor.enabled')
 
@@ -447,7 +447,7 @@ function stop_image_sourcing() {
 function start_opensearch() {
     local opensearch_available count status_check opensearch_timeout pod_name
     local opensearch_start_cmd opensearch_status_cmd common_container_args
-    local RC stage
+    local RC=0 stage
     opensearch_start_cmd="${CRUCIBLE_HOME}/bin/services/start-opensearch.sh ${opensearch_dir} ${var_crucible}"
     # localhost:9200 hardcoded here because this should only ever be used for local opensearch
     opensearch_status_cmd="curl --silent --show-error --stderr - -X GET localhost:9200/_cluster/health"
@@ -543,7 +543,7 @@ function stop_opensearch() {
 }
 
 function start_cdm_server() {
-    local RC cdm_server_cmd cdm_query_opt cdm_server_port actual_port
+    local RC=0 cdm_server_cmd cdm_query_opt cdm_server_port actual_port
 
     cdm_server_port=$(jq_query ${SERVICES_CFG} '."cdm-server".port')
 
@@ -679,7 +679,7 @@ function extract_primary_periods() {
 }
 
 function post_process_run() {
-    local rs_pp_b_cmd ps_pp_t_cmd
+    local rs_pp_b_cmd rs_pp_t_cmd
     local run_json this_id RUN_DIR
     local post_process_fail RC result_summary
     local log_level="${run_log_level:-normal}"
@@ -719,8 +719,7 @@ function post_process_run() {
 }
 
 function index_run() {
-    local rs_gendocs_opt rs_gendocs_cmd
-    local cdm_index_opt cdm_index_cmd
+    local gen_docs_cmd index_docs_cmd
     local run_json this_id RUN_DIR
     local post_process_fail RC result_summary
     local access_opt cdmver_opt
@@ -761,7 +760,6 @@ function index_run() {
     RC=$?
     if [ ${RC} == 0 ]; then
         echo "Opensearch documents have been created"
-        RC=$?
     else
         echo "ERROR: Could not generate OpenSearch documents [rc=${RC}]"
     fi
@@ -780,7 +778,6 @@ function index_run() {
     RC=$?
     if [ ${RC} == 0 ]; then
         echo "Benchmark result now in OpenSearch, using ${access_opt} $cdmver_opt" | sed -e 's/--userpass\s\S*\s//'
-        RC=$?
     else
         echo "ERROR: Could not index result into OpenSearch [rc=${RC}]"
     fi

--- a/bin/manage_opensearch.py
+++ b/bin/manage_opensearch.py
@@ -284,6 +284,8 @@ def main():
 
     subparsers.add_parser('index-instance', help='Display the default instance to index to.')
 
+    subparsers.add_parser('gendocs-opt', help='Display the cmdline options to pass to doc generation utils.')
+
     parser_gethostaccess = subparsers.add_parser('instance-host-access-opt', help='Display the host access options for a specific instance.')
     parser_gethostaccess.add_argument('--name', type=str, required=True, help='Name of the instance.')
 

--- a/crucible-install.sh
+++ b/crucible-install.sh
@@ -162,7 +162,7 @@ function usage {
         --engine-registry <full registry url>
         Engine registry (required for install).
 
-        --quay-engine-expiration-refresh-token <authentication file>>
+        --quay-engine-expiration-refresh-token <authentication file>
         Quay OAuth authentication token file for refreshing engine image expiration timestamps.
 
         --quay-engine-expiration-refresh-api-url <api url>
@@ -676,7 +676,7 @@ function update_repos_config() {
                 fi
             fi
         fi
-        if echo "${BRANCH}" | grep -q "^\(20[0-9][0-9]\.[1234]\|version-test\|ci-verstion-test\)$"; then
+        if echo "${BRANCH}" | grep -q "^\(20[0-9][0-9]\.[1234]\|version-test\|ci-version-test\)$"; then
             # this is a version install so lock it down
             update_mode=1
             MODE="locked"
@@ -982,7 +982,7 @@ _SYSCFG_
     CRUCIBLE_HOME=${INSTALL_PATH} source ${INSTALL_PATH}/bin/base
 else
     SYSCONFIG_CRUCIBLE_ENGINE_TLS_VERIFY="\"${SYSCONFIG_CRUCIBLE_ENGINE_TLS_VERIFY}\""
-    if [ -n "${SYSCONFIG_CRUCIBLE_ENGINE_AUTH_FILE}" ]; then
+    if [ -n "${SYSCONFIG_CRUCIBLE_ENGINE_AUTH}" ]; then
         SYSCONFIG_CRUCIBLE_ENGINE_AUTH="\"${SYSCONFIG_CRUCIBLE_ENGINE_AUTH}\""
     fi
     if [ -n "${CRUCIBLE_ENGINE_TLS_VERIFY}" ]; then


### PR DESCRIPTION
## Summary

- **bin/base**: Fix variable scoping leaks (`ps_pp_t_cmd` typo, wrong local names in `index_run`), initialize `RC=0` in four `start_*` functions to prevent uninitialized return when services are already running, quote array expansions in `crucible_log`, and remove `RC=$?` after `echo` that clobbered meaningful return codes in `index_run`
- **crucible-install.sh**: Fix `ci-verstion-test` typo in grep pattern, `SYSCONFIG_CRUCIBLE_ENGINE_AUTH_FILE` → `SYSCONFIG_CRUCIBLE_ENGINE_AUTH` wrong variable name, and extra `>` in help text
- **bin/manage_opensearch.py**: Add missing `gendocs-opt` subparser registration (action was handled in dispatch but unreachable from CLI)
- **INSTALL.md**: Update deprecated `--client-server-registry`/`--client-server-auth-file` to current `--engine-registry`/`--engine-auth-file`

Resolves: https://github.com/perftool-incubator/crucible/issues/623
Resolves: https://github.com/perftool-incubator/crucible/issues/624

## Test plan

- [x] `bash -n bin/base` — syntax check passes
- [x] `bash -n crucible-install.sh` — syntax check passes
- [x] `python3 -m py_compile bin/manage_opensearch.py` — syntax check passes
- [x] `crucible update` — end-to-end check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)