### PR TITLE
feat: add .agents/plugins.json manifest for antigravity plugin discovery

### DIFF
--- a/.agents/plugins.json
+++ b/.agents/plugins.json
@@ -1,0 +1,5 @@
+{
+  "entries": [
+    { "path": "subprojects/core/crucible-dev-tools/plugins" }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
             .github/workflows/fork-check.yaml
             .gitignore
             .claude/**
+            .agents/**
             docs/**
             spec/**
       - name: Display changes

--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -38,6 +38,7 @@ jobs:
             .github/workflows/fork-check.yaml
             .gitignore
             .claude/**
+            .agents/**
             docs/**
             spec/**
       - name: Display changes

--- a/.github/workflows/crucible-release-ci.yaml
+++ b/.github/workflows/crucible-release-ci.yaml
@@ -37,6 +37,7 @@ jobs:
             .github/workflows/fork-check.yaml
             .gitignore
             .claude/**
+            .agents/**
             docs/**
             spec/**
       - name: Display changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,10 @@ claude plugin marketplace add ${CRUCIBLE_HOME}/subprojects/core/crucible-dev-too
 
 Claude Code will prompt you to install the crucible-tools plugin — accept it.
 
+Antigravity users don't need this manual step: `.agents/plugins.json` at the
+repo root points Antigravity at the same plugin directory for automatic
+discovery.
+
 Available skills:
 - `/crucible-tools:activity-summary` — generate an activity summary for the GitHub organization
 - `/crucible-tools:architecture-review` — top-down architecture and design review across crucible subsystems

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -60,6 +60,10 @@ claude plugin marketplace add \
     ${CRUCIBLE_HOME}/subprojects/core/crucible-dev-tools
 ```
 
+Antigravity users don't need this manual step: `.agents/plugins.json` at the
+repo root points Antigravity at the same plugin directory for automatic
+discovery.
+
 Available skills:
 
 - `/crucible-tools:activity-summary` — generate an activity summary for the GitHub organization

--- a/docs/how-ci-works.md
+++ b/docs/how-ci-works.md
@@ -141,6 +141,7 @@ to check if all modified files match the docs-only list:
 - Most workflow files (CI, release, tracking, fork-check)
 - `.gitignore`
 - `.claude/**`
+- `.agents/**`
 - `docs/**`, `spec/**`
 
 ### Faux workflows


### PR DESCRIPTION
## Summary
- Adds `.agents/plugins.json`, a manifest antigravity uses to locate the crucible-dev-tools plugin (pointing at `subprojects/core/crucible-dev-tools/plugins`) instead of requiring manual marketplace registration
- Adds `.agents/**` to the CI change-detection filters in `crucible-ci.yaml`, `ci.yaml`, and `crucible-release-ci.yaml` (alongside the existing `.claude/**` entry) so a PR touching only this manifest is treated as a docs-only change and skips the full CI suite

## Test plan
- [x] Validated all three modified workflow YAML files parse correctly
- [x] Confirmed no other workflow files (e.g. `crucible-weekly-ci.yaml`) use this docs-only filter mechanism, so no other files needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)