### PR TITLE
feat: add tool-bpf eBPF data collection tool

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -371,6 +371,16 @@
             }
         },
         {
+            "name": "bpf",
+            "type": "tool",
+            "repository": "https://github.com/perftool-incubator/tool-bpf",
+            "primary-branch": "master",
+            "checkout": {
+                "mode": "follow",
+                "target": "master"
+            }
+        },
+        {
             "name": "dpdk",
             "type": "tool",
             "repository": "https://github.com/perftool-incubator/tool-dpdk",


### PR DESCRIPTION
## Summary

- Registers `tool-bpf` as a new tool subproject in `config/repos.json`
- `tool-bpf` uses bpftrace scripts and libbpf CO-RE programs to capture kernel-level metrics during benchmark runs
- Initial subtool: `tcp-window` — attaches to the `tcp:tcp_probe` tracepoint to record `snd_cwnd`, `ssthresh`, `snd_wnd`, `srtt`, and `rcv_wnd` per TCP flow into CDM
- All dependencies (`bpftrace`, `clang`, `libbpf`, `libbpf-devel`, `bpftool`) are available as distro packages on Fedora 43/44 — no source builds required
- Follows the `tool-kernel` subtool pattern: comma-separated `--subtools` argument, per-subtool bpftrace scripts deployed via `files-from-controller`, Python post-processor using `toolbox.metrics`

## Test plan

- [x] End-to-end validated: tool-bpf with tcp-window subtool ran successfully in a crucible uperf benchmark on RHEL 10 / Scale Lab 100G hosts (run b2d08c4c)
- [x] bpftrace captured 1.4M tcp:tcp_probe events on the uperf data-plane flow
- [x] CDM metric files written correctly with correct epoch timestamps
- [x] Review agent confirmed cwnd=607KB, srtt=332µs, ssthresh=INT_MAX (no congestion)
- [ ] CI will validate repos.json schema

Generated with Claude Code