### PR TITLE
feat: replace CDM Indexed column with Metrics/Params counts, wrap descriptions

### DIFF
--- a/bin/_main
+++ b/bin/_main
@@ -77,7 +77,7 @@ elif [ "${1}" == "tools" -o "${1}" == "benchmarks" ]; then
         # can't detect the real terminal width on its own -- forward it
         # explicitly via COLUMNS instead
         terminal_columns=$(tput cols 2>/dev/null || echo 100)
-        ${podman_run} --name crucible-${subproject_kind}s-list-${SESSION_ID} "${container_common_args[@]}" "${container_non_service_args[@]}" "-e COLUMNS=${terminal_columns}" ${CRUCIBLE_CONTROLLER_IMAGE} ${list_cmd}
+        ${podman_run} --name crucible-${subproject_kind}s-list-${SESSION_ID} "${container_common_args[@]}" "${container_non_service_args[@]}" -e "COLUMNS=${terminal_columns}" ${CRUCIBLE_CONTROLLER_IMAGE} ${list_cmd}
         EXIT_VAL=$?
     else
         echo "ERROR: unsupported '${subproject_kind}s' argument [${1}]"

--- a/bin/_main
+++ b/bin/_main
@@ -73,7 +73,11 @@ elif [ "${1}" == "tools" -o "${1}" == "benchmarks" ]; then
     if [ "${1}" == "list" ]; then
         shift
         list_cmd="${CRUCIBLE_HOME}/bin/list-subprojects.py --kind ${subproject_kind} $@"
-        ${podman_run} --name crucible-${subproject_kind}s-list-${SESSION_ID} "${container_common_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${list_cmd}
+        # no tty is allocated for this container, so the table formatter
+        # can't detect the real terminal width on its own -- forward it
+        # explicitly via COLUMNS instead
+        terminal_columns=$(tput cols 2>/dev/null || echo 100)
+        ${podman_run} --name crucible-${subproject_kind}s-list-${SESSION_ID} "${container_common_args[@]}" "${container_non_service_args[@]}" "-e COLUMNS=${terminal_columns}" ${CRUCIBLE_CONTROLLER_IMAGE} ${list_cmd}
         EXIT_VAL=$?
     else
         echo "ERROR: unsupported '${subproject_kind}s' argument [${1}]"

--- a/bin/list-subprojects.py
+++ b/bin/list-subprojects.py
@@ -51,7 +51,7 @@ def load_json(filepath):
         return json.load(f)
 
 
-def build_entry(subproject_dir, config, schema):
+def build_entry(subproject_dir, config, schema, multiplex_schema=None):
     """Aggregate one subproject's rickshaw.json/{tool,benchmark}-metadata.json/multiplex.json
     into a single normalized entry. Falls back to name-only if the metadata file is
     missing or fails schema validation -- a malformed file for one subproject should
@@ -105,12 +105,16 @@ def build_entry(subproject_dir, config, schema):
             multiplex = load_json(multiplex_path)
             if not isinstance(multiplex, dict):
                 raise TypeError(f"expected a JSON object, got {type(multiplex).__name__}")
+            if multiplex_schema is not None:
+                validate(instance=multiplex, schema=multiplex_schema)
             entry["params"] = {
                 "presets": multiplex.get("presets", {}),
                 "validations": multiplex.get("validations", {}),
             }
         except (json.JSONDecodeError, TypeError) as e:
             print(f"WARNING: could not parse {multiplex_path}: {e}", file=sys.stderr)
+        except ValidationError as e:
+            print(f"WARNING: {multiplex_path} failed schema validation, ignoring params for '{name}': {e.message}", file=sys.stderr)
 
     entry["metrics_count"] = count_metrics(entry, subgroup_field)
     entry["params_count"] = count_params(entry)
@@ -162,6 +166,9 @@ def collect_entries(config, name_filter):
     schema_path = os.path.join(CRUCIBLE_HOME, "schema", config["metadata_filename"])
     schema = load_json(schema_path)
 
+    multiplex_schema_path = os.path.join(CRUCIBLE_HOME, "subprojects", "core", "multiplex", "JSON", "req-schema.json")
+    multiplex_schema = load_json(multiplex_schema_path) if os.path.isfile(multiplex_schema_path) else None
+
     entries = []
     if not os.path.isdir(subprojects_root):
         return entries
@@ -171,7 +178,7 @@ def collect_entries(config, name_filter):
         if not os.path.isdir(subproject_dir):
             continue
 
-        entry = build_entry(subproject_dir, config, schema)
+        entry = build_entry(subproject_dir, config, schema, multiplex_schema)
         if entry is None:
             continue
         if name_filter and entry["name"] != name_filter:

--- a/bin/list-subprojects.py
+++ b/bin/list-subprojects.py
@@ -3,7 +3,9 @@
 import argparse
 import json
 import os
+import shutil
 import sys
+import textwrap
 
 from jsonschema import validate, ValidationError
 
@@ -110,7 +112,49 @@ def build_entry(subproject_dir, config, schema):
         except (json.JSONDecodeError, TypeError) as e:
             print(f"WARNING: could not parse {multiplex_path}: {e}", file=sys.stderr)
 
+    entry["metrics_count"] = count_metrics(entry, subgroup_field)
+    entry["params_count"] = count_params(entry)
+
     return entry
+
+
+def count_metrics(entry, subgroup_field):
+    """Total distinct CDM metric types this subproject reports, summed across
+    cdm_indexed subtools/sub-benchmarks (or the top-level cdm_sources if it
+    has no subgroup). None if there's no metadata file to derive this from.
+    """
+    if not entry["has_metadata"]:
+        return None
+
+    subgroup = entry.get(subgroup_field, [])
+    if subgroup:
+        return sum(
+            len(source.get("types", []))
+            for item in subgroup if item.get("cdm_indexed")
+            for source in item.get("cdm_sources", [])
+        )
+    if entry.get("cdm_indexed"):
+        return sum(len(source.get("types", [])) for source in entry.get("cdm_sources", []))
+    return 0
+
+
+def count_params(entry):
+    """Total distinct arg names covered by multiplex.json's presets and
+    validations -- the full recognized/validated parameter surface, not just
+    the ones with a default. None if there's no multiplex.json file at all.
+    """
+    params = entry.get("params")
+    if params is None:
+        return None
+
+    args = set()
+    for group in params.get("presets", {}).values():
+        for param in group:
+            if "arg" in param:
+                args.add(param["arg"])
+    for validation in params.get("validations", {}).values():
+        args.update(validation.get("args", []))
+    return len(args)
 
 
 def collect_entries(config, name_filter):
@@ -137,45 +181,66 @@ def collect_entries(config, name_filter):
     return entries
 
 
-MAX_DESCRIPTION_WIDTH = 70
+MIN_DESCRIPTION_WIDTH = 20
+COLUMN_SEPARATOR = "  "
 
 
-def truncate(text, max_width):
-    if len(text) <= max_width:
-        return text
-    return text[:max_width - 3].rstrip() + "..."
+def print_table(entries, config, terminal_width=None):
+    if terminal_width is None:
+        terminal_width = shutil.get_terminal_size(fallback=(100, 24)).columns
 
-
-def print_table(entries, config):
     subgroup_field = config["subgroup_field"]
     subgroup_label = subgroup_field.replace("-", " ").title()
-    subgroup_singular = subgroup_field[:-1]
-    headers = ["Name", "Description", subgroup_label, "CDM Indexed"]
+    headers = ["Name", "Description", subgroup_label, "Metrics", "Params"]
 
-    rows = []
+    fixed_cells = []
     for entry in entries:
-        subgroup = entry[subgroup_field]
+        subgroup = entry.get(subgroup_field, [])
         subgroup_display = str(len(subgroup)) if subgroup else "-"
 
-        if not entry["has_metadata"]:
-            cdm_display = "-"
-        elif subgroup:
-            cdm_display = f"per-{subgroup_singular}"
-        else:
-            cdm_display = "yes" if entry["cdm_indexed"] else "no"
+        metrics = count_metrics(entry, subgroup_field)
+        metrics_display = str(metrics) if metrics is not None else "-"
 
+        params = count_params(entry)
+        params_display = str(params) if params is not None else "-"
+
+        fixed_cells.append([entry["name"], subgroup_display, metrics_display, params_display])
+
+    # Name/subgroup/metrics/params widths are fixed by content; whatever's
+    # left of the terminal width goes to Description, which wraps instead of
+    # truncating -- unlike the other columns, its content is prose and can
+    # run arbitrarily long.
+    def column_width(header, cell_index):
+        return max([len(header)] + [len(c[cell_index]) for c in fixed_cells])
+
+    name_width = column_width(headers[0], 0)
+    subgroup_width = column_width(headers[2], 1)
+    metrics_width = column_width(headers[3], 2)
+    params_width = column_width(headers[4], 3)
+
+    reserved = name_width + subgroup_width + metrics_width + params_width + len(COLUMN_SEPARATOR) * 4
+    description_wrap_width = max(MIN_DESCRIPTION_WIDTH, terminal_width - reserved)
+
+    rows = []
+    for entry, cells in zip(entries, fixed_cells):
+        name, subgroup_display, metrics_display, params_display = cells
         if entry["description"]:
             single_line_description = " ".join(entry["description"].split())
-            description = truncate(single_line_description, MAX_DESCRIPTION_WIDTH)
+            desc_lines = textwrap.wrap(single_line_description, width=description_wrap_width) or ["-"]
         else:
-            description = "-"
-        rows.append([entry["name"], description, subgroup_display, cdm_display])
+            desc_lines = ["-"]
 
-    all_rows = [headers] + rows
-    widths = [max(len(str(row[i])) for row in all_rows) for i in range(len(headers))]
+        for i, desc_line in enumerate(desc_lines):
+            if i == 0:
+                rows.append([name, desc_line, subgroup_display, metrics_display, params_display])
+            else:
+                rows.append(["", desc_line, "", "", ""])
+
+    description_width = max([len(headers[1])] + [len(row[1]) for row in rows])
+    widths = [name_width, description_width, subgroup_width, metrics_width, params_width]
 
     def fmt_row(row):
-        return "  ".join(str(cell).ljust(widths[i]) for i, cell in enumerate(row))
+        return COLUMN_SEPARATOR.join(str(cell).ljust(widths[i]) for i, cell in enumerate(row))
 
     print(fmt_row(headers))
     print(fmt_row(["-" * w for w in widths]))

--- a/bin/test_list_subprojects.py
+++ b/bin/test_list_subprojects.py
@@ -33,6 +33,13 @@ BENCHMARK_SCHEMA = {
     "required": ["benchmark", "description"],
 }
 
+REAL_MULTIPLEX_SCHEMA_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "subprojects", "core", "multiplex", "JSON", "req-schema.json",
+)
+with open(REAL_MULTIPLEX_SCHEMA_PATH) as f:
+    REAL_MULTIPLEX_SCHEMA = json.load(f)
+
 
 class TestListSubprojects(unittest.TestCase):
 
@@ -46,6 +53,12 @@ class TestListSubprojects(unittest.TestCase):
             json.dump(TOOL_SCHEMA, f)
         with open(os.path.join(schema_dir, "benchmark-metadata.json"), "w") as f:
             json.dump(BENCHMARK_SCHEMA, f)
+
+        multiplex_schema_dir = os.path.join(self.crucible_home, "subprojects", "core", "multiplex", "JSON")
+        os.makedirs(multiplex_schema_dir)
+        with open(os.path.join(multiplex_schema_dir, "req-schema.json"), "w") as f:
+            json.dump(REAL_MULTIPLEX_SCHEMA, f)
+        self.multiplex_schema = REAL_MULTIPLEX_SCHEMA
 
         self.tools_dir = os.path.join(self.crucible_home, "subprojects", "tools")
         self.benchmarks_dir = os.path.join(self.crucible_home, "subprojects", "benchmarks")
@@ -190,6 +203,42 @@ class TestListSubprojects(unittest.TestCase):
             entry = list_subprojects.build_entry(subproject_dir, self.tool_config, schema)
         self.assertIsNone(entry["params"])
         self.assertIn("could not parse", stderr.getvalue())
+
+    def test_build_entry_valid_multiplex_json_passes_schema_validation(self):
+        subproject_dir = self.make_subproject(
+            self.tools_dir, "schemavalid", "tool",
+            multiplex={
+                "presets": {"defaults": [{"arg": "interval", "vals": ["3"]}]},
+                "validations": {"positive_integer": {"args": ["interval"], "vals": "^[1-9][0-9]*$"}},
+            },
+        )
+        schema = json.load(open(os.path.join(self.crucible_home, "schema", "tool-metadata.json")))
+        entry = list_subprojects.build_entry(subproject_dir, self.tool_config, schema, self.multiplex_schema)
+        self.assertIsNotNone(entry["params"])
+        self.assertEqual(entry["params_count"], 1)
+
+    def test_build_entry_malformed_multiplex_shape_rejected_by_schema(self):
+        # 'validations' mapped to a list instead of an object -- valid JSON,
+        # passes the plain isinstance(dict) check, but violates req-schema.json.
+        # This is the exact shape that used to crash count_params() outright
+        # (AttributeError: 'list' object has no attribute ...) before schema
+        # validation was added to reject it at parse time instead.
+        subproject_dir = self.make_subproject(
+            self.tools_dir, "schemainvalid", "tool",
+            multiplex={"validations": ["not", "a", "dict"]},
+        )
+        schema = json.load(open(os.path.join(self.crucible_home, "schema", "tool-metadata.json")))
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            entry = list_subprojects.build_entry(subproject_dir, self.tool_config, schema, self.multiplex_schema)
+        self.assertIsNone(entry["params"])
+        self.assertIsNone(entry["params_count"])
+        self.assertIn("failed schema validation", stderr.getvalue())
+        # confirm the whole listing survives -- table rendering must not crash either
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            list_subprojects.print_table([entry], self.tool_config, terminal_width=100)
+        self.assertIn("-", stdout.getvalue().splitlines()[2].split())
 
     def test_collect_entries_name_filter(self):
         self.make_subproject(self.tools_dir, "toolone", "tool")

--- a/bin/test_list_subprojects.py
+++ b/bin/test_list_subprojects.py
@@ -33,12 +33,43 @@ BENCHMARK_SCHEMA = {
     "required": ["benchmark", "description"],
 }
 
+# A simplified stand-in for multiplex's real req-schema.json, used by
+# TestListSubprojects below. multiplex is a separate subproject repo
+# (subprojects/core/multiplex/) that isn't checked out in crucible-ci's
+# unittest job -- unlike schema/tool-metadata.json and
+# schema/benchmark-metadata.json, which live in this repo and are always
+# present. TestRealMultiplexSchema further down validates against the
+# actual file, but only when it's available locally.
+MULTIPLEX_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "presets": {
+            "type": "object",
+            "patternProperties": {".*": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"arg": {"type": "string"}, "vals": {"type": "array"}},
+                    "required": ["arg", "vals"],
+                },
+            }},
+        },
+        "validations": {
+            "type": "object",
+            "patternProperties": {".*": {
+                "type": "object",
+                "properties": {"args": {"type": "array", "items": {"type": "string"}}},
+                "required": ["args"],
+            }},
+        },
+    },
+    "required": ["validations"],
+}
+
 REAL_MULTIPLEX_SCHEMA_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "subprojects", "core", "multiplex", "JSON", "req-schema.json",
 )
-with open(REAL_MULTIPLEX_SCHEMA_PATH) as f:
-    REAL_MULTIPLEX_SCHEMA = json.load(f)
 
 
 class TestListSubprojects(unittest.TestCase):
@@ -57,8 +88,8 @@ class TestListSubprojects(unittest.TestCase):
         multiplex_schema_dir = os.path.join(self.crucible_home, "subprojects", "core", "multiplex", "JSON")
         os.makedirs(multiplex_schema_dir)
         with open(os.path.join(multiplex_schema_dir, "req-schema.json"), "w") as f:
-            json.dump(REAL_MULTIPLEX_SCHEMA, f)
-        self.multiplex_schema = REAL_MULTIPLEX_SCHEMA
+            json.dump(MULTIPLEX_SCHEMA, f)
+        self.multiplex_schema = MULTIPLEX_SCHEMA
 
         self.tools_dir = os.path.join(self.crucible_home, "subprojects", "tools")
         self.benchmarks_dir = os.path.join(self.crucible_home, "subprojects", "benchmarks")
@@ -491,6 +522,45 @@ class TestRealBenchmarkMetadataSchema(unittest.TestCase):
 
     def test_sub_benchmark_cdm_indexed_true_without_sources_is_invalid(self):
         self.assertInvalid(self.base(**{"sub-benchmarks": [{"name": "a", "description": "d", "cdm_indexed": True}]}))
+
+
+@unittest.skipUnless(
+    os.path.isfile(REAL_MULTIPLEX_SCHEMA_PATH),
+    "multiplex subproject not checked out (expected in a full crucible install, not in crucible-ci's bare checkout)",
+)
+class TestRealMultiplexSchema(unittest.TestCase):
+    """Validates the actual shipped subprojects/core/multiplex/JSON/req-schema.json --
+    the synthetic MULTIPLEX_SCHEMA stub used above is a simplification and could drift."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(REAL_MULTIPLEX_SCHEMA_PATH) as f:
+            cls.schema = json.load(f)
+
+    def assertValid(self, doc):
+        list_subprojects.validate(instance=doc, schema=self.schema)
+
+    def assertInvalid(self, doc):
+        with self.assertRaises(list_subprojects.ValidationError):
+            list_subprojects.validate(instance=doc, schema=self.schema)
+
+    def test_minimal_valid_document(self):
+        self.assertValid({"validations": {}})
+
+    def test_valid_presets_and_validations(self):
+        self.assertValid({
+            "presets": {"defaults": [{"arg": "interval", "vals": ["3"]}]},
+            "validations": {"positive_integer": {"args": ["interval"], "vals": "^[1-9][0-9]*$"}},
+        })
+
+    def test_validations_as_list_is_invalid(self):
+        self.assertInvalid({"validations": ["not", "a", "dict"]})
+
+    def test_presets_as_string_is_invalid(self):
+        self.assertInvalid({"presets": "not-a-dict", "validations": {}})
+
+    def test_missing_validations_is_invalid(self):
+        self.assertInvalid({"presets": {}})
 
 
 if __name__ == "__main__":

--- a/bin/test_list_subprojects.py
+++ b/bin/test_list_subprojects.py
@@ -220,12 +220,116 @@ class TestListSubprojects(unittest.TestCase):
         }]
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
-            list_subprojects.print_table(entries, self.tool_config)
+            list_subprojects.print_table(entries, self.tool_config, terminal_width=100)
         lines = stdout.getvalue().splitlines()
         # header + separator + exactly one data row -- the embedded newline
         # must not have produced an extra line
         self.assertEqual(len(lines), 3)
         self.assertIn("Line one Line two continues here", lines[2])
+
+    def test_print_table_wraps_long_description_at_terminal_width(self):
+        entries = [{
+            "name": "mytool",
+            "has_metadata": True,
+            "description": "one two three four five six seven eight nine ten",
+            "subtools": [],
+            "cdm_indexed": False,
+            "cdm_sources": [],
+            "output_files": [],
+            "params": None,
+        }]
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            list_subprojects.print_table(entries, self.tool_config, terminal_width=40)
+        lines = stdout.getvalue().splitlines()
+        # narrow terminal forces the description across multiple lines,
+        # each one indented under the Description column with blank cells
+        # for Name/Subtools/Metrics/Params
+        self.assertGreater(len(lines), 3)
+        self.assertTrue(lines[2].startswith("mytool"))
+        self.assertFalse(lines[3].startswith("mytool"))
+
+    def test_print_table_metrics_column_counts_cdm_types(self):
+        entries = [{
+            "name": "mytool",
+            "has_metadata": True,
+            "description": "does things",
+            "subtools": [],
+            "cdm_indexed": True,
+            "cdm_sources": [{"source": "s", "types": ["a", "b", "c"]}],
+            "output_files": [],
+            "params": None,
+        }]
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            list_subprojects.print_table(entries, self.tool_config, terminal_width=100)
+        lines = stdout.getvalue().splitlines()
+        self.assertIn("3", lines[2].split())
+
+    def test_print_table_metrics_column_sums_across_subtools(self):
+        entries = [{
+            "name": "mytool",
+            "has_metadata": True,
+            "description": "does things",
+            "subtools": [
+                {"name": "a", "cdm_indexed": True, "cdm_sources": [{"source": "a", "types": ["x", "y"]}]},
+                {"name": "b", "cdm_indexed": True, "cdm_sources": [{"source": "b", "types": ["z"]}]},
+                {"name": "c", "cdm_indexed": False, "cdm_sources": []},
+            ],
+            "cdm_indexed": None,
+            "cdm_sources": [],
+            "output_files": [],
+            "params": None,
+        }]
+        self.assertEqual(list_subprojects.count_metrics(entries[0], "subtools"), 3)
+
+    def test_print_table_no_metadata_shows_dashes(self):
+        entries = [{
+            "name": "mytool",
+            "has_metadata": False,
+            "description": None,
+            "subtools": [],
+            "cdm_indexed": None,
+            "cdm_sources": [],
+            "output_files": [],
+            "params": None,
+        }]
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            list_subprojects.print_table(entries, self.tool_config, terminal_width=100)
+        lines = stdout.getvalue().splitlines()
+        self.assertEqual(lines[2].split(), ["mytool", "-", "-", "-", "-"])
+
+    def test_count_metrics_no_metadata_returns_none(self):
+        entry = {"has_metadata": False, "subtools": [], "cdm_indexed": None, "cdm_sources": []}
+        self.assertIsNone(list_subprojects.count_metrics(entry, "subtools"))
+
+    def test_count_metrics_metadata_but_not_indexed_returns_zero(self):
+        entry = {"has_metadata": True, "subtools": [], "cdm_indexed": False, "cdm_sources": []}
+        self.assertEqual(list_subprojects.count_metrics(entry, "subtools"), 0)
+
+    def test_count_params_no_multiplex_returns_none(self):
+        self.assertIsNone(list_subprojects.count_params({"params": None}))
+
+    def test_count_params_counts_distinct_args_across_presets_and_validations(self):
+        entry = {"params": {
+            "presets": {"defaults": [{"arg": "a", "vals": ["1"]}], "essentials": [{"arg": "b", "vals": ["2"]}]},
+            "validations": {"rule": {"args": ["a", "c"], "vals": ".+"}},
+        }}
+        # a, b, c -- 'a' appears in both a preset and a validation but counts once
+        self.assertEqual(list_subprojects.count_params(entry), 3)
+
+    def test_build_entry_includes_metrics_and_params_counts(self):
+        subproject_dir = self.make_subproject(
+            self.tools_dir, "counted", "tool",
+            metadata={"tool": "counted", "description": "d", "cdm_indexed": True,
+                      "cdm_sources": [{"source": "s", "types": ["a", "b"]}]},
+            multiplex={"presets": {"defaults": [{"arg": "x", "vals": ["1"]}]}, "validations": {}},
+        )
+        schema = json.load(open(os.path.join(self.crucible_home, "schema", "tool-metadata.json")))
+        entry = list_subprojects.build_entry(subproject_dir, self.tool_config, schema)
+        self.assertEqual(entry["metrics_count"], 2)
+        self.assertEqual(entry["params_count"], 1)
 
 
 REAL_SCHEMA_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "schema")


### PR DESCRIPTION
## Summary
- `bin/list-subprojects.py`: replaces the `CDM Indexed` column (which only ever showed yes/no/per-subtool) with a real **Metrics** count -- the number of distinct CDM metric types summed across all `cdm_indexed` subtools/sub-benchmarks (or the top-level `cdm_sources` if there's no subgroup). Adds a **Params** column -- the number of distinct args covered by `multiplex.json`'s `presets` + `validations`. Both show `-` when there's no metadata/`multiplex.json` file at all.
- Replaces the old hard 70-char description truncation with terminal-width-aware wrapping (`textwrap`), so long descriptions are fully readable instead of cut off with `...`.
- `--format json` output gains `metrics_count`/`params_count` fields alongside the existing raw data (nothing removed).
- `bin/_main`: the `tools list`/`benchmarks list` commands run `list-subprojects.py` inside a container with no tty allocated, so the formatter couldn't detect the real terminal width on its own. Forwards it explicitly via `-e COLUMNS=$(tput cols)`.

## Before / after
Before:
```
sysstat       System activity reporting via the Linux sysstat package -- per-CPU...   4         per-subtool
```
After:
```
sysstat    System activity reporting via the Linux sysstat package --   4         65       2
           per-CPU utilization, memory/IO/scheduler pressure, network
           throughput, block device IO, and per-process CPU usage.
```

## Test plan
- [x] `bin/test_list_subprojects.py` — 38 tests pass, including 9 new ones covering the Metrics/Params columns, description wrapping, and edge cases (no metadata file, metadata present but not CDM-indexed, no `multiplex.json`)
- [x] Verified against real repo data through the actual `crucible tools list`/`crucible benchmarks list` commands (not just unit tests) -- confirmed real metric/param counts for sysstat (65 metrics / 2 params), fio (5 metrics / 147 params), kernel, procstat, forkstat, iperf, uperf
- [x] Confirmed `COLUMNS` correctly reaches the container and changes the wrap width (verified at the container's actual ~80-column terminal vs. the previous fixed 100-column fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)