### PR TITLE
feat: register perftest as an official benchmark

### DIFF
--- a/config/repos.json
+++ b/config/repos.json
@@ -261,6 +261,16 @@
             }
         },
         {
+            "name": "perftest",
+            "type": "benchmark",
+            "repository": "https://github.com/perftool-incubator/bench-perftest",
+            "primary-branch": "main",
+            "checkout": {
+                "mode": "follow",
+                "target": "main"
+            }
+        },
+        {
             "name": "sysstat",
             "type": "tool",
             "repository": "https://github.com/perftool-incubator/tool-sysstat",


### PR DESCRIPTION
## Summary
- bench-perftest#2 (RDMA/PCIe throughput benchmark via ib_write_bw/ib_read_bw/ib_send_bw) merged; register it in `config/repos.json`'s `official` array so it's part of the standard ecosystem.

## Test plan
- [x] Validated against `schema/repos.json`
- [x] `crucible tools list` / `crucible benchmarks list` pick up the new entry after `crucible update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)