### PR TITLE
feat: gate crucible-ci on crucible's own unit tests

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -43,8 +43,13 @@ jobs:
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
-  call-real-core-release-crucible-ci:
+  call-unittest:
     needs: changes
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
+    uses: ./.github/workflows/unittest.yaml
+
+  call-real-core-release-crucible-ci:
+    needs: [ changes, call-unittest ]
     if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: perftool-incubator/crucible-ci/.github/workflows/core-release-crucible-ci.yaml@main
     with:
@@ -61,7 +66,7 @@ jobs:
     uses: perftool-incubator/crucible-ci/.github/workflows/faux-core-release-crucible-ci.yaml@main
 
   crucible-ci-complete:
-    needs: [ call-real-core-release-crucible-ci, call-faux-core-release-crucible-ci ]
+    needs: [ call-unittest, call-real-core-release-crucible-ci, call-faux-core-release-crucible-ci ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,0 +1,27 @@
+name: unittest
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install jsonschema
+
+      - name: Run crucible python unit tests
+        run: |
+          source .venv/bin/activate
+          cd bin
+          python3 -m unittest discover -s . -p "test_*.py" -v

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -23,5 +23,4 @@ jobs:
       - name: Run crucible python unit tests
         run: |
           source .venv/bin/activate
-          cd bin
-          python3 -m unittest discover -s . -p "test_*.py" -v
+          python3 -m unittest discover -s bin -p "test_*.py" -v

--- a/docs/how-ci-works.md
+++ b/docs/how-ci-works.md
@@ -24,6 +24,9 @@ Key CI capabilities:
 
 - **Docs-only filtering**: PRs that only change documentation
   skip full integration tests
+- **Local test gating**: Repos with their own fast test suite
+  can gate the expensive integration run behind it (adopted
+  per repo, not universal)
 - **Capability-based runner matching**: Scenarios declare
   requirements, runner pools declare capabilities, and the
   system matches them
@@ -38,6 +41,10 @@ CI uses a multi-level calling structure:
 
 ```
 Repo trigger workflow (e.g., crucible-ci.yaml)
+  │
+  ├── (optional) local test gate — unittest.yaml
+  │     Must pass before the reusable workflow below runs
+  │
   └── crucible-ci reusable workflow
         (e.g., core-release-crucible-ci.yaml)
       └── Per-release workflow
@@ -51,8 +58,10 @@ Repo trigger workflow (e.g., crucible-ci.yaml)
 ### Level 1: Repo trigger
 
 Each repo has a `crucible-ci.yaml` in `.github/workflows/`
-that fires on pull requests. It performs the docs-only check
-and calls the appropriate crucible-ci reusable workflow.
+that fires on pull requests. It performs the docs-only check,
+optionally gates on the repo's own local test suite (see
+"Local test gating" below), and calls the appropriate
+crucible-ci reusable workflow.
 
 ### Level 2: Reusable workflows
 
@@ -145,6 +154,46 @@ runner resources.
 When non-docs files changed (or on manual `workflow_dispatch`
 triggers), the **real workflow** runs with full integration
 testing.
+
+## Local test gating
+
+Some repos wire their own fast test suite in as a gate in
+front of the expensive crucible-ci reusable workflow call, so
+a regression a local test would catch never reaches the
+(much slower) integration test matrix.
+
+### How it works
+
+The repo's trigger workflow (`crucible-ci.yaml`) adds a
+`call-unittest` job that calls a local, `workflow_call`-only
+`unittest.yaml` in the same repo. That job is:
+
+- Given the same `if:` condition as the real integration-test
+  call, so it runs (or is skipped for docs-only PRs / forks)
+  under identical conditions
+- Added to the real integration-test job's `needs:`, so a
+  failing gate prevents the expensive job from starting at all
+- Added directly to the trigger workflow's `*-complete` job's
+  `needs:` as well, not just relied on transitively. GitHub
+  Actions reports a job skipped because a dependency failed as
+  `skipped`, not `failure`, and `*-complete`'s own check only
+  looks for `failure`/`cancelled`. Without this direct
+  dependency, a failing gate would still produce a passing
+  `*-complete` check.
+
+`unittest.yaml` itself has no `pull_request` trigger — only
+`workflow_call`/`workflow_dispatch` — so its tests don't run a
+second, redundant time outside of `crucible-ci.yaml`.
+
+### Adoption is per repo, not universal
+
+Test tooling varies by repo (stdlib `unittest`, `pytest`,
+language-specific runners), so there's no single shared
+reusable workflow for this gate — each repo's `unittest.yaml`
+contains its own test-invocation logic; only the gating
+*shape* described above is shared. Not every repo has adopted
+this pattern, and repos without a fast local test suite have
+no reason to.
 
 ## Capability-based runner matching
 


### PR DESCRIPTION
## Summary

- Adds a `call-unittest` job to `crucible-ci.yaml` that gates the expensive `call-real-core-release-crucible-ci` reusable-workflow call behind crucible's own unit tests (`bin/test_list_subprojects.py` + `bin/test_manage_opensearch.py`, 63 tests total, previously unwired to any CI).
- New `.github/workflows/unittest.yaml` (`workflow_call`/`workflow_dispatch` only — no `pull_request` trigger, so tests don't run twice per PR).
- Same 3-part wiring already merged in toolbox (#130) and rickshaw (#864): `call-unittest` shares `call-real-core-release-crucible-ci`'s `if:` condition, is added to that job's `needs:`, and is *also* added directly to `crucible-ci-complete`'s `needs:` — a failed gate produces `skipped` (not `failure`) on the downstream job, and `crucible-ci-complete`'s check only looks for `failure`/`cancelled`, so without this direct dependency a failing gate would silently pass the required check.
- No branch-protection change needed: crucible's ruleset only requires `crucible-ci-complete` for this path (verified via `gh api .../rulesets/3637247`, not the `.github/rulesets/*` backup), and `call-unittest` now feeds that job directly.
- Updates `docs/how-ci-works.md` with a new "Local test gating" section (parallel to "Docs-only filtering"), the workflow hierarchy diagram, and the Level 1 trigger description — this pattern wasn't documented anywhere yet despite being live in two other repos already.

Closes #637 — `bin/test_manage_opensearch.py` now runs on every PR via this gate.

## Test plan

- [x] `bash -n`/YAML-parsed both workflow files
- [x] Ran all 63 tests in a fresh venv with only `jsonschema` installed (matching the CI environment exactly) — all pass
- [x] Confirmed `unittest.yaml` is not in `crucible-ci.yaml`'s docs-only skip-file list (it's the test payload, not orchestration)
- [ ] Confirm on this PR's own CI run: `call-unittest` passes before `call-real-core-release-crucible-ci` starts, `call-faux-core-release-crucible-ci` still correctly skips for non-docs changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)