### PR TITLE
docs: document repeatable args and multiplex --flat mode for tools

### DIFF
--- a/docs/implementing-a-new-benchmark.md
+++ b/docs/implementing-a-new-benchmark.md
@@ -305,6 +305,25 @@ error messages.
 matching validation rule. A param without a validation entry will
 cause errors during multiplex processing.
 
+A validation group can also set `"repeatable": true` to declare that
+its args may legitimately be specified more than once within a
+single set — e.g. a benchmark/tool that accepts multiple independent
+setup commands. By default (no `repeatable` key), a second occurrence
+of the same arg in one set collapses to the last one, and an
+`essentials` preset for that arg replaces whatever's already there.
+A repeatable arg is always unioned instead: duplicate occurrences all
+survive, and an `essentials` entry is added only if that exact value
+isn't already present rather than replacing anything.
+
+Each occurrence of a repeatable arg must still be single-valued —
+`"vals"` sweeping multiple values within one occurrence has no
+defined interaction with a repeatable arg's other occurrences yet
+(would it union all the values together, or multiply them?) and
+multiplex rejects it outright rather than silently producing a
+confusing cross-multiplied result. If you need a repeatable arg's
+values to vary across test iterations, define separate `sets` instead
+of trying to sweep one occurrence's values.
+
 ### Units (optional)
 
 Conversion tables for parameters with units. Users can specify

--- a/docs/implementing-a-new-tool.md
+++ b/docs/implementing-a-new-tool.md
@@ -269,15 +269,13 @@ for the full `presets`/`validations`/`units` reference), validated
 against the same `multiplex/JSON/req-schema.json`.
 
 If a tool has no `multiplex.json`, its `tool-params` are used as-is
-(today's behavior, unchanged). If it has one, rickshaw wraps every
-`tool-params` value into a single-element `vals` array before
-handing it to `multiplex.py`, and unwraps the result back into
-`tool-params.json`'s flat `{"arg", "val"}` shape afterward. Because
-every `vals` array has exactly one element, `multiplex.py`'s
-cartesian-product expansion can only ever produce one combination —
-this is what makes it safe to reuse the benchmark mechanism
-unmodified for a use case (a static, non-iterating parameter set)
-that's fundamentally different from what it was built for.
+(today's behavior, unchanged). If it has one, rickshaw hands
+`tool-params`'s flat `{"arg", "val"}` list directly to `multiplex.py
+--flat` and gets the same shape back, validated/converted/transformed
+and with `defaults`/`essentials` applied. `--flat` mode has no
+sets/include/cartesian-product concept, since tools never need any of
+that — they always have exactly one implicit parameter set and, per
+`tool-params.json`'s own schema, never more than one value per param.
 
 **Backward compatibility (read this before adding a `multiplex.json`
 to an existing tool):** `tool-params.json` only requires a `tool`
@@ -299,13 +297,14 @@ referenced anywhere) is:
 ```
 
 A couple of things that differ from the benchmark case:
-- `id`/`ids` (per-engine restriction) have no tool analog and are
-  silently dropped when the multiplexed result is unwrapped back
-  into `tool-params.json`'s shape.
-- `role` is not meaningful for tools (there's no client/server
-  concept); rickshaw sets it internally so multiplex's own dedup
-  logic behaves consistently — you don't need to (and shouldn't) set
-  it yourself in a tool's `multiplex.json`.
+- `id`/`ids` (per-engine restriction) and `role` (client/server) have
+  no tool analog; `--flat` mode handles this internally (every param
+  defaults to role `all`) — you don't need to (and shouldn't) set
+  `role` yourself in a tool's `multiplex.json`.
+- A `repeatable` arg's individual occurrences must each be single-
+  valued (this restriction applies to benchmarks too) — multiplex
+  rejects an occurrence with more than one value outright, since a
+  tool never sweeps.
 
 ---
 


### PR DESCRIPTION
## Summary
- Documents the `repeatable` schema field for benchmark param groups, including the single-value-per-occurrence restriction (a repeatable arg's `vals` sweeping multiple values in one occurrence is rejected, not silently cross-multiplied).
- Rewrites `docs/implementing-a-new-tool.md`'s `multiplex.json` section to describe multiplex's `--flat` mode (rickshaw#869, merged), which replaced the old wrap-into-single-element-`vals`-array/unwrap mechanism.

## Test plan
- [x] Docs-only change; content verified against the merged rickshaw diff (`apply_flat_params()`, `--flat` CLI flag, `merge_repeatable_param()`)