### PR TITLE
docs: add pending-work skill to CLAUDE.md available skills list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Available skills:
 - `/crucible-tools:image-cleanup` — clean up local podman images (engine images, dangling images, local builds)
 - `/crucible-tools:new-repo` — create a new repository in the GitHub organization with standard config
 - `/crucible-tools:open-prs` — show all open PRs in the org (optionally filter by author)
+- `/crucible-tools:pending-work` — generate a comprehensive pending work report from Jira tickets and GitHub issues/PRs
 - `/crucible-tools:pr-review` — structured multi-dimension code review for a PR
 - `/crucible-tools:repo-status` — git status across all crucible repos
 - `/crucible-tools:workflow-status` — show active CI workflow runs across crucible repos


### PR DESCRIPTION
## Summary

Adds the newly merged `/crucible-tools:pending-work` skill to the **Available skills** table in `CLAUDE.md`.

The `pending-work` skill synthesizes an inventory of pending and actionable work across Jira (PERFNFV) and GitHub (perftool-incubator), categorized by actionability and priority.

— AI-signed: Antigravity | model: gemini-2.5-pro | effort: high