### PR TITLE
config: add tool-bpf (eBPF-based data collection) to official repos

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -301,6 +301,16 @@
             }
         },
         {
+            "name": "bpf",
+            "type": "tool",
+            "repository": "https://github.com/perftool-incubator/tool-bpf",
+            "primary-branch": "master",
+            "checkout": {
+                "mode": "follow",
+                "target": "master"
+            }
+        },
+        {
             "name": "forkstat",
             "type": "tool",
             "repository": "https://github.com/perftool-incubator/tool-forkstat",


### PR DESCRIPTION
## Summary

Adds [`perftool-incubator/tool-bpf`](https://github.com/perftool-incubator/tool-bpf) as an official crucible tool subproject by registering it in `config/repos.json`.

## What tool-bpf provides

`tool-bpf` is an eBPF/bpftrace-based data collection framework for crucible with two subtools:

**`tcp-window`** — per-connection TCP congestion and flow-control state sampled on every receive event:
- `snd_cwnd` — congestion window (MSS units)
- `ssthresh` — slow-start threshold
- `snd_wnd` — receiver-advertised window (bytes)
- `srtt` — smoothed RTT (µs)
- `rcv_wnd` — local receive window (bytes)

Uses `kprobe:tcp_rcv_established` with BTF struct access rather than `tracepoint:tcp:tcp_probe`, giving consistent field availability across kernel versions (the tracepoint's field set varies between RHEL releases).

**`tx-burst`** — per-packet transmit timestamps and byte counts on a named interface at nanosecond resolution. Enables post-processing to reconstruct instantaneous throughput and inter-packet gap histograms for micro-burst detection.

Both subtools emit CDM metrics with per-flow breakouts (`src`, `sport`, `dst`, `dport`).

## Requirements

- `CONFIG_DEBUG_INFO_BTF=y` on profiler hosts (standard on RHEL 9+ and recent Fedora kernels)
- `bpftrace` installed on profiler hosts

## Usage in a run file

```json
{
  "tool-params": [
    {
      "tool": "bpf",
      "params": [
        {"arg": "subtools", "val": "tcp-window"},
        {"arg": "iface",    "val": "eno16695np0"}
      ]
    }
  ]
}
```