### PR TITLE
feat: add crucible validate command for run files and JSON documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,9 @@ These guides define the required file structure, naming conventions, JSON schema
 # Run a benchmark (requires JSON run-file)
 crucible run <run-file.json>
 
+# Validate a run-file or JSON document against schema
+crucible validate <json-file> [--type <type>]
+
 # Update all subprojects and controller image
 crucible update [all|crucible|controller-image|<subproject>]
 

--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -89,6 +89,23 @@ _complete_run() {
     compopt -o filenames
 }
 
+_complete_validate() {
+    local cur="${COMP_WORDS[${num_index}]}"
+    local prev="${COMP_WORDS[$((num_index - 1))]}"
+
+    case "${prev}" in
+        --type)
+            COMPREPLY=($(compgen -W "run-file multiplex workshop tool-metadata benchmark-metadata repos services registries rickshaw rickshaw-benchmark rickshaw-tool" -- "${cur}"))
+            return
+            ;;
+    esac
+
+    local remaining
+    remaining=$(_crucible_filter_used_flags 2 --type --help)
+    COMPREPLY=($(compgen -W "${remaining}" -f -- "${cur}"))
+    compopt -o filenames
+}
+
 _complete_log_view() {
     local cur="${COMP_WORDS[${num_index}]}"
     local prev="${COMP_WORDS[$((num_index - 1))]}"
@@ -584,7 +601,7 @@ _crucible_completions() {
 
     # Position 2: top-level commands
     if [ "${num_words}" -eq 2 ]; then
-        COMPREPLY=($(compgen -W "help log repo registries userenvs tools benchmarks update run run-ci wrapper console start stop ps images get rm index postprocess opensearch extract ls tags archive unarchive reset" -- "${cur}"))
+        COMPREPLY=($(compgen -W "help log repo registries validate userenvs tools benchmarks update run run-ci wrapper console start stop ps images get rm index postprocess opensearch extract ls tags archive unarchive reset" -- "${cur}"))
         return
     fi
 
@@ -592,7 +609,7 @@ _crucible_completions() {
     if [ "${num_words}" -eq 3 ]; then
         case "${COMP_WORDS[1]}" in
             help)
-                COMPREPLY=($(compgen -W "archive benchmarks console extract get images index log ls opensearch postprocess ps registries repo reset rm run run-ci start stop tags tools unarchive update userenvs wrapper" -- "${cur}"))
+                COMPREPLY=($(compgen -W "archive benchmarks console extract get images index log ls opensearch postprocess ps registries repo reset rm run run-ci start stop tags tools unarchive update userenvs validate wrapper" -- "${cur}"))
                 ;;
             tools|benchmarks)
                 COMPREPLY=($(compgen -W "list" -- "${cur}"))
@@ -617,6 +634,9 @@ _crucible_completions() {
                 ;;
             run)
                 _complete_run
+                ;;
+            validate)
+                _complete_validate
                 ;;
             wrapper)
                 COMPREPLY=($(compgen -c -f -- "${cur}"))
@@ -673,6 +693,9 @@ _crucible_completions() {
             ;;
         run)
             _complete_run
+            ;;
+        validate)
+            _complete_validate
             ;;
         log)
             case "${COMP_WORDS[2]}" in

--- a/bin/_help
+++ b/bin/_help
@@ -11,6 +11,8 @@ function help() {
     echo "help                          |  Show this help message"
     echo "run <file>                    |  Run a benchmark"
     echo "  [--log-level <level>]       |    Optional: normal, verbose, debug, verbose-debug (default: normal)"
+    echo "validate <file>               |  Validate a JSON file against its schema"
+    echo "  [--type <type>]             |    Optional: document type (default: run-file)"
     echo "log                           |  Manage the crucible log"
     echo "  view [first|last|sessionid] |    - View log entries (supports --stream, --grep, --since, --until, --head, --tail, --follow, --raw, --color)"
     echo "  sessions                    |    - List all sessions (supports --grep, --sort, --order, --color)"
@@ -91,6 +93,8 @@ function help() {
         ${CRUCIBLE_HOME}/bin/_log.py help
     elif [ "${1}" == "repo" ]; then
         ${CRUCIBLE_HOME}/bin/repo help
+    elif [ "${1}" == "validate" ]; then
+        ${CRUCIBLE_HOME}/bin/validate help
     elif [ "${1}" == "userenvs" ]; then
         ${CRUCIBLE_HOME}/bin/userenvs help
     elif [ "${1}" == "update" ]; then

--- a/bin/_main
+++ b/bin/_main
@@ -92,6 +92,10 @@ elif [ "${1}" == "repo" ]; then
         ${CRUCIBLE_HOME}/bin/repo "$@"
         EXIT_VAL=$?
     fi
+elif [ "${1}" == "validate" ]; then
+    shift
+    ${CRUCIBLE_HOME}/bin/validate "$@"
+    EXIT_VAL=$?
 elif [ "${1}" == "update" ]; then
     shift
     if [ -z "${1}" ]; then

--- a/bin/validate
+++ b/bin/validate
@@ -144,7 +144,7 @@ if [ "${doc_type}" == "run-file" ]; then
     for this_benchmark in ${benchmark_names}; do
         this_benchmark_subproj_dir="${CRUCIBLE_HOME}/subprojects/benchmarks/${this_benchmark}"
         if [ ! -e "${this_benchmark_subproj_dir}" ]; then
-            echo "ERROR: Running benchmark ${this_benchmark} requires that the subproject be"
+            echo "ERROR: Validating benchmark ${this_benchmark} requires that the subproject be"
             echo "located in "${CRUCIBLE_HOME}"/subprojects/benchmarks/${this_benchmark}"
             echo "This directory could not be found.  Here are the benchmark"
             echo "subproject directories:"
@@ -197,6 +197,6 @@ else
         exit 0
     else
         echo "INVALID"
-        exit ${EC_FAIL_USER}
+        exit 1
     fi
 fi

--- a/bin/validate
+++ b/bin/validate
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+
+# validate JSON files against JSON schemas
+
+source /etc/sysconfig/crucible
+
+if [ ! -e "${CRUCIBLE_HOME}" ]; then
+    echo "Could not find \$CRUCIBLE_HOME, exiting."
+    exit 1
+fi
+
+source "${CRUCIBLE_HOME}/bin/base"
+
+function help() {
+    echo "Usage: crucible validate [OPTIONS] <json-file>"
+    echo ""
+    echo "Validate a JSON file against its corresponding schema."
+    echo ""
+    echo "Options:"
+    echo "  --type <type>        Document type to validate against (default: run-file)"
+    echo "                       Supported types: run-file, multiplex, workshop, tool-metadata,"
+    echo "                       benchmark-metadata, repos, services, registries, rickshaw,"
+    echo "                       rickshaw-benchmark, rickshaw-tool"
+    echo "  --help               Show this help and exit"
+}
+
+if [ "$1" == "help" ]; then
+    help
+    exit 0
+fi
+
+target_file=""
+doc_type="run-file"
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+        --type)
+            shift
+            if [ $# -eq 0 ]; then
+                exit_error "--type requires a value"
+            fi
+            doc_type="${1}"
+            shift
+            ;;
+        --type=*)
+            doc_type="${1#--type=}"
+            if [ -z "${doc_type}" ]; then
+                exit_error "--type requires a value"
+            fi
+            shift
+            ;;
+        --help)
+            help
+            exit 0
+            ;;
+        --*)
+            exit_error "Unknown option '${1}'. See 'crucible help validate' for usage."
+            ;;
+        *)
+            if [ -n "${target_file}" ]; then
+                exit_error "Only one JSON file can be specified."
+            fi
+            target_file="${1}"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "${target_file}" ]; then
+    exit_error "You must specify a JSON file to validate."
+fi
+if [ ! -f "${target_file}" ]; then
+    exit_error "File not found: ${target_file}"
+fi
+
+function resolve_type_schema() {
+    local dtype="${1}"
+    local target="${2}"
+    schema=""
+
+    case "${dtype}" in
+        multiplex)
+            schema="${CRUCIBLE_HOME}/subprojects/core/multiplex/JSON/req-schema.json"
+            ;;
+        workshop)
+            schema="${CRUCIBLE_HOME}/subprojects/core/workshop/schema.json"
+            ;;
+        tool-metadata)
+            schema="${CRUCIBLE_HOME}/schema/tool-metadata.json"
+            ;;
+        benchmark-metadata)
+            schema="${CRUCIBLE_HOME}/schema/benchmark-metadata.json"
+            ;;
+        repos)
+            schema="${CRUCIBLE_HOME}/schema/repos.json"
+            ;;
+        services)
+            schema="${CRUCIBLE_HOME}/schema/services.json"
+            ;;
+        registries)
+            schema="${CRUCIBLE_HOME}/schema/registries.json"
+            ;;
+        rickshaw)
+            local has_benchmark
+            local has_tool
+            has_benchmark=$(jq_query "${target}" '.benchmark // empty')
+            has_tool=$(jq_query "${target}" '.tool // empty')
+            if [ -n "${has_benchmark}" ]; then
+                schema="${CRUCIBLE_HOME}/subprojects/core/rickshaw/schema/benchmark.json"
+            elif [ -n "${has_tool}" ]; then
+                schema="${CRUCIBLE_HOME}/subprojects/core/rickshaw/schema/tool.json"
+            else
+                exit_error "Could not determine rickshaw document type (neither 'benchmark' nor 'tool' key found in ${target})"
+            fi
+            ;;
+        rickshaw-benchmark)
+            schema="${CRUCIBLE_HOME}/subprojects/core/rickshaw/schema/benchmark.json"
+            ;;
+        rickshaw-tool)
+            schema="${CRUCIBLE_HOME}/subprojects/core/rickshaw/schema/tool.json"
+            ;;
+        *)
+            exit_error "Unknown document type '${dtype}'. See 'crucible help validate' for supported types."
+            ;;
+    esac
+
+    if [ ! -f "${schema}" ]; then
+        exit_error "Schema file not found: ${schema}. Is the required subproject installed?"
+    fi
+}
+
+if [ "${doc_type}" == "run-file" ]; then
+    if [ -z "${CRUCIBLE_CONTROLLER_IMAGE}" ]; then
+        exit_error "Exiting because CRUCIBLE_CONTROLLER_IMAGE is not defined"
+    fi
+
+    # extract the list of benchmarks from the run file
+    benchmark_names=$(jq_query "${target_file}" '.benchmarks[].name // empty' 2>/dev/null)
+
+    # validate the benchmarks and create the list of their directories
+    benchmark_subproj_dir=""
+    for this_benchmark in ${benchmark_names}; do
+        this_benchmark_subproj_dir="${CRUCIBLE_HOME}/subprojects/benchmarks/${this_benchmark}"
+        if [ ! -e "${this_benchmark_subproj_dir}" ]; then
+            echo "ERROR: Running benchmark ${this_benchmark} requires that the subproject be"
+            echo "located in "${CRUCIBLE_HOME}"/subprojects/benchmarks/${this_benchmark}"
+            echo "This directory could not be found.  Here are the benchmark"
+            echo "subproject directories:"
+            /bin/ls "${CRUCIBLE_HOME}"/subprojects/benchmarks
+            exit 1
+        fi
+        benchmark_subproj_dir+=",${this_benchmark_subproj_dir}"
+    done
+    benchmark_subproj_dir=$(echo ${benchmark_subproj_dir} | sed -e 's/^,//')
+
+    tmp_dir=$(mktemp -d -p "${var_crucible}" validate-XXXXXX)
+    trap 'rm -rf "${tmp_dir}"' EXIT
+
+    mkdir -p "${tmp_dir}/config"
+    cp "${target_file}" "${tmp_dir}/config/run-file.json"
+
+    rs_run_cmd="${CRUCIBLE_HOME}/subprojects/core/rickshaw/rickshaw-run.py"
+    rs_run_cmd+=" --from-file=${tmp_dir}/config/run-file.json"
+    rs_run_cmd+=" --id ${SESSION_ID}"
+    if [ -n "${benchmark_subproj_dir}" ]; then
+        rs_run_cmd+=" --bench-dir ${benchmark_subproj_dir}"
+    fi
+    rs_run_cmd+=" --engine-dir=${CRUCIBLE_HOME}/subprojects/core/engine"
+    rs_run_cmd+=" --roadblock-dir=${CRUCIBLE_HOME}/subprojects/core/roadblock"
+    rs_run_cmd+=" --roadblock-password=validate-dummy"
+    rs_run_cmd+=" --workshop-dir=${CRUCIBLE_HOME}/subprojects/core/workshop"
+    rs_run_cmd+=" --workshop-script=workshop.py"
+    rs_run_cmd+=" --packrat-dir=${CRUCIBLE_HOME}/subprojects/core/packrat"
+    rs_run_cmd+=" --tools-dir=${CRUCIBLE_HOME}/subprojects/tools"
+    rs_run_cmd+=" --registries-json=${REGISTRIES_CFG}"
+    rs_run_cmd+=" --base-run-dir=${tmp_dir}"
+    rs_run_cmd+=" --external-userenvs-dir=${CRUCIBLE_HOME}/subprojects/userenvs"
+    rs_run_cmd+=" --log-level=normal"
+    rs_run_cmd+=" --validate-only"
+
+    ${podman_run} --name crucible-rickshaw-validate-${SESSION_ID} "${container_common_args[@]}" "${container_rs_args[@]}" "${container_non_service_args[@]}" ${CRUCIBLE_CONTROLLER_IMAGE} ${rs_run_cmd}
+    RC=$?
+    exit ${RC}
+else
+    resolve_type_schema "${doc_type}" "${target_file}"
+
+    tmp_dir=$(mktemp -d -p "${var_crucible}" validate-XXXXXX)
+    trap 'rm -rf "${tmp_dir}"' EXIT
+
+    target_basename=$(basename "${target_file}")
+    cp "${target_file}" "${tmp_dir}/${target_basename}"
+
+    if validate_json_schema "${tmp_dir}/${target_basename}" "${schema}"; then
+        echo "VALID"
+        exit 0
+    else
+        echo "INVALID"
+        exit ${EC_FAIL_USER}
+    fi
+fi

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -229,6 +229,19 @@ crucible stop valkey opensearch image-sourcing httpd
 Then start them again or run a benchmark to exercise the
 changes.
 
+### Schema and run-file validation
+
+Validate JSON configuration files and run files without deploying engines or executing runs:
+
+```bash
+# Deep validation of a run file (checks schemas, endpoint blocks, benchmark/tool multiplex expansion)
+crucible validate my-run-file.json
+
+# Flat schema validation of config or subproject files
+crucible validate --type services config/services.json
+crucible validate --type rickshaw subprojects/benchmarks/fio/rickshaw.json
+```
+
 ### Integration testing
 
 The most thorough test is running a benchmark:

--- a/docs/how-endpoints-work.md
+++ b/docs/how-endpoints-work.md
@@ -51,6 +51,11 @@ to verify connectivity and discover its capabilities. The
 endpoint runs in validate mode and reports structured output
 that rickshaw parses.
 
+> **Note**: Static schema validation of endpoint definition blocks is performed
+> offline as part of `crucible validate` (deep run-file validation against
+> `kube.json`, `remotehosts.json`, `kvm.json`, or `osp.json`). Live connectivity checks,
+> SSH validation, and capability discovery described below occur only during `crucible run`.
+
 ### What validation reports
 
 Endpoints output specific keywords that rickshaw-run.py parses:

--- a/docs/how-run-files-work.md
+++ b/docs/how-run-files-work.md
@@ -441,7 +441,8 @@ listing the supported algorithms.
 
 ## Tags
 
-The `tags` section adds free-form metadata for identifying
+The `tags` section is optional and can be omitted entirely.
+When specified, it adds free-form metadata for identifying
 and filtering runs:
 
 ```json
@@ -458,7 +459,8 @@ dashboard, enabling filtering and comparison across runs.
 They're especially useful for tracking what changed between
 runs (kernel version, tuning profile, hardware configuration).
 
-Values are always strings. Any key names can be used.
+Values are always strings. Any key names can be used. When
+omitted or set to `{}`, no tags are associated with the run.
 
 ## Complete annotated example
 
@@ -541,3 +543,28 @@ each executed 3 times (num-samples) in random order. Sysstat
 collects CPU and system metrics at 1-second intervals, and
 procstat captures /proc data with default settings. The run
 is tagged for later identification.
+
+## Validating run files
+
+You can validate a run file before starting execution using the `crucible validate` command:
+
+```bash
+crucible validate my-run-file.json
+```
+
+By default, `crucible validate` assumes `--type run-file` and performs **deep validation**:
+
+1. Validates the top-level structure against `rickshaw/schema/run-file.json`
+2. Validates each endpoint definition block against its specific endpoint schema (`remotehosts.json`, `kube.json`, `kvm.json`, `osp.json`)
+3. Validates benchmark parameter definitions and expands parameter sets via multiplex
+4. Validates controller environment settings
+5. Validates tool configurations and tool multiplex expansion
+6. Validates utility parameters
+
+Deep validation verifies the complete run configuration without connecting to or deploying on target endpoints, building container images, or modifying `/var/lib/crucible/run/`.
+
+You can also perform flat schema validation on other Crucible and subproject JSON files using `--type <type>` (e.g., `multiplex`, `workshop`, `tool-metadata`, `benchmark-metadata`, `repos`, `services`, `registries`, `rickshaw`, `rickshaw-benchmark`, `rickshaw-tool`):
+
+```bash
+crucible validate --type services config/services.json
+```


### PR DESCRIPTION
## Summary

Add the `crucible validate` command for offline and pre-flight validation of run files and JSON configuration/subproject documents.

- **Run File Validation (`--type run-file`, default)**: Invokes `rickshaw-run.py` with `--validate-only` inside the controller container to perform comprehensive validation:
  - Validates `schema/run-file.json`
  - Validates endpoint blocks against their type-specific schemas (`schema/remotehosts.json`, `schema/kube.json`, `schema/osp.json`, etc.)
  - Validates and expands benchmark and tool parameter sets via multiplex
  - Validates controller environment settings, endpoint directory existence, and utility parameters
  - Exits with `VALID` without provisioning resources, deploying engines, running workloads, or modifying `/var/lib/crucible/run/`
- **Flat Schema Validation (`--type <type>`)**: Directly validates other Crucible and subproject JSON files against their respective schemas (`multiplex`, `workshop`, `tool-metadata`, `benchmark-metadata`, `repos`, `services`, `registries`, `rickshaw`, `rickshaw-benchmark`, `rickshaw-tool`).
- **Completions & Help**: Added tab completion in `bin/_crucible_completions`, updated main `crucible help` and `crucible help validate`.
- **Documentation**: Updated `docs/how-run-files-work.md`, `docs/how-endpoints-work.md`, and `docs/developer-guide.md`.

## Test Plan

- [✓] Rickshaw `--validate-only` implemented, tested (115 unit tests passing), and merged in rickshaw#877
- [✓] Tab completions and help text verified
- [✓] Documented in user and developer guides