### PR TITLE
Add bench-rant benchmark

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -251,6 +251,16 @@
             }
         },
         {
+            "name": "rant",
+            "type": "benchmark",
+            "repository": "https://github.com/perftool-incubator/bench-rant",
+            "primary-branch": "main",
+            "checkout": {
+                "mode": "follow",
+                "target": "main"
+            }
+        },
+        {
             "name": "sysstat",
             "type": "tool",
             "repository": "https://github.com/perftool-incubator/tool-sysstat",


### PR DESCRIPTION
## Summary
- Register **bench-rant** (rant UDP latency micro-benchmark) in `config/repos.json` as an official crucible benchmark
- Repository: https://github.com/perftool-incubator/bench-rant
- Rant measures hardware-timestamped round-trip UDP latency using 1-byte packets in a client-server (emit/reflect) model

## Test plan
- [x] End-to-end crucible run completed successfully (run ID: ace63f6e-db0e-4f4e-b946-d3f068268d98)
- [x] Workshop builds rant from source, installs to /usr/local/bin/rant
- [x] Client and server post-processing produces correct CDM metrics
- [x] All 19 metric types indexed into OpenSearch
- [x] Client RTT: p50=7us, MAX=18us; Server response: p50=1us, MAX=11us (2.4M samples in 30s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)