### PR TITLE
fix: start CDM server when OpenSearch is already running

### DIFF
--- a/bin/base
+++ b/bin/base
@@ -512,6 +512,18 @@ function start_opensearch() {
                 fi
             fi
         fi
+    else
+        # OpenSearch was already running -- still need to check the CDM
+        # server companion service, since it's tracked as a separate
+        # container and may have been stopped (or never started)
+        # independently of OpenSearch. start_cdm_server() is a no-op if
+        # it's already running.
+        start_cdm_server
+        local CDM_RC=$?
+        if [ ${CDM_RC} != 0 ]; then
+            echo "WARNING: OpenSearch already running but CDM server failed to start"
+            RC=${CDM_RC}
+        fi
     fi
     return ${RC}
 }


### PR DESCRIPTION
## Summary
- `start_opensearch()` only called `start_cdm_server` inside the branch that starts OpenSearch fresh. If OpenSearch was already running (e.g. left running from a prior session), the CDM server was never checked or started.
- Result: the benchmark succeeds, but `index_run` later fails at `add-run.sh` with a confusing `Error: node_modules not found. Run start-server.sh or 'npm install' in .../cdmq first.` -- far removed from the actual root cause.
- `start_cdm_server()` is already idempotent (no-ops if its container is already running), so the fix just calls it unconditionally in the "OpenSearch already running" branch too, matching the existing branch's pattern of propagating a CDM server startup failure through `start_opensearch()`'s own return code.

Fixes #651

## Test plan
- [x] `bash -n bin/base`
- [x] Live reproduction: stopped only `crucible-cdm-server` (`--rm`, so this fully removes it) while leaving `crucible-opensearch` running, then ran `crucible start opensearch` -- confirmed it now detects the missing CDM server and recreates it (`Checking for CDM server...not present` -> `Successfully started CDM server on port 3000`)
- [x] Confirmed idempotency: running `crucible start opensearch` again with both already up reports `...appears to be running` for both and does nothing further

🤖 Generated with [Claude Code](https://claude.com/claude-code)