### PR TITLE
docs: document incompatible metric aggregations

### DIFF
--- a/bin/_crucible_completions
+++ b/bin/_crucible_completions
@@ -236,7 +236,7 @@ _complete_get_metric() {
     esac
 
     local remaining
-    remaining=$(_crucible_filter_used_flags 3 --run --period --source --type --begin --end --resolution --breakout --filter --output-format --date-format --decimal-places --output-content --horizontal-break --timestamp-rows --aggregation)
+    remaining=$(_crucible_filter_used_flags 3 --run --period --source --type --begin --end --resolution --breakout --filter --output-format --date-format --decimal-places --output-content --horizontal-break --timestamp-rows --aggregation --allow-incompatible-aggregation)
     COMPREPLY=($(compgen -W "${remaining}" -- "${cur}"))
 }
 

--- a/bin/_help
+++ b/bin/_help
@@ -45,6 +45,8 @@ function help() {
     echo "                              |        (found from initial metric query, like cstype or id)"
     echo "                              |      --aggregation <sum|avg|max|min>"
     echo "                              |        (override the metric's default-aggregation for this query)"
+    echo "                              |      --allow-incompatible-aggregation"
+    echo "                              |        (allow an aggregation explicitly disallowed by the metric definition)"
     echo "                              |      --filter <gt|lt:number>"
     echo "                              |        (gt = only show metrics greater-then value, lt = onlt show metrics less than value"
     echo "opensearch                    |  Manage OpenSearch instance configuration (add, remove, update, info, query-opt, index-instance, etc.)"

--- a/docs/how-cdm-works.md
+++ b/docs/how-cdm-works.md
@@ -47,7 +47,7 @@ run
 | **period** | A time window within a sample | period UUID, name, begin/end timestamps |
 | **param** | A benchmark parameter | arg name, value, role (client/server) |
 | **tag** | Run metadata | name, value (e.g., kernel version, test purpose) |
-| **metric_desc** | What a metric IS | source, type, class, default-aggregation, breakout dimensions |
+| **metric_desc** | What a metric IS | source, type, class, default-aggregation, disallowed aggregations, breakout dimensions |
 | **metric_data** | Actual values | begin, end, value, duration |
 
 Each level adds context. A metric_data document inherits its
@@ -84,6 +84,14 @@ Defines what a metric measures:
   If absent, CDM falls back to `sum` (preserving current
   behavior for existing metrics). Users can override the
   aggregation at query time with `--aggregation`.
+- **disallowed-aggregations**: An optional list of aggregation names that
+  have no meaningful interpretation for this specific metric descriptor.
+  CDM rejects a query-time `--aggregation` override listed here with an
+  `INCOMPATIBLE_AGGREGATION` error. This is intentionally descriptor-level
+  metadata rather than a universal class-based rule: some unusual operations
+  are meaningful for particular boolean, pass/fail, count, or percentage
+  metrics. Use `--allow-incompatible-aggregation` when an explicitly
+  disallowed combination is nevertheless intentional.
 - **names**: Breakout dimensions that identify specific
   instances of this metric (e.g., `hostname=worker-01`,
   `cpu=3`, `device=sda`, `direction=rx`)


### PR DESCRIPTION
## Summary

Document the metric-level aggregation compatibility policy introduced by CommonDataModel PR #210.

## Changes

- Document `disallowed-aggregations` in the CDM architecture guide.
- Document the `INCOMPATIBLE_AGGREGATION` rejection behavior.
- Document the explicit `--allow-incompatible-aggregation` escape hatch.
- Add the new option to Crucible metric-query help and shell completions.

This keeps Crucible's user-facing documentation and CLI discovery aligned with the CDM implementation and the reference implementations in bench-trafficgen PR #141 and tool-bpf PR #8.

Validation:
- `bash -n bin/_help bin/_crucible_completions`
- `git diff --check`

— AI-signed: Codex | model: GPT-5 | effort: not specified