### PR TITLE
fix: tls-verify=false ignored in remote archive rclone args

### DIFF
--- a/bin/_remote_archive
+++ b/bin/_remote_archive
@@ -43,7 +43,7 @@ function _build_rclone_args() {
     cred_file=$(jq_query ${SERVICES_CFG} --arg name "${remote_name}" '."remote-archive".remotes[$name].credentials')
 
     local tls_verify
-    tls_verify=$(jq_query ${SERVICES_CFG} --arg name "${remote_name}" '."remote-archive".remotes[$name]."tls-verify" // true')
+    tls_verify=$(jq_query ${SERVICES_CFG} --arg name "${remote_name}" '."remote-archive".remotes[$name]."tls-verify" | if . == null then true else . end')
 
     _rclone_args=()
 


### PR DESCRIPTION
## Summary

- The jq `//` (alternative) operator treats both `null` and `false` as falsy, so `."tls-verify" // true` always returned `true` — even when `tls-verify` was explicitly set to `false` in the remote config. This made `--no-check-certificate` unreachable, breaking remotes with self-signed or custom CA certificates.
- Replace with an explicit null check so only a missing field defaults to `true`.

## Test plan

- [ ] Configure a remote with `--tls-verify false` and a self-signed cert endpoint
- [ ] Verify `crucible archive --remote <name> <run>` succeeds (previously failed with TLS errors)
- [ ] Verify a remote without `tls-verify` set still defaults to verifying certificates

🤖 Generated with [Claude Code](https://claude.com/claude-code)