### PR TITLE
feat: validate repos.json against its schema at startup

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -1694,3 +1694,6 @@ if [ -e ${REGISTRIES_CFG} ]; then
 else
     exit_error "Could not locate ${REGISTRIES_CFG}"
 fi
+
+REPOS_CFG=${CRUCIBLE_HOME}/config/repos.json
+REPOS_CFG_SCHEMA=${CRUCIBLE_HOME}/schema/repos.json

--- a/bin/crucible
+++ b/bin/crucible
@@ -44,6 +44,7 @@ fi
 # make sure the JSON config files validate against their schemas before proceeding
 validate_json_schema ${SERVICES_CFG} ${SERVICES_CFG_SCHEMA} || exit_error "Services Configuration Error: ${SERVICES_CFG} does not validate against ${SERVICES_CFG_SCHEMA}"
 validate_json_schema ${REGISTRIES_CFG} ${REGISTRIES_CFG_SCHEMA} || exit_error "Registries Configuration Error: ${REGISTRIES_CFG} does not validate against ${REGISTRIES_CFG_SCHEMA}"
+validate_json_schema ${REPOS_CFG} ${REPOS_CFG_SCHEMA} || exit_error "Repos Configuration Error: ${REPOS_CFG} does not validate against ${REPOS_CFG_SCHEMA}"
 
 check_id
 

--- a/docs/how-the-repo-system-works.md
+++ b/docs/how-the-repo-system-works.md
@@ -300,3 +300,11 @@ All configuration changes are validated against the
 schema enforces valid repo types, checkout modes, branch
 names, and URL formats, preventing misconfiguration that
 could break the update or install process.
+
+`repos.json` is also validated against this schema at the
+start of every `crucible` command invocation, alongside
+`services.json` and `registries.json`. This catches manual
+edits (e.g., swapping in an SSH URL for local development)
+that bypass `crucible repo config` and would otherwise only
+surface as a cryptic `jq` error deep inside `bin/repo` or
+`bin/update`.


### PR DESCRIPTION
## Summary
- Add `REPOS_CFG`/`REPOS_CFG_SCHEMA` to `bin/base`, matching the existing `SERVICES_CFG`/`REGISTRIES_CFG` pattern
- Validate `repos.json` against `schema/repos.json` at the start of every `crucible` command invocation, alongside the existing `services.json` and `registries.json` checks
- Document the new startup validation in `docs/how-the-repo-system-works.md`

`repos.json` was previously only validated during mutations via `jq_update_validated()` in `bin/repo`. Manual edits (e.g. swapping in an SSH URL for local dev, per the repo's own documented convention) went unchecked, so a typo would surface as a cryptic `jq` error deep in `bin/repo` or `bin/update` instead of a clear schema validation message.

Addresses [PERFNFV-465](https://redhat.atlassian.net/browse/PERFNFV-465) from the architecture review.

## Test plan
- [x] `bash -n` syntax check on `bin/base` and `bin/crucible`
- [x] `crucible help` runs cleanly with the current (valid) `repos.json`
- [x] Manually verified `validate_json_schema` against a valid copy of `repos.json` (rc=0) and a copy with an injected invalid field (rc=3, clear error message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)